### PR TITLE
improve resource_id validation logics

### DIFF
--- a/internal/services/azapi_update_resource.go
+++ b/internal/services/azapi_update_resource.go
@@ -47,11 +47,11 @@ func ResourceAzApiUpdateResource() *schema.Resource {
 			},
 
 			"parent_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-				Computed: true,
-				//ValidateFunc:  validate.AzureResourceID,
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				Computed:      true,
+				ValidateFunc:  validation.StringIsNotEmpty,
 				RequiredWith:  []string{"name"},
 				ConflictsWith: []string{"resource_id"},
 			},
@@ -116,9 +116,15 @@ func ResourceAzApiUpdateResource() *schema.Resource {
 			}
 
 			if name := d.Get("name").(string); len(name) != 0 {
-				id, err := parse.BuildResourceID(d.Get("name").(string), d.Get("parent_id").(string), d.Get("type").(string))
-				if err != nil && len(id.ParentId) > 0 {
-					return err
+				parentId := d.Get("parent_id").(string)
+				resourceType := d.Get("type").(string)
+
+				// verify parent_id when it's known
+				if len(parentId) > 0 {
+					_, err := parse.BuildResourceID(name, parentId, resourceType)
+					if err != nil {
+						return err
+					}
 				}
 			}
 

--- a/internal/services/parse/resource.go
+++ b/internal/services/parse/resource.go
@@ -30,6 +30,7 @@ func BuildResourceID(name, parentId, resourceType string) (ResourceId, error) {
 		log.Printf("[ERROR] load embedded schema: %+v\n", err)
 	}
 
+	// case 1: child resource, verify parent_id's type matches with resource type's parent type
 	if !utils.IsTopLevelResourceType(azureResourceType) {
 		parentIdExpectedType := utils.GetParentType(azureResourceType)
 		parentIdType := utils.GetResourceType(parentId)
@@ -53,6 +54,7 @@ func BuildResourceID(name, parentId, resourceType string) (ResourceId, error) {
 		}, nil
 	}
 
+	// case 2: top level resource, verify parent_id providers correct scope
 	scopeTypes := make([]types.ScopeType, 0)
 	if resourceDef != nil {
 		for _, scope := range resourceDef.ScopeTypes {
@@ -74,6 +76,7 @@ func BuildResourceID(name, parentId, resourceType string) (ResourceId, error) {
 					matchedScope = scope
 				}
 			case types.Extension:
+				// only supports extension on a resource group scope resource
 				if parentIdScope == types.ResourceGroup {
 					matchedScope = scope
 				}
@@ -89,6 +92,7 @@ func BuildResourceID(name, parentId, resourceType string) (ResourceId, error) {
 	if strings.EqualFold(azureResourceType, "Microsoft.Resources/resourceGroups") {
 		azureResourceId = fmt.Sprintf("%s/resourceGroups/%s", parentId, name)
 	} else {
+		// avoid duplicated `/` if parent_id is tenant scope
 		scopeId := parentId
 		if parentId == "/" {
 			scopeId = ""

--- a/internal/services/parse/resource_test.go
+++ b/internal/services/parse/resource_test.go
@@ -1,6 +1,8 @@
 package parse
 
-import "testing"
+import (
+	"testing"
+)
 
 func Test_NewResourceID(t *testing.T) {
 	testData := []struct {
@@ -20,7 +22,7 @@ func Test_NewResourceID(t *testing.T) {
 				AzureResourceType: "Microsoft.Management/managementGroups",
 				AzureResourceId:   "/providers/Microsoft.Management/managementGroups/test",
 				Name:              "test",
-				ParentId:          "",
+				ParentId:          "/",
 			},
 		},
 
@@ -188,6 +190,9 @@ func Test_NewResourceID(t *testing.T) {
 		if actual.AzureResourceType != v.Expected.AzureResourceType {
 			t.Fatalf("Expected %q but got %q for AzureResourceType", v.Expected.AzureResourceType, actual.AzureResourceType)
 		}
+		if actual.ParentId != v.Expected.ParentId {
+			t.Fatalf("Expected %q but got %q for ParentId", v.Expected.ParentId, actual.ParentId)
+		}
 		if v.ResourceDefExist && actual.ResourceDef == nil {
 			t.Fatal("Expected a resource def but got nil")
 		}
@@ -211,7 +216,7 @@ func Test_ResourceID(t *testing.T) {
 				AzureResourceType: "Microsoft.Management/managementGroups",
 				AzureResourceId:   "/providers/Microsoft.Management/managementGroups/test",
 				Name:              "test",
-				ParentId:          "",
+				ParentId:          "/",
 			},
 		},
 
@@ -370,6 +375,9 @@ func Test_ResourceID(t *testing.T) {
 		if actual.AzureResourceType != v.Expected.AzureResourceType {
 			t.Fatalf("Expected %q but got %q for AzureResourceType", v.Expected.AzureResourceType, actual.AzureResourceType)
 		}
+		if actual.ParentId != v.Expected.ParentId {
+			t.Fatalf("Expected %q but got %q for ParentId", v.Expected.ParentId, actual.ParentId)
+		}
 		if v.ResourceDefExist && actual.ResourceDef == nil {
 			t.Fatal("Expected a resource def but got nil")
 		}
@@ -387,8 +395,34 @@ func Test_BuildResourceID(t *testing.T) {
 	}{
 		{
 			// tenant scope
+			Name:             "myDeployment",
+			ParentId:         "/",
+			ResourceType:     "Microsoft.Resources/deployments@2021-04-01",
+			ResourceDefExist: true,
+			Expected: &ResourceId{
+				ApiVersion:        "2021-04-01",
+				AzureResourceType: "Microsoft.Resources/deployments",
+				AzureResourceId:   "/providers/Microsoft.Resources/deployments/myDeployment",
+			},
+		},
+
+		{
+			// tenant scope, but child resource
+			Name:             "default",
+			ParentId:         "/providers/Microsoft.Management/managementGroups/myGroup",
+			ResourceType:     "Microsoft.Management/managementGroups/settings@2021-04-01",
+			ResourceDefExist: true,
+			Expected: &ResourceId{
+				ApiVersion:        "2021-04-01",
+				AzureResourceType: "Microsoft.Management/managementGroups/settings",
+				AzureResourceId:   "/providers/Microsoft.Management/managementGroups/myGroup/settings/default",
+			},
+		},
+
+		{
+			// tenant scope
 			Name:             "test",
-			ParentId:         "",
+			ParentId:         "/",
 			ResourceType:     "Microsoft.Management/managementGroups@2021-04-01",
 			ResourceDefExist: true,
 			Expected: &ResourceId{

--- a/internal/services/resource.go
+++ b/internal/services/resource.go
@@ -7,19 +7,18 @@ import (
 
 	"github.com/Azure/terraform-provider-azapi/internal/azure"
 	"github.com/Azure/terraform-provider-azapi/internal/azure/types"
-	"github.com/Azure/terraform-provider-azapi/internal/services/parse"
 	"github.com/Azure/terraform-provider-azapi/utils"
 )
 
-func schemaValidation(id parse.ResourceId, body interface{}) error {
-	log.Printf("[INFO] prepare validation for resource type: %s, api-version: %s", id.AzureResourceType, id.ApiVersion)
-	versions := azure.GetApiVersions(id.AzureResourceType)
+func schemaValidation(azureResourceType, apiVersion string, resourceDef *types.ResourceType, body interface{}) error {
+	log.Printf("[INFO] prepare validation for resource type: %s, api-version: %s", azureResourceType, apiVersion)
+	versions := azure.GetApiVersions(azureResourceType)
 	if len(versions) == 0 {
-		return fmt.Errorf("the `type` is invalid, resource type %s can't be found", id.AzureResourceType)
+		return fmt.Errorf("the `type` is invalid, resource type %s can't be found", azureResourceType)
 	}
 	isVersionValid := false
 	for _, version := range versions {
-		if version == id.ApiVersion {
+		if version == apiVersion {
 			isVersionValid = true
 			break
 		}
@@ -28,8 +27,8 @@ func schemaValidation(id parse.ResourceId, body interface{}) error {
 		return fmt.Errorf("the `type`'s api-version is invalid. The supported versions are [%s]\n", strings.Join(versions, ", "))
 	}
 
-	if id.ResourceDef != nil {
-		errors := (*id.ResourceDef).Validate(utils.NormalizeObject(body), "")
+	if resourceDef != nil {
+		errors := (*resourceDef).Validate(utils.NormalizeObject(body), "")
 		if len(errors) != 0 {
 			errorMsg := "the `body` is invalid: \n"
 			for _, err := range errors {

--- a/utils/helper.go
+++ b/utils/helper.go
@@ -127,6 +127,9 @@ func GetParentId(id string) string {
 			parentId += "/" + key + "/" + value
 		}
 	}
+	if parentId == "" {
+		return "/"
+	}
 	return parentId
 }
 

--- a/utils/helper.go
+++ b/utils/helper.go
@@ -78,7 +78,7 @@ func GetName(id string) string {
 
 func GetParentId(id string) string {
 	if len(id) == 0 || id == "/" {
-		return ""
+		return "/"
 	}
 	idURL, err := url.ParseRequestURI(id)
 	if err != nil {
@@ -91,13 +91,13 @@ func GetParentId(id string) string {
 
 	components := strings.Split(path, "/")
 	if len(components) == 2 && strings.EqualFold(components[0], "subscriptions") {
-		return ""
+		return "/"
 	}
 	if len(components) == 4 &&
 		strings.EqualFold(components[0], "providers") &&
 		strings.EqualFold(components[1], "Microsoft.Management") &&
 		strings.EqualFold(components[2], "managementGroups") {
-		return ""
+		return "/"
 	}
 	if len(components) == 4 &&
 		strings.EqualFold(components[0], "subscriptions") &&
@@ -192,6 +192,10 @@ func GetAzureResourceTypeApiVersion(resourceType string) (string, string, error)
 		return "", "", fmt.Errorf("`type` is invalid, it should be like `ResourceProvider/resourceTypes@ApiVersion`")
 	}
 	return azureResourceType, apiVersion, nil
+}
+
+func IsTopLevelResourceType(resourceType string) bool {
+	return len(strings.Split(resourceType, "/")) == 2
 }
 
 func ExpandStringSlice(input []interface{}) *[]string {

--- a/utils/helper.go
+++ b/utils/helper.go
@@ -78,7 +78,7 @@ func GetName(id string) string {
 
 func GetParentId(id string) string {
 	if len(id) == 0 || id == "/" {
-		return "/"
+		return ""
 	}
 	idURL, err := url.ParseRequestURI(id)
 	if err != nil {

--- a/utils/helper_test.go
+++ b/utils/helper_test.go
@@ -14,11 +14,11 @@ func Test_GetParentId(t *testing.T) {
 	}{
 		{
 			Input:  "",
-			Output: "/",
+			Output: "",
 		},
 		{
 			Input:  "/",
-			Output: "/",
+			Output: "",
 		},
 		{
 			Input:  "/providers/Microsoft.Billing/billingAccounts/myAccount",

--- a/utils/helper_test.go
+++ b/utils/helper_test.go
@@ -14,15 +14,15 @@ func Test_GetParentId(t *testing.T) {
 	}{
 		{
 			Input:  "",
-			Output: "",
+			Output: "/",
 		},
 		{
 			Input:  "/",
-			Output: "",
+			Output: "/",
 		},
 		{
 			Input:  "/providers/Microsoft.Billing/billingAccounts/myAccount",
-			Output: "",
+			Output: "/",
 		},
 		{
 			Input:  "/providers/Microsoft.Billing/billingAccounts/myAccount/billingProfiles/myProfile",
@@ -30,7 +30,7 @@ func Test_GetParentId(t *testing.T) {
 		},
 		{
 			Input:  "/subscriptions/12345678-1234-9876-4563-123456789012",
-			Output: "",
+			Output: "/",
 		},
 		{
 			Input:  "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.Authorization/policydefinitions/myDef",
@@ -42,7 +42,7 @@ func Test_GetParentId(t *testing.T) {
 		},
 		{
 			Input:  "/providers/Microsoft.Management/managementGroups/myMgmtGroup",
-			Output: "",
+			Output: "/",
 		},
 		{
 			Input:  "/providers/Microsoft.Management/managementGroups/myMgmtGroup/providers/Microsoft.CostManagement/externalSubscriptions/mySub",


### PR DESCRIPTION
To address issue:
https://github.com/Azure/terraform-provider-azapi/issues/73
Add a validation to prevent user setting `parent_id = ""`, which means "/" is the only allowed value for tenant scope top level resource.

To address issue:
https://github.com/Azure/terraform-provider-azapi/issues/72
I refactored the validation logics, into two parts.
1. Child resource type: verify if the parent_id's type matches the expected resource type, for example,
resource type is `Microsoft.Network/virtualNetworks/subnets`, we need to verify whether `parent_id` is an ID of a `Microsoft.Network/virtualNetworks`
2. Top level resource type: verify if `parent_id` provides a correct scope, like tenant scope `/`, subscription scope `/subscriptions/000-000-00`

 

