### PR TITLE
bugfix: identity and location defined inside body will be over-written by computed identity and location when update

### DIFF
--- a/internal/services/azapi_resource.go
+++ b/internal/services/azapi_resource.go
@@ -181,10 +181,10 @@ func ResourceAzApiResource() *schema.Resource {
 						body["tags"] = tagsModel
 					}
 				}
-				if value, ok := d.GetOk("location"); ok {
+				if value, ok := d.GetOk("location"); ok && isConfigExist(config, "location") {
 					body["location"] = location.Normalize(value.(string))
 				}
-				if value, ok := d.GetOk("identity"); ok {
+				if value, ok := d.GetOk("identity"); ok && isConfigExist(config, "identity") {
 					identityModel, err := identity.ExpandIdentity(value.([]interface{}))
 					if err != nil {
 						return err
@@ -254,10 +254,10 @@ func resourceAzApiResourceCreateUpdate(d *schema.ResourceData, meta interface{})
 			body["tags"] = tagsModel
 		}
 	}
-	if value, ok := d.GetOk("location"); ok {
+	if value, ok := d.GetOk("location"); ok && isConfigExist(config, "location") {
 		body["location"] = location.Normalize(value.(string))
 	}
-	if value, ok := d.GetOk("identity"); ok {
+	if value, ok := d.GetOk("identity"); ok && isConfigExist(config, "identity") {
 		identityModel, err := identity.ExpandIdentity(value.([]interface{}))
 		if err != nil {
 			return err


### PR DESCRIPTION
This is a bugfix for an edge case, when update `azapi_resource`, identity and location defined inside body will be over-written by computed identity and location