### PR TITLE
remove use_msi from documents

### DIFF
--- a/docs/guides/managed_service_identity.md
+++ b/docs/guides/managed_service_identity.md
@@ -60,9 +60,9 @@ Terraform can be configured to use managed identity for authentication in one of
 
 Using managed identity for Azure resources as authentication is enabled in `azapi` provider by default.
 
-By default, Terraform will use the system assigned identity for authentication. To use a user assigned identity instead, you will need to specify the `ARM_CLIENT_ID` environment variable (equivalent to provider block argument [`client_id`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs#client_id)) to the [client id](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/user_assigned_identity#client_id) of the identity.
+By default, Terraform will use the system assigned identity for authentication. To use a user assigned identity instead, you will need to specify the `ARM_CLIENT_ID` environment variable (equivalent to provider block argument [`client_id`](https://registry.terraform.io/providers/azure/azapi/latest/docs#client_id)) to the [client id](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/user_assigned_identity#client_id) of the identity.
 
-By default, Terraform will use a well-known MSI endpoint to get the authentication token, which covers most use cases. In other cases where the endpoint is different (e.g. when running as an Azure Function App), you must explicitly specify the endpoint using the `ARM_MSI_ENDPOINT` environment variable (equivalent to provider block argument [`msi_endpoint`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs#msi_endpoint)).
+By default, Terraform will use a well-known MSI endpoint to get the authentication token, which covers most use cases. 
 
 !> **Note:** we recommend against running Terraform inside of a Function App as the low memory ceiling can lead to Terraform being terminated and data (including the State File) being lost. Instead we’d recommend considering triggering an external process, such as Terraform Cloud or a CI System to run these longer-running more intensive processes - see [Terraform in Automation](https://learn.hashicorp.com/tutorials/terraform/automate-terraform) for more details.
 
@@ -72,7 +72,6 @@ In addition to a properly-configured management identity, Terraform needs to kno
 $ export ARM_SUBSCRIPTION_ID=159f2485-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 $ export ARM_TENANT_ID=72f988bf-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 $ export ARM_CLIENT_ID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx # only necessary for user assigned identity
-$ export ARM_MSI_ENDPOINT=$MSI_ENDPOINT # only necessary when the msi endpoint is different than the well-known one
 ```
 
 A provider block is _technically_ optional when using environment variables. Even so, we recommend defining provider blocks so that you can pin or constrain the version of the provider being used, and configure other optional settings:
@@ -136,14 +135,3 @@ provider "azapi" {
 More information on [the fields supported in the provider block can be found here](../index.html#argument-reference).
 
 <!-- it's not clear to me that we even need this info; it seems like this is the sort of thing you'd know about if you needed it.
-
-### Custom MSI endpoints
-
-Developers who are using a custom MSI endpoint can specify the endpoint in one of two ways:
-
-- In the provider block using the `msi_endpoint` field
-- Using the `ARM_MSI_ENDPOINT` environment variable.
-
-You don't normally need to set the endpoint, because Terraform and the Azure Provider will automatically locate the appropriate endpoint.
-
--->

--- a/docs/guides/managed_service_identity.md
+++ b/docs/guides/managed_service_identity.md
@@ -58,7 +58,7 @@ Terraform can be configured to use managed identity for authentication in one of
 
 ### Configuring with environment variables
 
-Setting the`ARM_USE_MSI` environment variable (equivalent to provider block argument [`use_msi`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs#use_msi)) to `true` tells Terraform to use a managed identity.
+Using managed identity for Azure resources as authentication is enabled in `azapi` provider by default.
 
 By default, Terraform will use the system assigned identity for authentication. To use a user assigned identity instead, you will need to specify the `ARM_CLIENT_ID` environment variable (equivalent to provider block argument [`client_id`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs#client_id)) to the [client id](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/user_assigned_identity#client_id) of the identity.
 
@@ -69,7 +69,6 @@ By default, Terraform will use a well-known MSI endpoint to get the authenticati
 In addition to a properly-configured management identity, Terraform needs to know the subscription ID and tenant ID to identify the full context for the Azure provider.
 
 ```shell
-$ export ARM_USE_MSI=true
 $ export ARM_SUBSCRIPTION_ID=159f2485-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 $ export ARM_TENANT_ID=72f988bf-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 $ export ARM_CLIENT_ID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx # only necessary for user assigned identity
@@ -107,13 +106,11 @@ terraform {
 }
 
 provider "azapi" {
-
-  use_msi = true
   #...
 }
 ```
 
-If you intend to configure a remote backend in the provider block, put `use_msi` outside of the backend block:
+If you intend to configure a remote backend in the provider block:
 
 ```hcl
 terraform {
@@ -126,9 +123,6 @@ terraform {
 }
 
 provider "azapi" {
-
-  use_msi = true
-
   backend "azurerm" {
     storage_account_name = "abcd1234"
     container_name       = "tfstate"


### PR DESCRIPTION
To address https://github.com/Azure/terraform-provider-azapi/issues/87

Managed identity authentication is enabled in authentication chain by default, no need to expose property `use_msi`.

ref: https://github.com/Azure/terraform-provider-azapi/blob/main/vendor/github.com/Azure/azure-sdk-for-go/sdk/azidentity/default_azure_credential.go#L42