### PR TITLE
improve error message for schema validation failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Unreleased
+FEATURES:
 
+ENHANCEMENTS:
+
+BUG FIXES:
+- Improve error message for schema validation failure.
+
+## v0.2.0
 FEATURES:
 
 ENHANCEMENTS:


### PR DESCRIPTION
The previous error message from schema validation failure is misleading, users might think it's a server-side error, so I added some messages suggesting how to fix it or bypass it.