### PR TITLE
fix crash when update on a resource whose id is null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ BUG FIXES:
 - Improve error message for schema validation failure.
 - DefaultAzureCredential reads the client ID of a user-assigned managed identity.
 - Fix the modification is not working, when use `azapi_update_resource` to modify additional properties.
+- Fix crash when use `azapi_update_resource` on a resource whose id is null
+- Fix crash when the discriminated type is not in the embedded schema
 
 ## v0.2.0
 FEATURES:

--- a/internal/azure/types/discriminated_object_type.go
+++ b/internal/azure/types/discriminated_object_type.go
@@ -40,7 +40,7 @@ func (t *DiscriminatedObjectType) GetWriteOnly(body interface{}) interface{} {
 	}
 
 	if discriminator, ok := bodyMap[t.Discriminator].(string); ok {
-		if t.Elements[discriminator].Type != nil {
+		if t.Elements[discriminator] != nil && t.Elements[discriminator].Type != nil {
 			if additionalProps := (*t.Elements[discriminator].Type).GetWriteOnly(body); additionalProps != nil {
 				if additionalMap, ok := additionalProps.(map[string]interface{}); ok {
 					for key, value := range additionalMap {

--- a/internal/services/azapi_update_resource.go
+++ b/internal/services/azapi_update_resource.go
@@ -158,7 +158,7 @@ func resourceAzApiUpdateResourceCreateUpdate(d *schema.ResourceData, meta interf
 	if err != nil {
 		return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
 	}
-	if len(utils.GetId(existing)) == 0 {
+	if utils.GetId(existing) == nil {
 		return fmt.Errorf("update target does not exist %s", id)
 	}
 

--- a/internal/services/azapi_update_resource_test.go
+++ b/internal/services/azapi_update_resource_test.go
@@ -65,7 +65,7 @@ func (r GenericUpdateResource) Exists(ctx context.Context, client *clients.Clien
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	exist := len(utils.GetId(resp)) != 0
+	exist := utils.GetId(resp) != nil
 	return &exist, nil
 }
 

--- a/utils/helper.go
+++ b/utils/helper.go
@@ -8,16 +8,20 @@ import (
 	"github.com/Azure/terraform-provider-azapi/internal/azure/types"
 )
 
-func GetId(resource interface{}) string {
+func GetId(resource interface{}) *string {
 	if resource == nil {
-		return ""
+		return nil
 	}
 	if resourceMap, ok := resource.(map[string]interface{}); ok {
 		if id, ok := resourceMap["id"]; ok {
-			return id.(string)
+			idStr := ""
+			if id != nil {
+				idStr = id.(string)
+			}
+			return &idStr
 		}
 	}
-	return ""
+	return nil
 }
 
 func GetResourceType(id string) string {


### PR DESCRIPTION
To address: https://github.com/Azure/terraform-provider-azapi/issues/112

Though the root cause is server-side bugs, but azapi provider should not crash.