### PR TITLE
`azapi_resource` data source supports `resource_id`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ ENHANCEMENTS:
 - `azapi_resource`: Supports default api-version when importing existing resource into terraform state.
 - `azapi_resource`: Supports `locks` which used to prevent creating/modifying/deleting resources at the same time.
 - `azapi_update_resource`: Supports `locks` which used to prevent creating/modifying/deleting resources at the same time.
+- `azapi_resource` data source: Supports configuring `resource_id` as an alternative way to configure `name` and `parent_id`.
 
 BUG FIXES:
 

--- a/docs/data-sources/azapi_resource.md
+++ b/docs/data-sources/azapi_resource.md
@@ -63,8 +63,8 @@ output "quarantine_policy" {
 ## Arguments Reference
 
 The following arguments are supported:
-* `name` - (Required) Specifies the name of the azure resource. Changing this forces a new resource to be created.
-* `parent_id` - (Required) The ID of the azure resource in which this resource is created. Changing this forces a new resource to be created. It supports different kinds of deployment scope for **top level** resources: 
+* `name` - (Optional) Specifies the name of the azure resource.
+* `parent_id` - (Optional) The ID of the azure resource in which this resource is created. It supports different kinds of deployment scope for **top level** resources: 
     - resource group scope: `parent_id` should be the ID of a resource group, it's recommended to manage a resource group by [azurerm_resource_group](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group).
     - management group scope: `parent_id` should be the ID of a management group, it's recommended to manage a management group by [azurerm_management_group](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/management_group).
     - extension scope: `parent_id` should be the ID of the resource you're adding the extension to.
@@ -72,6 +72,10 @@ The following arguments are supported:
     - tenant scope: `parent_id` should be `/`
 
   For child level resources, the `parent_id` should be the ID of its parent resource, for example, subnet resource's `parent_id` is the ID of the vnet.
+
+* `resource_id` - (Optional) The ID of an existing azure source.
+
+~> **Note:** Configuring `name` and `parent_id` is an alternative way to configure `resource_id`.
 
 * `type` - (Required) It is in a format like `<resource-type>@<api-version>`. `<resource-type>` is the Azure resource type, for example, `Microsoft.Storage/storageAccounts`.
   `<api-version>` is version of the API used to manage this azure resource.

--- a/internal/services/azapi_resource_data_source.go
+++ b/internal/services/azapi_resource_data_source.go
@@ -26,28 +26,25 @@ func ResourceAzApiDataSource() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"name": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				ValidateFunc:  validation.StringIsNotEmpty,
-				RequiredWith:  []string{"parent_id"},
-				ConflictsWith: []string{"resource_id"},
-				ExactlyOneOf:  []string{"name", "resource_id"},
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+				RequiredWith: []string{"parent_id"},
+				ExactlyOneOf: []string{"name", "resource_id"},
 			},
 
 			"parent_id": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				ValidateFunc:  validation.StringIsNotEmpty,
-				RequiredWith:  []string{"name"},
-				ConflictsWith: []string{"resource_id"},
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+				RequiredWith: []string{"name"},
 			},
 
 			"resource_id": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				ValidateFunc:  validate.AzureResourceID,
-				ConflictsWith: []string{"name", "parent_id"},
-				ExactlyOneOf:  []string{"name", "resource_id"},
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validate.AzureResourceID,
+				ExactlyOneOf: []string{"name", "resource_id"},
 			},
 
 			"type": {

--- a/internal/services/azapi_resource_data_source.go
+++ b/internal/services/azapi_resource_data_source.go
@@ -31,7 +31,7 @@ func ResourceAzApiDataSource() *schema.Resource {
 				ValidateFunc:  validation.StringIsNotEmpty,
 				RequiredWith:  []string{"parent_id"},
 				ConflictsWith: []string{"resource_id"},
-				AtLeastOneOf:  []string{"name", "resource_id"},
+				ExactlyOneOf:  []string{"name", "resource_id"},
 			},
 
 			"parent_id": {
@@ -47,7 +47,7 @@ func ResourceAzApiDataSource() *schema.Resource {
 				Optional:      true,
 				ValidateFunc:  validate.AzureResourceID,
 				ConflictsWith: []string{"name", "parent_id"},
-				AtLeastOneOf:  []string{"name", "resource_id"},
+				ExactlyOneOf:  []string{"name", "resource_id"},
 			},
 
 			"type": {

--- a/internal/services/azapi_resource_data_source_test.go
+++ b/internal/services/azapi_resource_data_source_test.go
@@ -32,6 +32,26 @@ func TestAccGenericDataSource_basic(t *testing.T) {
 	})
 }
 
+func TestAccGenericDataSource_withResourceId(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azapi_resource", "test")
+	r := GenericDataSource{}
+
+	data.DataSourceTest(t, []resource.TestStep{
+		{
+			Config: r.withResourceId(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("identity.#").HasValue("1"),
+				check.That(data.ResourceName).Key("identity.0.type").HasValue("SystemAssigned, UserAssigned"),
+				check.That(data.ResourceName).Key("identity.0.identity_ids.#").HasValue("1"),
+				check.That(data.ResourceName).Key("identity.0.principal_id").Exists(),
+				check.That(data.ResourceName).Key("identity.0.tenant_id").Exists(),
+				check.That(data.ResourceName).Key("location").HasValue(location.Normalize(data.LocationPrimary)),
+				check.That(data.ResourceName).Key("tags.%").HasValue("1"),
+			),
+		},
+	})
+}
+
 func (r GenericDataSource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
@@ -40,6 +60,17 @@ data "azapi_resource" "test" {
   name      = azapi_resource.test.name
   parent_id = azapi_resource.test.parent_id
   type      = azapi_resource.test.type
+}
+`, GenericResource{}.complete(data))
+}
+
+func (r GenericDataSource) withResourceId(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+data "azapi_resource" "test" {
+  type      = azapi_resource.test.type
+  resource_id = azapi_resource.test.id
 }
 `, GenericResource{}.complete(data))
 }

--- a/internal/services/azapi_resource_data_source_test.go
+++ b/internal/services/azapi_resource_data_source_test.go
@@ -69,7 +69,7 @@ func (r GenericDataSource) withResourceId(data acceptance.TestData) string {
 %s
 
 data "azapi_resource" "test" {
-  type      = azapi_resource.test.type
+  type        = azapi_resource.test.type
   resource_id = azapi_resource.test.id
 }
 `, GenericResource{}.complete(data))

--- a/internal/services/azapi_update_resource.go
+++ b/internal/services/azapi_update_resource.go
@@ -37,34 +37,31 @@ func ResourceAzApiUpdateResource() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"name": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				ForceNew:      true,
-				Computed:      true,
-				ValidateFunc:  validation.StringIsNotEmpty,
-				RequiredWith:  []string{"parent_id"},
-				ConflictsWith: []string{"resource_id"},
-				ExactlyOneOf:  []string{"name", "resource_id"},
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				Computed:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+				RequiredWith: []string{"parent_id"},
+				ExactlyOneOf: []string{"name", "resource_id"},
 			},
 
 			"parent_id": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				ForceNew:      true,
-				Computed:      true,
-				ValidateFunc:  validation.StringIsNotEmpty,
-				RequiredWith:  []string{"name"},
-				ConflictsWith: []string{"resource_id"},
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				Computed:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+				RequiredWith: []string{"name"},
 			},
 
 			"resource_id": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				ForceNew:      true,
-				Computed:      true,
-				ValidateFunc:  validate.AzureResourceID,
-				ConflictsWith: []string{"name", "parent_id"},
-				ExactlyOneOf:  []string{"name", "resource_id"},
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				Computed:     true,
+				ValidateFunc: validate.AzureResourceID,
+				ExactlyOneOf: []string{"name", "resource_id"},
 			},
 
 			"type": {

--- a/internal/services/azapi_update_resource.go
+++ b/internal/services/azapi_update_resource.go
@@ -44,7 +44,7 @@ func ResourceAzApiUpdateResource() *schema.Resource {
 				ValidateFunc:  validation.StringIsNotEmpty,
 				RequiredWith:  []string{"parent_id"},
 				ConflictsWith: []string{"resource_id"},
-				AtLeastOneOf:  []string{"name", "resource_id"},
+				ExactlyOneOf:  []string{"name", "resource_id"},
 			},
 
 			"parent_id": {
@@ -64,7 +64,7 @@ func ResourceAzApiUpdateResource() *schema.Resource {
 				Computed:      true,
 				ValidateFunc:  validate.AzureResourceID,
 				ConflictsWith: []string{"name", "parent_id"},
-				AtLeastOneOf:  []string{"name", "resource_id"},
+				ExactlyOneOf:  []string{"name", "resource_id"},
 			},
 
 			"type": {


### PR DESCRIPTION
To address: https://github.com/Azure/terraform-provider-azapi/issues/134

`azapi_resource` data source: Supports configuring `resource_id` as an alternative way to configure `name` and `parent_id`.