### PR TITLE
azapi provider support `partner_id`, `disable_terraform_partner_id` ...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ ENHANCEMENTS:
 - `azapi_resource`: Supports `locks` which used to prevent creating/modifying/deleting resources at the same time.
 - `azapi_update_resource`: Supports `locks` which used to prevent creating/modifying/deleting resources at the same time.
 - `azapi_resource` data source: Supports configuring `resource_id` as an alternative way to configure `name` and `parent_id`.
+- `azapi` provider: Supports `partner_id`, `disable_terraform_partner_id` and `disable_terraform_partner_id`.
 - Update bicep types to https://github.com/Azure/bicep-types-az/commit/7121acc12c7d558960cb9a2e333cb3c8469ae8cb
 
 BUG FIXES:

--- a/docs/index.md
+++ b/docs/index.md
@@ -89,6 +89,12 @@ More information on [how to configure a Service Principal using a Client Secret 
 
 For some advanced scenarios, such as where more granular permissions are necessary - the following properties can be set:
 
+* `disable_correlation_request_id` - (Optional) Disable sending the `x-ms-correlation-request-id` header. This can also be sourced from the `ARM_DISABLE_CORRELATION_REQUEST_ID` environment variable. Defaults to `false`.
+
+* `disable_terraform_partner_id` - (Optional) Disable sending the Terraform Partner ID if a custom `partner_id` isn't specified, which allows Microsoft to better understand the usage of Terraform. The Partner ID does not give HashiCorp any direct access to usage information. This can also be sourced from the `ARM_DISABLE_TERRAFORM_PARTNER_ID` environment variable. Defaults to `false`.
+
+* `partner_id` - (Optional) A GUID/UUID that is [registered](https://docs.microsoft.com/azure/marketplace/azure-partner-customer-usage-attribution#register-guids-and-offers) with Microsoft to facilitate partner resource usage attribution. This can also be sourced from the `ARM_PARTNER_ID` Environment Variable.
+
 * `skip_provider_registration` - (Optional) Should the Provider skip registering the Resource Providers it supports? This can also be sourced from the `ARM_SKIP_PROVIDER_REGISTRATION` Environment Variable. Defaults to `false`.
 
 -> By default, Terraform will attempt to register the Resource Providers that the provisioning resources belong to. If you're running in an environment with restricted permissions, or wish to manage Resource Provider Registration outside of Terraform you may wish to disable this flag; however, please note that the error messages returned from Azure may be confusing as a result (example: `API version 2019-01-01 was not found for Microsoft.Foo`).

--- a/internal/clients/client.go
+++ b/internal/clients/client.go
@@ -22,11 +22,12 @@ type Client struct {
 }
 
 type Option struct {
-	SubscriptionId           string
-	Cred                     azcore.TokenCredential
-	ApplicationUserAgent     string
-	Features                 features.UserFeatures
-	SkipProviderRegistration bool
+	SubscriptionId              string
+	Cred                        azcore.TokenCredential
+	ApplicationUserAgent        string
+	Features                    features.UserFeatures
+	SkipProviderRegistration    bool
+	DisableCorrelationRequestID bool
 }
 
 // NOTE: it should be possible for this method to become Private once the top level Client's removed
@@ -38,6 +39,13 @@ func (client *Client) Build(ctx context.Context, o *Option) error {
 	azlog.SetListener(func(cls azlog.Event, msg string) {
 		log.Printf("[DEBUG] %s %s: %s\n", time.Now().Format(time.StampMicro), cls, msg)
 	})
+
+	perCallPolicies := make([]policy.Policy, 0)
+	perCallPolicies = append(perCallPolicies, withUserAgent(o.ApplicationUserAgent))
+	if !o.DisableCorrelationRequestID {
+		perCallPolicies = append(perCallPolicies, withCorrelationRequestID(correlationRequestID()))
+	}
+
 	resourceClient, err := NewResourceClient(o.SubscriptionId, o.Cred, &arm.ClientOptions{
 		ClientOptions: policy.ClientOptions{
 			// Disable the default telemetry policy, because it has a length limitation for user agent
@@ -47,10 +55,7 @@ func (client *Client) Build(ctx context.Context, o *Option) error {
 			Logging: policy.LogOptions{
 				IncludeBody: true,
 			},
-			PerCallPolicies: []policy.Policy{
-				withCorrelationRequestID(correlationRequestID()),
-				withUserAgent(o.ApplicationUserAgent),
-			},
+			PerCallPolicies: perCallPolicies,
 		},
 		DisableRPRegistration: o.SkipProviderRegistration,
 	})


### PR DESCRIPTION

To address https://github.com/Azure/terraform-provider-azapi/issues/138
azapi provider support `partner_id`, `disable_terraform_partner_id` and `disable_terraform_partner_id`

test evidences:
1. all default values
<img width="984" alt="image" src="https://user-images.githubusercontent.com/79895375/174553370-339b8aa0-a4c5-4fdb-9b40-8a991a97b92b.png">


2. disable correlation request id
<img width="984" alt="image" src="https://user-images.githubusercontent.com/79895375/174553612-f0e61289-c41f-4087-bf40-2505b9d075fe.png">

3. customize partner id
<img width="971" alt="image" src="https://user-images.githubusercontent.com/79895375/174553880-d5105296-8edd-4b41-94ca-7201f2af2249.png">

4. disable partner id
<img width="1000" alt="image" src="https://user-images.githubusercontent.com/79895375/174554495-821fd1ff-8637-47a1-b04e-4c2e89cc7dc2.png">
