### PR TITLE
action resource's id should be the request path

### DIFF
--- a/internal/services/azapi_resource_action_data_source.go
+++ b/internal/services/azapi_resource_action_data_source.go
@@ -109,7 +109,11 @@ func resourceResourceActionDataSourceRead(d *schema.ResourceData, meta interface
 		return fmt.Errorf("performing action %s of %q: %+v", actionName, id, err)
 	}
 
-	d.SetId(id.ID())
+	resourceId := id.ID()
+	if actionName != "" {
+		resourceId = fmt.Sprintf("%s/%s", id.ID(), resourceId)
+	}
+	d.SetId(resourceId)
 	d.Set("output", flattenOutput(responseBody, d.Get("response_export_values").([]interface{})))
 
 	return resourceResourceActionRead(d, meta)

--- a/internal/services/azapi_resource_action_data_source.go
+++ b/internal/services/azapi_resource_action_data_source.go
@@ -111,7 +111,7 @@ func resourceResourceActionDataSourceRead(d *schema.ResourceData, meta interface
 
 	resourceId := id.ID()
 	if actionName != "" {
-		resourceId = fmt.Sprintf("%s/%s", id.ID(), resourceId)
+		resourceId = fmt.Sprintf("%s/%s", id.ID(), actionName)
 	}
 	d.SetId(resourceId)
 	d.Set("output", flattenOutput(responseBody, d.Get("response_export_values").([]interface{})))

--- a/internal/services/azapi_resource_action_resource.go
+++ b/internal/services/azapi_resource_action_resource.go
@@ -128,7 +128,7 @@ func resourceResourceActionCreateUpdate(d *schema.ResourceData, meta interface{}
 
 	resourceId := id.ID()
 	if actionName != "" {
-		resourceId = fmt.Sprintf("%s/%s", id.ID(), resourceId)
+		resourceId = fmt.Sprintf("%s/%s", id.ID(), actionName)
 	}
 	d.SetId(resourceId)
 	d.Set("output", flattenOutput(responseBody, d.Get("response_export_values").([]interface{})))

--- a/internal/services/azapi_resource_action_resource.go
+++ b/internal/services/azapi_resource_action_resource.go
@@ -126,7 +126,11 @@ func resourceResourceActionCreateUpdate(d *schema.ResourceData, meta interface{}
 		return fmt.Errorf("performing action %s of %q: %+v", actionName, id, err)
 	}
 
-	d.SetId(id.ID())
+	resourceId := id.ID()
+	if actionName != "" {
+		resourceId = fmt.Sprintf("%s/%s", id.ID(), resourceId)
+	}
+	d.SetId(resourceId)
 	d.Set("output", flattenOutput(responseBody, d.Get("response_export_values").([]interface{})))
 
 	return resourceResourceActionRead(d, meta)


### PR DESCRIPTION
The IDs of `azapi_resource_action` resource and data source were set to the IDs of the targeting resources, but it's better to use request path(combining action).