### PR TITLE
`azapi_resource_action` supports text content-type output

### DIFF
--- a/internal/services/resource.go
+++ b/internal/services/resource.go
@@ -66,6 +66,9 @@ func isResourceHasProperty(resourceDef *types.ResourceType, property string) boo
 func flattenOutput(responseBody interface{}, paths []interface{}) string {
 	for _, path := range paths {
 		if path == "*" {
+			if v, ok := responseBody.(string); ok {
+				return v
+			}
 			outputJson, _ := json.Marshal(responseBody)
 			return string(outputJson)
 		}


### PR DESCRIPTION
Fixes https://github.com/Azure/terraform-provider-azapi/issues/171

Supports `text/plain` content-type response.

<img width="949" alt="image" src="https://user-images.githubusercontent.com/79895375/188587463-5db77e10-fe12-4447-9d31-ce71a35678b2.png">
