### PR TITLE
`azapi_resource_action`: The `output` should be refreshed when `body`  is changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## v1.1.0 (unreleased)
+FEATURES:
+
+ENHANCEMENTS:
+
+BUG FIXES:
+- `azapi_resource_action`: The `output` is not refreshed when `body` is changed.
+
 ## v1.0.0
 FEATURES:
 

--- a/internal/services/azapi_resource_action_resource.go
+++ b/internal/services/azapi_resource_action_resource.go
@@ -101,7 +101,7 @@ func ResourceResourceAction() *schema.Resource {
 		},
 
 		CustomizeDiff: func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
-			if d.HasChange("response_export_values") || d.HasChange("action") {
+			if d.HasChange("response_export_values") || d.HasChange("action") || d.HasChange("body") {
 				d.SetNewComputed("output")
 			}
 			return nil


### PR DESCRIPTION
Fixed https://github.com/Azure/terraform-provider-azapi/issues/206