### PR TITLE
`azapi_resource` - ignore secrets which are returned in asterisks

### DIFF
--- a/internal/acceptance/testcase.go
+++ b/internal/acceptance/testcase.go
@@ -116,7 +116,7 @@ func (td TestData) externalProviders() map[string]resource.ExternalProvider {
 	return map[string]resource.ExternalProvider{
 		"azurerm": {
 			Source:            "registry.terraform.io/hashicorp/azurerm",
-			VersionConstraint: "= 2.75.0",
+			VersionConstraint: "= 3.41.0",
 		},
 	}
 }

--- a/internal/services/azapi_resource_test.go
+++ b/internal/services/azapi_resource_test.go
@@ -844,6 +844,7 @@ resource "azurerm_storage_account" "test" {
   account_tier             = "Standard"
   account_replication_type = "GRS"
 }
+
 resource "azurerm_spring_cloud_service" "test" {
   name                = "acctest-sc-%[2]d"
   location            = azurerm_resource_group.test.location
@@ -851,7 +852,7 @@ resource "azurerm_spring_cloud_service" "test" {
 }
 
 resource "azapi_resource" "test" {
-  type      = "Microsoft.AppPlatform/Spring/storages@2022-12-01"
+  type      = "Microsoft.AppPlatform/spring/storages@2022-12-01"
   name      = "acctest-ss-%[2]d"
   parent_id = azurerm_spring_cloud_service.test.id
 
@@ -887,7 +888,7 @@ resource "azurerm_spring_cloud_service" "test" {
 }
 
 resource "azapi_resource" "test" {
-  type      = "Microsoft.AppPlatform/Spring/storages@2022-12-01"
+  type      = "Microsoft.AppPlatform/spring/storages@2022-12-01"
   name      = "acctest-ss-%[2]d"
   parent_id = azurerm_spring_cloud_service.test.id
 

--- a/internal/services/azapi_resource_test.go
+++ b/internal/services/azapi_resource_test.go
@@ -338,6 +338,22 @@ func TestAccGenericResource_oidc(t *testing.T) {
 	})
 }
 
+func TestAccGenericResource_secretsInAsterisks(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azapi_resource", "test")
+	clientId := os.Getenv("ARM_CLIENT_ID")
+	clientSecret := os.Getenv("ARM_CLIENT_SECRET")
+	r := GenericResource{}
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.secretsInAsterisks(data, clientId, clientSecret),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("sso.0.client_id", "sso.0.client_secret"),
+	})
+}
+
 func (GenericResource) Exists(ctx context.Context, client *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	resourceType := state.Attributes["type"]
 	id, err := parse.ResourceIDWithResourceType(state.ID, resourceType)
@@ -948,6 +964,47 @@ resource "azapi_resource" "test2" {
   locks = [azurerm_route_table.test.id, azurerm_resource_group.test.id]
 }
 `, r.template(data), data.RandomInteger, data.RandomStringOfLength(10))
+}
+
+func (r GenericResource) secretsInAsterisks(data acceptance.TestData, clientId, clientSecret string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "azurerm_client_config" "current" {
+}
+
+resource "azurerm_spring_cloud_service" "test" {
+  name                = "acctest-sc-%[2]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku_name            = "E0"
+}
+
+resource "azurerm_spring_cloud_gateway" "test" {
+  name                    = "default"
+  spring_cloud_service_id = azurerm_spring_cloud_service.test.id
+}
+
+resource "azapi_resource" "test" {
+  type      = "Microsoft.AppPlatform/Spring/apiPortals@2022-12-01"
+  parent_id = azurerm_spring_cloud_service.test.id
+  name      = "default"
+  body = jsonencode({
+    properties = {
+      gatewayIds = [azurerm_spring_cloud_gateway.test.id]
+      httpsOnly  = false
+      public     = false
+      ssoProperties = {
+        clientId     = "%[4]s"
+        clientSecret = "%[5]s"
+        issuerUri    = "https://login.microsoftonline.com/${data.azurerm_client_config.current.tenant_id}/v2.0"
+        scope        = ["read"]
+      }
+    }
+  })
+  ignore_casing = true
+}
+`, r.template(data), data.RandomInteger, data.RandomStringOfLength(10), clientId, clientSecret)
 }
 
 func (GenericResource) template(data acceptance.TestData) string {

--- a/internal/services/azapi_resource_test.go
+++ b/internal/services/azapi_resource_test.go
@@ -879,6 +879,7 @@ resource "azurerm_storage_account" "test" {
   account_tier             = "Standard"
   account_replication_type = "GRS"
 }
+
 resource "azurerm_spring_cloud_service" "test" {
   name                = "acctest-sc-%[2]d"
   location            = azurerm_resource_group.test.location

--- a/internal/services/azapi_resource_test.go
+++ b/internal/services/azapi_resource_test.go
@@ -350,7 +350,6 @@ func TestAccGenericResource_secretsInAsterisks(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep("sso.0.client_id", "sso.0.client_secret"),
 	})
 }
 

--- a/internal/services/azapi_update_resource_test.go
+++ b/internal/services/azapi_update_resource_test.go
@@ -242,7 +242,7 @@ func (GenericUpdateResource) template(data acceptance.TestData) string {
 terraform {
   required_providers {
     azurerm = {
-      version = "= 2.75.0"
+      version = "= 3.41.0"
       source  = "hashicorp/azurerm"
     }
   }

--- a/utils/json.go
+++ b/utils/json.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"strings"
 )
 
@@ -92,6 +93,9 @@ func GetUpdatedJson(old interface{}, new interface{}, option UpdateJsonOption) i
 	case string:
 		if newStr, ok := new.(string); ok {
 			if option.IgnoreCasing && strings.EqualFold(oldValue, newStr) {
+				return oldValue
+			}
+			if option.IgnoreMissingProperty && regexp.MustCompile(`^\**$`).MatchString(newStr) {
 				return oldValue
 			}
 		}

--- a/utils/json.go
+++ b/utils/json.go
@@ -95,7 +95,7 @@ func GetUpdatedJson(old interface{}, new interface{}, option UpdateJsonOption) i
 			if option.IgnoreCasing && strings.EqualFold(oldValue, newStr) {
 				return oldValue
 			}
-			if option.IgnoreMissingProperty && regexp.MustCompile(`^\**$`).MatchString(newStr) {
+			if option.IgnoreMissingProperty && regexp.MustCompile(`^\*+$`).MatchString(newStr) {
 				return oldValue
 			}
 		}


### PR DESCRIPTION
By Azure rest API guideline, sensitive properties should be omitted in GET response, but some of them are returned in asterisks. This PR will ignore those secrets in asterisks.