### PR TITLE
support `partial mode` to avoid writing diff to state while `Update` error

### DIFF
--- a/internal/services/azapi_resource.go
+++ b/internal/services/azapi_resource.go
@@ -281,6 +281,10 @@ func resourceAzApiResourceCreateUpdate(d *schema.ResourceData, meta interface{})
 	ctx, cancel := tf.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
+	if !d.IsNewResource() {
+		d.Partial(true)
+	}
+
 	config := d.GetRawConfig()
 	var resourceName string
 
@@ -307,8 +311,6 @@ func resourceAzApiResourceCreateUpdate(d *schema.ResourceData, meta interface{})
 		if !utils.ResponseErrorWasNotFound(err) {
 			return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
 		}
-	} else {
-		d.Partial(true)
 	}
 
 	var body map[string]interface{}

--- a/internal/services/azapi_resource.go
+++ b/internal/services/azapi_resource.go
@@ -307,6 +307,8 @@ func resourceAzApiResourceCreateUpdate(d *schema.ResourceData, meta interface{})
 		if !utils.ResponseErrorWasNotFound(err) {
 			return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
 		}
+	} else {
+		d.Partial(true)
 	}
 
 	var body map[string]interface{}
@@ -373,6 +375,10 @@ func resourceAzApiResourceCreateUpdate(d *schema.ResourceData, meta interface{})
 	}
 
 	d.SetId(id.ID())
+
+	if !d.IsNewResource() {
+		d.Partial(false)
+	}
 
 	return resourceAzApiResourceRead(d, meta)
 }

--- a/internal/services/azapi_resource_action_resource.go
+++ b/internal/services/azapi_resource_action_resource.go
@@ -115,6 +115,10 @@ func resourceResourceActionCreateUpdate(d *schema.ResourceData, meta interface{}
 	ctx, cancel := tf.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
+	if !d.IsNewResource() {
+		d.Partial(true)
+	}
+
 	id, err := parse.ResourceIDWithResourceType(d.Get("resource_id").(string), d.Get("type").(string))
 	if err != nil {
 		return err
@@ -150,6 +154,10 @@ func resourceResourceActionCreateUpdate(d *schema.ResourceData, meta interface{}
 	d.SetId(resourceId)
 	// #nosec G104
 	d.Set("output", flattenOutput(responseBody, d.Get("response_export_values").([]interface{})))
+
+	if !d.IsNewResource() {
+		d.Partial(false)
+	}
 
 	return resourceResourceActionRead(d, meta)
 }

--- a/internal/services/azapi_resource_test.go
+++ b/internal/services/azapi_resource_test.go
@@ -59,9 +59,11 @@ func TestAccGenericResource_invalidVersionUpdate(t *testing.T) {
 		{
 			Config:      r.basicInvalidVersion(data),
 			ExpectError: regexp.MustCompile("400 Bad Request"),
-			Check: resource.ComposeTestCheckFunc(
-				check.That(data.ResourceName).Key("type").HasValue("Microsoft.Automation/automationAccounts/certificates@2022-08-08"),
-			),
+		},
+		data.ImportStep(defaultIgnores()...),
+		{
+			Config:   r.basic(data),
+			PlanOnly: true,
 		},
 	})
 }

--- a/internal/services/azapi_update_resource.go
+++ b/internal/services/azapi_update_resource.go
@@ -148,6 +148,10 @@ func resourceAzApiUpdateResourceCreateUpdate(d *schema.ResourceData, meta interf
 	ctx, cancel := tf.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
+	if !d.IsNewResource() {
+		d.Partial(true)
+	}
+
 	var id parse.ResourceId
 	if name := d.Get("name").(string); len(name) != 0 {
 		buildId, err := parse.NewResourceID(d.Get("name").(string), d.Get("parent_id").(string), d.Get("type").(string))
@@ -193,6 +197,10 @@ func resourceAzApiUpdateResourceCreateUpdate(d *schema.ResourceData, meta interf
 	}
 
 	d.SetId(id.ID())
+
+	if !d.IsNewResource() {
+		d.Partial(false)
+	}
 
 	return resourceAzApiUpdateResourceRead(d, meta)
 }


### PR DESCRIPTION
Update with wrong API version will write wrong value to state file, which leads to state refresh error in later apply.

related to https://github.com/hashicorp/terraform-plugin-sdk/issues/476
use the `partial mode`, see [doc](https://www.hashicorp.com/blog/writing-custom-terraform-providers):
> If the Update callback returns with or without an error, the full state is saved. If the ID becomes blank, the resource is destroyed (even within an update, though this shouldn't happen except in error scenarios).

> Partial mode is a mode that can be enabled by a callback that tells Terraform that it is possible for partial state to occur. When this mode is enabled, the provider must explicitly tell Terraform what is safe to persist and what is not.

```
TF_ACC=1 go test -v ./internal/services -parallel 20 -test.run=TestAccGenericResource_invalidVersionUpdate -timeout 1440m -ldflags="-X=github.com/Azure/terraform-provider-azapi/version.ProviderVersion=acc"
=== RUN   TestAccGenericResource_invalidVersionUpdate
=== PAUSE TestAccGenericResource_invalidVersionUpdate
=== CONT  TestAccGenericResource_invalidVersionUpdate
--- PASS: TestAccGenericResource_invalidVersionUpdate (99.38s)
PASS
ok      github.com/Azure/terraform-provider-azapi/internal/services     101.030s

```