### PR TITLE
Fix a bug that schema validation requires redundant `name` fields boh in resource and in body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ ENHANCEMENTS:
 
 BUG FIXES:
 - Fix a bug that when apply failed there still are some attributes stored in the state.
+- Fix a bug that schema validation requires redundant `name` fields both in resource and in body.
 
 ## v1.3.0
 FEATURES:

--- a/internal/services/azapi_resource.go
+++ b/internal/services/azapi_resource.go
@@ -267,6 +267,7 @@ func ResourceAzApiResource() *schema.Resource {
 						body["identity"] = identityModel
 					}
 				}
+				body["name"] = assignedName
 				if err := schemaValidation(azureResourceType, apiVersion, resourceDef, body); err != nil {
 					return err
 				}
@@ -357,6 +358,7 @@ func resourceAzApiResourceCreateUpdate(d *schema.ResourceData, meta interface{})
 		}
 	}
 
+	body["name"] = id.Name
 	if d.Get("schema_validation_enabled").(bool) {
 		if err := schemaValidation(id.AzureResourceType, id.ApiVersion, id.ResourceDef, body); err != nil {
 			return err


### PR DESCRIPTION
Fix a bug that schema validation requires redundant `name` fields boh in resource and in body

Fixes https://github.com/Azure/terraform-provider-azapi/issues/245