### PR TITLE
Ignore `<redacted>` in response

### DIFF
--- a/utils/json.go
+++ b/utils/json.go
@@ -95,7 +95,7 @@ func GetUpdatedJson(old interface{}, new interface{}, option UpdateJsonOption) i
 			if option.IgnoreCasing && strings.EqualFold(oldValue, newStr) {
 				return oldValue
 			}
-			if option.IgnoreMissingProperty && regexp.MustCompile(`^\*+$`).MatchString(newStr) {
+			if option.IgnoreMissingProperty && (regexp.MustCompile(`^\*+$`).MatchString(newStr) || regexp.MustCompile(`^<redacted>$`).MatchString(newStr)) {
 				return oldValue
 			}
 		}

--- a/utils/json.go
+++ b/utils/json.go
@@ -95,7 +95,7 @@ func GetUpdatedJson(old interface{}, new interface{}, option UpdateJsonOption) i
 			if option.IgnoreCasing && strings.EqualFold(oldValue, newStr) {
 				return oldValue
 			}
-			if option.IgnoreMissingProperty && (regexp.MustCompile(`^\*+$`).MatchString(newStr) || regexp.MustCompile(`^<redacted>$`).MatchString(newStr)) {
+			if option.IgnoreMissingProperty && (regexp.MustCompile(`^\*+$`).MatchString(newStr) || "<redacted>" == newStr) {
 				return oldValue
 			}
 		}

--- a/utils/json_test.go
+++ b/utils/json_test.go
@@ -69,6 +69,32 @@ func Test_GetUpdatedJson(t *testing.T) {
 				IgnoreCasing:          true,
 			},
 		},
+		{
+			OldJson: `
+{
+  "properties": {
+    "sshPrivateKey": "asdf"
+  }
+}`,
+			NewJson: `
+{
+  "properties": {
+    "sshPrivateKey": "<redacted>"
+  }
+}
+`,
+			ExpectJson: `
+{
+  "properties": {
+    "sshPrivateKey": "asdf"
+  }
+}
+`,
+			Option: utils.UpdateJsonOption{
+				IgnoreMissingProperty: true,
+				IgnoreCasing:          true,
+			},
+		},
 	}
 
 	for _, testcase := range testcases {


### PR DESCRIPTION
- Update regex match to be either stars or the literal `<redacted>`
- Resolves #268
- Included test case where plan sees key, server response shows `<redacted>`, but resulting json is still key