### PR TITLE
`azapi` - `custom_correlation_request_id`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 FEATURES:
 - `azapi`: Support `use_msi` and `use_cli` features.
 - `azapi`: Support `auxiliary_tenant_ids` field, which is required for multi-tenancy and cross-tenant scenarios.
+- `azapi`: Support `custom_correlation_request_id` field, which is used to specify the correlation request id.
 
 ENHANCEMENTS:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -132,6 +132,8 @@ More information on [how to authenticate to Azure using Azure CLI can be found i
 
 For some advanced scenarios, such as where more granular permissions are necessary - the following properties can be set:
 
+* `custom_correlation_request_id` - (Optional) The value of the `x-ms-correlation-request-id` header, otherwise an auto-generated UUID will be used. This can also be sourced from the `ARM_CORRELATION_REQUEST_ID` environment variable.
+
 * `disable_correlation_request_id` - (Optional) Disable sending the `x-ms-correlation-request-id` header. This can also be sourced from the `ARM_DISABLE_CORRELATION_REQUEST_ID` environment variable. Defaults to `false`.
 
 * `disable_terraform_partner_id` - (Optional) Disable sending the Terraform Partner ID if a custom `partner_id` isn't specified, which allows Microsoft to better understand the usage of Terraform. The Partner ID does not give HashiCorp any direct access to usage information. This can also be sourced from the `ARM_DISABLE_TERRAFORM_PARTNER_ID` environment variable. Defaults to `false`.

--- a/internal/clients/client.go
+++ b/internal/clients/client.go
@@ -29,6 +29,7 @@ type Option struct {
 	SkipProviderRegistration    bool
 	DisableCorrelationRequestID bool
 	CloudCfg                    cloud.Configuration
+	CustomCorrelationRequestID  string
 }
 
 // NOTE: it should be possible for this method to become Private once the top level Client's removed
@@ -44,7 +45,11 @@ func (client *Client) Build(ctx context.Context, o *Option) error {
 	perCallPolicies := make([]policy.Policy, 0)
 	perCallPolicies = append(perCallPolicies, withUserAgent(o.ApplicationUserAgent))
 	if !o.DisableCorrelationRequestID {
-		perCallPolicies = append(perCallPolicies, withCorrelationRequestID(correlationRequestID()))
+		id := o.CustomCorrelationRequestID
+		if id == "" {
+			id = correlationRequestID()
+		}
+		perCallPolicies = append(perCallPolicies, withCorrelationRequestID(id))
 	}
 
 	resourceClient, err := NewResourceClient(o.Cred, &arm.ClientOptions{

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -189,7 +189,7 @@ func azureProvider() *schema.Provider {
 			"custom_correlation_request_id": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Default:     schema.EnvDefaultFunc("ARM_CORRELATION_REQUEST_ID", ""),
+				DefaultFunc: schema.EnvDefaultFunc("ARM_CORRELATION_REQUEST_ID", ""),
 				Description: "The value of the x-ms-correlation-request-id header (otherwise an auto-generated UUID will be used).",
 			},
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -186,6 +186,13 @@ func azureProvider() *schema.Provider {
 				Description:  "A GUID/UUID that is registered with Microsoft to facilitate partner resource usage attribution.",
 			},
 
+			"custom_correlation_request_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     schema.EnvDefaultFunc("ARM_CORRELATION_REQUEST_ID", ""),
+				Description: "The value of the x-ms-correlation-request-id header (otherwise an auto-generated UUID will be used).",
+			},
+
 			"disable_correlation_request_id": {
 				Type:        schema.TypeBool,
 				Optional:    true,
@@ -293,6 +300,7 @@ func providerConfigure(p *schema.Provider) schema.ConfigureContextFunc {
 			},
 			SkipProviderRegistration:    d.Get("skip_provider_registration").(bool),
 			DisableCorrelationRequestID: d.Get("disable_correlation_request_id").(bool),
+			CustomCorrelationRequestID:  d.Get("custom_correlation_request_id").(string),
 		}
 
 		//lint:ignore SA1019 SDKv2 migration - staticcheck's own linter directives are currently being ignored under golanci-lint


### PR DESCRIPTION
fixes https://github.com/Azure/terraform-provider-azapi/issues/296

```hcl
provider "azapi" {
  custom_correlation_request_id = "1234567890"
}
```

```
PUT https://management.azure.com/subscriptions/******/resourceGroups/henglu1114/providers/Microsoft.Automation/automationAccounts/henglu1114?api-version=2022-08-08 HTTP/2.0
content-type: application/json
user-agent: HashiCorp Terraform/1.4.5 (+https://www.terraform.io) Terraform Plugin SDK/2.8.0 terraform-provider-azapi/dev pid-222c6c49-1b0a-5959-a213-6608f9eb8820

x-ms-correlation-request-id: 1234567890       <<----- here

authorization: ******
accept: application/json
content-length: 83
accept-encoding: gzip

{"location":"westeurope","name":"henglu1114","properties":{"sku":{"name":"Basic"}}}
```