### PR TITLE
`azapi_resource_action` - supports provider level actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ ENHANCEMENTS:
 - `azapi_resource_action`: Support provider action.
 
 BUG FIXES:
+- Fix a bug that resource id for type `Microsoft.Resources/providers` is not parsed correctly.
 - Fix a bug that resource id for type `Microsoft.Resources/tenants` is not parsed correctly.
 
 ## v1.7.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
-## v1.8.0
+## v1.8.0 (unreleased)
 FEATURES:
 
 ENHANCEMENTS:
+- `azapi_resource_action`: Support provider action.
 
 BUG FIXES:
 - Fix a bug that resource id for type `Microsoft.Resources/tenants` is not parsed correctly.

--- a/docs/data-sources/azapi_resource_action.md
+++ b/docs/data-sources/azapi_resource_action.md
@@ -50,6 +50,25 @@ data "azapi_resource_action" "example" {
 }
 ```
 
+Here's an example to use `azapi_resource_action` resource to perform a provider action.
+
+```hcl
+terraform {
+  required_providers {
+    azapi = {
+      source = "Azure/azapi"
+    }
+  }
+}
+
+resource "azapi_resource_action" "test" {
+  type        = "Microsoft.Resources/providers@2021-04-01"
+  resource_id = "/subscriptions/{subscription_id}/providers/Microsoft.Compute"
+  action      = "register"
+  method      = "POST"
+}
+```
+
 ## Arguments Reference
 
 The following arguments are supported:

--- a/docs/data-sources/azapi_resource_action.md
+++ b/docs/data-sources/azapi_resource_action.md
@@ -67,6 +67,16 @@ resource "azapi_resource_action" "test" {
   action      = "register"
   method      = "POST"
 }
+
+resource "azapi_resource_action" "test" {
+  type        = "Microsoft.Databox@2022-10-01"
+  resource_id = "/subscriptions/{subscription_id}/providers/Microsoft.Databox"
+  action      = "validateAddress"
+  method      = "POST"
+  body = jsonencode({
+    // ...
+  })
+}
 ```
 
 ## Arguments Reference

--- a/docs/data-sources/azapi_resource_action.md
+++ b/docs/data-sources/azapi_resource_action.md
@@ -50,7 +50,24 @@ data "azapi_resource_action" "example" {
 }
 ```
 
-Here's an example to use `azapi_resource_action` resource to perform a provider action.
+Here's an example to use the `azapi_resource_action` data source to get a provider's permissions.
+
+```hcl
+provider "azurerm" {
+  features {}
+}
+
+data "azurerm_client_config" "current" {}
+
+data "azapi_resource_action" "test" {
+  type        = "Microsoft.Resources/providers@2021-04-01"
+  resource_id = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/providers/Microsoft.Network"
+  action      = "providerPermissions"
+  method      = "GET"
+}
+```
+
+Here's an example to use the `azapi_resource_action` data source to perform a provider action.
 
 ```hcl
 terraform {
@@ -62,19 +79,12 @@ terraform {
 }
 
 resource "azapi_resource_action" "test" {
-  type        = "Microsoft.Resources/providers@2021-04-01"
-  resource_id = "/subscriptions/{subscription_id}/providers/Microsoft.Compute"
-  action      = "register"
-  method      = "POST"
-}
-
-resource "azapi_resource_action" "test" {
-  type        = "Microsoft.Databox@2022-10-01"
-  resource_id = "/subscriptions/{subscription_id}/providers/Microsoft.Databox"
-  action      = "validateAddress"
-  method      = "POST"
+  type        = "Microsoft.Cache@2023-04-01"
+  resource_id = "/subscriptions/85b3dbca-5974-4067-9669-67a141095a76/providers/Microsoft.Cache"
+  action      = "CheckNameAvailability"
   body = jsonencode({
-    // ...
+    type = "Microsoft.Cache/Redis"
+    name = "cacheName"
   })
 }
 ```

--- a/docs/guides/frequently_asked_questions.md
+++ b/docs/guides/frequently_asked_questions.md
@@ -58,10 +58,11 @@ It can be solved by using `azapi_update_resource` to perform a multi-steps deplo
 
 ## What are the types for the resource group, subscription and tenant?
 
-| Resource Type | Type | Example |
-| --- | --- | --- |
-| resource group | `Microsoft.Resources/resourceGroups` | `/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg` |
-| subscription | `Microsoft.Resources/subscriptions` | `/subscriptions/00000000-0000-0000-0000-000000000000` |
-| tenant | `Microsoft.Resources/tenants` | `/tenants/00000000-0000-0000-0000-000000000000` |
-| management group | `Microsoft.Management/managementGroups` | `/providers/Microsoft.Management/managementGroups/00000000-0000-0000-0000-000000000000` |
-| provider | `Microsoft.Resources/providers` | `/providers/Microsoft.Storage` |
+| Resource Type | Type | Example | Comment |
+| --- | --- | --- | --- |
+| resource group | `Microsoft.Resources/resourceGroups` | `/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg` | |
+| subscription | `Microsoft.Resources/subscriptions` | `/subscriptions/00000000-0000-0000-0000-000000000000` | |
+| tenant | `Microsoft.Resources/tenants` | `/tenants/00000000-0000-0000-0000-000000000000` | |
+| management group | `Microsoft.Management/managementGroups` | `/providers/Microsoft.Management/managementGroups/00000000-0000-0000-0000-000000000000` | |
+| generic provider | `Microsoft.Resources/providers` | `<scope>/providers/<RP>` | This is the generic provider resource type whose operations are defined by ARM, and is supported by all of Azure RPs (e.g. actions like `register`, `providerPermissions`, etc.) |
+| concrete provider | `Microsoft.Resources/providers` | `<scope>/providers/Microsoft.Storage` | This is the concrete provider whose operations are only defined for this provider itself |

--- a/docs/guides/frequently_asked_questions.md
+++ b/docs/guides/frequently_asked_questions.md
@@ -55,3 +55,13 @@ its request body won't contain any subnets definitions, so existing subnets will
 More context: Properties like CMK(customer managed key) can't be set when create this resource. Because CMK depends on key vault key which depends on this resource's identity.
 
 It can be solved by using `azapi_update_resource` to perform a multi-steps deployment, here's an [example](https://github.com/Azure/terraform-provider-azapi/tree/main/examples/Microsoft.ServiceBus/ServiceBusNamespace-CMK/main.tf).
+
+## What are the types for the resource group, subscription and tenant?
+
+| Resource Type | Type | Example |
+| --- | --- | --- |
+| resource group | `Microsoft.Resources/resourceGroups` | `/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg` |
+| subscription | `Microsoft.Resources/subscriptions` | `/subscriptions/00000000-0000-0000-0000-000000000000` |
+| tenant | `Microsoft.Resources/tenants` | `/tenants/00000000-0000-0000-0000-000000000000` |
+| management group | `Microsoft.Management/managementGroups` | `/providers/Microsoft.Management/managementGroups/00000000-0000-0000-0000-000000000000` |
+| provider | `Microsoft.Resources/providers` | `/providers/Microsoft.Storage` |

--- a/docs/resources/azapi_data_plane_resource.md
+++ b/docs/resources/azapi_data_plane_resource.md
@@ -29,8 +29,8 @@ provider "azurerm" {
 }
 
 data "azurerm_synapse_workspace" "example" {
-  name                                 = "example-workspace"
-  resource_group_name                  = azurerm_resource_group.example.name
+  name                = "example-workspace"
+  resource_group_name = azurerm_resource_group.example.name
 }
 
 resource "azapi_data_plane_resource" "dataset" {

--- a/docs/resources/azapi_resource_action.md
+++ b/docs/resources/azapi_resource_action.md
@@ -69,7 +69,24 @@ resource "azapi_resource_action" "stop" {
 }
 ```
 
-Here's an example to use `azapi_resource_action` resource to perform a provider action.
+Here's an example to use the `azapi_resource_action` resource to register a provider.
+
+```hcl
+provider "azurerm" {
+  features {}
+}
+
+data "azurerm_client_config" "current" {}
+
+resource "azapi_resource_action" "test" {
+  type        = "Microsoft.Resources/providers@2021-04-01"
+  resource_id = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/providers/Microsoft.Compute"
+  action      = "register"
+  method      = "POST"
+}
+```
+
+Here's an example to use the `azapi_resource_action` resource to perform a provider action.
 
 ```hcl
 terraform {
@@ -88,12 +105,6 @@ data "azapi_resource_action" "test" {
     query = "resources| where name contains \"test\""
   })
   response_export_values = ["*"]
-}
-
-data "azapi_resource_action" "rp" {
-  type        = "Microsoft.Resources/providers@2021-04-01"
-  resource_id = "/subscriptions/{subscription_id}/providers/Microsoft.Compute"
-  method      = "GET"
 }
 ```
 

--- a/docs/resources/azapi_resource_action.md
+++ b/docs/resources/azapi_resource_action.md
@@ -69,6 +69,28 @@ resource "azapi_resource_action" "stop" {
 }
 ```
 
+Here's an example to use `azapi_resource_action` resource to perform a provider action.
+
+```hcl
+terraform {
+  required_providers {
+    azapi = {
+      source = "Azure/azapi"
+    }
+  }
+}
+
+data "azapi_resource_action" "test" {
+  type        = "Microsoft.Resources/providers@2020-04-01-preview"
+  resource_id = "/providers/Microsoft.ResourceGraph"
+  action      = "resources"
+  body = jsonencode({
+    query = "resources| where name contains \"test\""
+  })
+  response_export_values = ["*"]
+}
+```
+
 ## Arguments Reference
 
 The following arguments are supported:

--- a/docs/resources/azapi_resource_action.md
+++ b/docs/resources/azapi_resource_action.md
@@ -81,13 +81,19 @@ terraform {
 }
 
 data "azapi_resource_action" "test" {
-  type        = "Microsoft.Resources/providers@2020-04-01-preview"
+  type        = "Microsoft.ResourceGraph@2020-04-01-preview"
   resource_id = "/providers/Microsoft.ResourceGraph"
   action      = "resources"
   body = jsonencode({
     query = "resources| where name contains \"test\""
   })
   response_export_values = ["*"]
+}
+
+data "azapi_resource_action" "rp" {
+  type        = "Microsoft.Resources/providers@2021-04-01"
+  resource_id = "/subscriptions/{subscription_id}/providers/Microsoft.Compute"
+  method      = "GET"
 }
 ```
 

--- a/internal/services/azapi_resource_action_data_source_test.go
+++ b/internal/services/azapi_resource_action_data_source_test.go
@@ -49,8 +49,6 @@ data "azapi_resource_action" "test" {
 
 func (r ActionDataSource) providerAction() string {
 	return `
-
-
 data "azapi_resource_action" "test" {
   type        = "Microsoft.ResourceGraph@2020-04-01-preview"
   resource_id = "/providers/Microsoft.ResourceGraph"

--- a/internal/services/azapi_resource_action_data_source_test.go
+++ b/internal/services/azapi_resource_action_data_source_test.go
@@ -22,6 +22,18 @@ func TestAccActionDataSource_basic(t *testing.T) {
 	})
 }
 
+func TestAccActionDataSource_providerAction(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azapi_resource_action", "test")
+	r := ActionDataSource{}
+
+	data.DataSourceTest(t, []resource.TestStep{
+		{
+			Config: r.providerAction(),
+			Check:  resource.ComposeTestCheckFunc(),
+		},
+	})
+}
+
 func (r ActionDataSource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
@@ -33,4 +45,20 @@ data "azapi_resource_action" "test" {
   response_export_values = ["*"]
 }
 `, GenericResource{}.defaultTag(data))
+}
+
+func (r ActionDataSource) providerAction() string {
+	return `
+
+
+data "azapi_resource_action" "test" {
+  type        = "Microsoft.Resources/providers@2020-04-01-preview"
+  resource_id = "/providers/Microsoft.ResourceGraph"
+  action      = "resources"
+  body = jsonencode({
+    query = "resources| limit 1"
+  })
+  response_export_values = ["*"]
+}
+`
 }

--- a/internal/services/azapi_resource_action_data_source_test.go
+++ b/internal/services/azapi_resource_action_data_source_test.go
@@ -52,7 +52,7 @@ func (r ActionDataSource) providerAction() string {
 
 
 data "azapi_resource_action" "test" {
-  type        = "Microsoft.Resources/providers@2020-04-01-preview"
+  type        = "Microsoft.ResourceGraph@2020-04-01-preview"
   resource_id = "/providers/Microsoft.ResourceGraph"
   action      = "resources"
   body = jsonencode({

--- a/internal/services/azapi_resource_action_data_source_test.go
+++ b/internal/services/azapi_resource_action_data_source_test.go
@@ -22,6 +22,18 @@ func TestAccActionDataSource_basic(t *testing.T) {
 	})
 }
 
+func TestAccActionDataSource_providerPermissions(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azapi_resource_action", "test")
+	r := ActionDataSource{}
+
+	data.DataSourceTest(t, []resource.TestStep{
+		{
+			Config: r.providerPermissions(),
+			Check:  resource.ComposeTestCheckFunc(),
+		},
+	})
+}
+
 func TestAccActionDataSource_providerAction(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azapi_resource_action", "test")
 	r := ActionDataSource{}
@@ -45,6 +57,23 @@ data "azapi_resource_action" "test" {
   response_export_values = ["*"]
 }
 `, GenericResource{}.defaultTag(data))
+}
+
+func (r ActionDataSource) providerPermissions() string {
+	return `
+provider "azurerm" {
+  features {}
+}
+
+data "azurerm_client_config" "current" {}
+
+data "azapi_resource_action" "test" {
+  type        = "Microsoft.Resources/providers@2021-04-01"
+  resource_id = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/providers/Microsoft.Network"
+  action      = "providerPermissions"
+  method      = "GET"
+}
+`
 }
 
 func (r ActionDataSource) providerAction() string {

--- a/internal/services/azapi_resource_action_resource_test.go
+++ b/internal/services/azapi_resource_action_resource_test.go
@@ -28,7 +28,7 @@ func TestAccActionResource_providerAction(t *testing.T) {
 
 	data.DataSourceTest(t, []resource.TestStep{
 		{
-			Config: r.basic(data),
+			Config: r.providerAction(),
 			Check:  resource.ComposeTestCheckFunc(),
 		},
 	})
@@ -59,8 +59,12 @@ resource "azapi_resource_action" "test" {
 `, GenericResource{}.defaultTag(data))
 }
 
-func (r ActionResource) providerAction(data acceptance.TestData) string {
+func (r ActionResource) providerAction() string {
 	return `
+provider "azurerm" {
+  features {}
+}
+
 data "azurerm_client_config" "current" {}
 
 resource "azapi_resource_action" "test" {

--- a/internal/services/azapi_resource_action_resource_test.go
+++ b/internal/services/azapi_resource_action_resource_test.go
@@ -28,7 +28,7 @@ func TestAccActionResource_registerResourceProvider(t *testing.T) {
 
 	data.DataSourceTest(t, []resource.TestStep{
 		{
-			Config: r.providerAction(),
+			Config: r.registerResourceProvider(),
 			Check:  resource.ComposeTestCheckFunc(),
 		},
 	})

--- a/internal/services/azapi_resource_action_resource_test.go
+++ b/internal/services/azapi_resource_action_resource_test.go
@@ -22,6 +22,18 @@ func TestAccActionResource_basic(t *testing.T) {
 	})
 }
 
+func TestAccActionResource_registerResourceProvider(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azapi_resource_action", "test")
+	r := ActionResource{}
+
+	data.DataSourceTest(t, []resource.TestStep{
+		{
+			Config: r.providerAction(),
+			Check:  resource.ComposeTestCheckFunc(),
+		},
+	})
+}
+
 func TestAccActionResource_providerAction(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azapi_resource_action", "test")
 	r := ActionResource{}
@@ -59,7 +71,7 @@ resource "azapi_resource_action" "test" {
 `, GenericResource{}.defaultTag(data))
 }
 
-func (r ActionResource) providerAction() string {
+func (r ActionResource) registerResourceProvider() string {
 	return `
 provider "azurerm" {
   features {}
@@ -72,6 +84,26 @@ resource "azapi_resource_action" "test" {
   resource_id = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/providers/Microsoft.Compute"
   action      = "register"
   method      = "POST"
+}
+`
+}
+
+func (r ActionResource) providerAction() string {
+	return `
+provider "azurerm" {
+  features {}
+}
+
+data "azurerm_client_config" "current" {}
+
+resource "azapi_resource_action" "test" {
+  type        = "Microsoft.Cache@2023-04-01"
+  resource_id = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/providers/Microsoft.Cache"
+  action      = "CheckNameAvailability"
+  body = jsonencode({
+    type = "Microsoft.Cache/Redis"
+    name = "cacheName"
+  })
 }
 `
 }

--- a/internal/services/azapi_resource_action_resource_test.go
+++ b/internal/services/azapi_resource_action_resource_test.go
@@ -22,6 +22,18 @@ func TestAccActionResource_basic(t *testing.T) {
 	})
 }
 
+func TestAccActionResource_providerAction(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azapi_resource_action", "test")
+	r := ActionResource{}
+
+	data.DataSourceTest(t, []resource.TestStep{
+		{
+			Config: r.basic(data),
+			Check:  resource.ComposeTestCheckFunc(),
+		},
+	})
+}
+
 func (r ActionResource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %[1]s
@@ -45,4 +57,17 @@ resource "azapi_resource_action" "test" {
   ]
 }
 `, GenericResource{}.defaultTag(data))
+}
+
+func (r ActionResource) providerAction(data acceptance.TestData) string {
+	return `
+data "azurerm_client_config" "current" {}
+
+resource "azapi_resource_action" "test" {
+  type        = "Microsoft.Resources/providers@2021-04-01"
+  resource_id = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/providers/Microsoft.Compute"
+  action      = "register"
+  method      = "POST"
+}
+`
 }

--- a/internal/services/parse/resource.go
+++ b/internal/services/parse/resource.go
@@ -46,6 +46,13 @@ func NewResourceID(name, parentId, resourceType string) (ResourceId, error) {
 			azureResourceId = fmt.Sprintf("/subscriptions/%s", name)
 		case arm.TenantResourceType.String():
 			azureResourceId = "/"
+		case arm.ProviderResourceType.String():
+			// avoid duplicated `/` if parent_id is tenant scope
+			scopeId := parentId
+			if parentId == "/" {
+				scopeId = ""
+			}
+			azureResourceId = fmt.Sprintf("%s/providers/%s", scopeId, name)
 		default:
 			// avoid duplicated `/` if parent_id is tenant scope
 			scopeId := parentId

--- a/internal/services/parse/resource.go
+++ b/internal/services/parse/resource.go
@@ -32,7 +32,16 @@ func NewResourceID(name, parentId, resourceType string) (ResourceId, error) {
 	}
 
 	azureResourceId := ""
-	if utils.IsTopLevelResourceType(azureResourceType) {
+	switch {
+	case !strings.Contains(azureResourceType, "/"):
+		// case 0: resource type is a provider type
+		// avoid duplicated `/` if parent_id is tenant scope
+		scopeId := parentId
+		if parentId == "/" {
+			scopeId = ""
+		}
+		azureResourceId = fmt.Sprintf("%s/providers/%s", scopeId, name)
+	case utils.IsTopLevelResourceType(azureResourceType):
 		// case 1: top level resource, verify parent_id providers correct scope
 		if err = validateParentIdScope(resourceDef, parentId); err != nil {
 			return ResourceId{}, fmt.Errorf("`parent_id is invalid`: %+v", err)
@@ -61,7 +70,7 @@ func NewResourceID(name, parentId, resourceType string) (ResourceId, error) {
 			}
 			azureResourceId = fmt.Sprintf("%s/providers/%s/%s", scopeId, azureResourceType, name)
 		}
-	} else {
+	default:
 		// case 2: child resource, verify parent_id's type matches with resource type's parent type
 		if err = validateParentIdType(azureResourceType, parentId); err != nil {
 			return ResourceId{}, fmt.Errorf("`parent_id is invalid`: %+v", err)
@@ -88,9 +97,18 @@ func ResourceIDWithResourceType(azureResourceId, resourceType string) (ResourceI
 	if err != nil {
 		return ResourceId{}, err
 	}
-	if resourceTypeFromId := utils.GetResourceType(azureResourceId); !strings.EqualFold(azureResourceType, resourceTypeFromId) {
-		return ResourceId{}, fmt.Errorf("`resource_id` and `type` are not matched, expect `type` to be %s, but got %s", resourceTypeFromId, azureResourceType)
+	resourceTypeFromId := utils.GetResourceType(azureResourceId)
+	// if resource type is a provider type, then `type` should be either `Microsoft.Foo` or `Microsoft.Resources/providers`
+	if strings.EqualFold(arm.ProviderResourceType.String(), resourceTypeFromId) {
+		if strings.Contains(azureResourceType, "/") && !strings.EqualFold(azureResourceType, arm.ProviderResourceType.String()) {
+			return ResourceId{}, fmt.Errorf("`resource_id` and `type` are not matched, expect `type` to be a provider type, but got %s", azureResourceType)
+		}
+	} else {
+		if !strings.EqualFold(azureResourceType, resourceTypeFromId) {
+			return ResourceId{}, fmt.Errorf("`resource_id` and `type` are not matched, expect `type` to be %s, but got %s", resourceTypeFromId, azureResourceType)
+		}
 	}
+
 	name := utils.GetName(azureResourceId)
 	parentId := utils.GetParentId(azureResourceId)
 	return NewResourceID(name, parentId, resourceType)

--- a/internal/services/parse/resource_test.go
+++ b/internal/services/parse/resource_test.go
@@ -13,6 +13,32 @@ func Test_ResourceIDWithResourceType(t *testing.T) {
 		Expected         *ResourceId
 	}{
 		{
+			ResourceType:     "Microsoft.Resources/providers@2020-04-01-preview",
+			ResourceId:       "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.ResourceGraph",
+			ResourceDefExist: false,
+			Expected: &ResourceId{
+				ApiVersion:        "2020-04-01-preview",
+				AzureResourceType: "Microsoft.Resources/providers",
+				AzureResourceId:   "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.ResourceGraph",
+				Name:              "Microsoft.ResourceGraph",
+				ParentId:          "/subscriptions/12345678-1234-9876-4563-123456789012",
+			},
+		},
+
+		{
+			ResourceType:     "Microsoft.Resources/providers@2020-04-01-preview",
+			ResourceId:       "/providers/Microsoft.ResourceGraph",
+			ResourceDefExist: false,
+			Expected: &ResourceId{
+				ApiVersion:        "2020-04-01-preview",
+				AzureResourceType: "Microsoft.Resources/providers",
+				AzureResourceId:   "/providers/Microsoft.ResourceGraph",
+				Name:              "Microsoft.ResourceGraph",
+				ParentId:          "/",
+			},
+		},
+
+		{
 			ResourceType:     "Microsoft.Resources/tenants@2021-04-01",
 			ResourceId:       "/",
 			ResourceDefExist: false,
@@ -430,6 +456,42 @@ func Test_NewResourceID(t *testing.T) {
 		Error            bool
 		Expected         *ResourceId
 	}{
+		{
+			Name:             "Microsoft.ResourceGraph",
+			ParentId:         "/subscriptions/12345678-1234-9876-4563-123456789012",
+			ResourceType:     "Microsoft.Resources/providers@2020-04-01-preview",
+			ResourceDefExist: false,
+			Expected: &ResourceId{
+				ApiVersion:        "2020-04-01-preview",
+				AzureResourceType: "Microsoft.Resources/providers",
+				AzureResourceId:   "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.ResourceGraph",
+			},
+		},
+
+		{
+			Name:             "Microsoft.ResourceGraph",
+			ParentId:         "/",
+			ResourceType:     "Microsoft.Resources/providers@2020-04-01-preview",
+			ResourceDefExist: false,
+			Expected: &ResourceId{
+				ApiVersion:        "2020-04-01-preview",
+				AzureResourceType: "Microsoft.Resources/providers",
+				AzureResourceId:   "/providers/Microsoft.ResourceGraph",
+			},
+		},
+
+		{
+			Name:             "",
+			ParentId:         "",
+			ResourceType:     "Microsoft.Resources/tenants@2021-04-01",
+			ResourceDefExist: false,
+			Expected: &ResourceId{
+				ApiVersion:        "2021-04-01",
+				AzureResourceType: "Microsoft.Resources/tenants",
+				AzureResourceId:   "/",
+			},
+		},
+
 		{
 			// tenant scope
 			Name:             "12345678-1234-9876-4563-123456789012",

--- a/internal/services/parse/resource_test.go
+++ b/internal/services/parse/resource_test.go
@@ -13,12 +13,25 @@ func Test_ResourceIDWithResourceType(t *testing.T) {
 		Expected         *ResourceId
 	}{
 		{
-			ResourceType:     "Microsoft.Resources/providers@2020-04-01-preview",
+			ResourceType:     "Microsoft.Resources/providers@2020-04-01",
+			ResourceId:       "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.Network",
+			ResourceDefExist: false,
+			Expected: &ResourceId{
+				ApiVersion:        "2020-04-01",
+				AzureResourceType: "Microsoft.Resources/providers",
+				AzureResourceId:   "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.Network",
+				Name:              "Microsoft.Network",
+				ParentId:          "/subscriptions/12345678-1234-9876-4563-123456789012",
+			},
+		},
+
+		{
+			ResourceType:     "Microsoft.ResourceGraph@2020-04-01-preview",
 			ResourceId:       "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.ResourceGraph",
 			ResourceDefExist: false,
 			Expected: &ResourceId{
 				ApiVersion:        "2020-04-01-preview",
-				AzureResourceType: "Microsoft.Resources/providers",
+				AzureResourceType: "Microsoft.ResourceGraph",
 				AzureResourceId:   "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.ResourceGraph",
 				Name:              "Microsoft.ResourceGraph",
 				ParentId:          "/subscriptions/12345678-1234-9876-4563-123456789012",
@@ -26,12 +39,12 @@ func Test_ResourceIDWithResourceType(t *testing.T) {
 		},
 
 		{
-			ResourceType:     "Microsoft.Resources/providers@2020-04-01-preview",
+			ResourceType:     "Microsoft.ResourceGraph@2020-04-01-preview",
 			ResourceId:       "/providers/Microsoft.ResourceGraph",
 			ResourceDefExist: false,
 			Expected: &ResourceId{
 				ApiVersion:        "2020-04-01-preview",
-				AzureResourceType: "Microsoft.Resources/providers",
+				AzureResourceType: "Microsoft.ResourceGraph",
 				AzureResourceId:   "/providers/Microsoft.ResourceGraph",
 				Name:              "Microsoft.ResourceGraph",
 				ParentId:          "/",
@@ -457,13 +470,25 @@ func Test_NewResourceID(t *testing.T) {
 		Expected         *ResourceId
 	}{
 		{
+			Name:             "Microsoft.Network",
+			ParentId:         "/subscriptions/12345678-1234-9876-4563-123456789012",
+			ResourceType:     "Microsoft.Resources/providers@2020-04-01",
+			ResourceDefExist: false,
+			Expected: &ResourceId{
+				ApiVersion:        "2020-04-01",
+				AzureResourceType: "Microsoft.Resources/providers",
+				AzureResourceId:   "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.Network",
+			},
+		},
+
+		{
 			Name:             "Microsoft.ResourceGraph",
 			ParentId:         "/subscriptions/12345678-1234-9876-4563-123456789012",
-			ResourceType:     "Microsoft.Resources/providers@2020-04-01-preview",
+			ResourceType:     "Microsoft.ResourceGraph@2020-04-01-preview",
 			ResourceDefExist: false,
 			Expected: &ResourceId{
 				ApiVersion:        "2020-04-01-preview",
-				AzureResourceType: "Microsoft.Resources/providers",
+				AzureResourceType: "Microsoft.ResourceGraph",
 				AzureResourceId:   "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.ResourceGraph",
 			},
 		},
@@ -471,11 +496,11 @@ func Test_NewResourceID(t *testing.T) {
 		{
 			Name:             "Microsoft.ResourceGraph",
 			ParentId:         "/",
-			ResourceType:     "Microsoft.Resources/providers@2020-04-01-preview",
+			ResourceType:     "Microsoft.ResourceGraph@2020-04-01-preview",
 			ResourceDefExist: false,
 			Expected: &ResourceId{
 				ApiVersion:        "2020-04-01-preview",
-				AzureResourceType: "Microsoft.Resources/providers",
+				AzureResourceType: "Microsoft.ResourceGraph",
 				AzureResourceId:   "/providers/Microsoft.ResourceGraph",
 			},
 		},


### PR DESCRIPTION
related issues: https://github.com/Azure/terraform-provider-azapi/issues/299, https://github.com/Azure/terraform-provider-azapi/issues/316

This PR does the following things:
1. The `type` supports the resource provider name as the resource type for the provider IDs, for example, `Microsoft.Network`, to enable provider level actions with `azapi_resource_action` resource/data source.
2. Fix the bug that resource IDs for type  `Microsoft.Resources/providers` for provider IDs as not parsed correctly. It's used to register/unregister RP or fetch information of RPs.


```

=== RUN   TestAccActionResource_basic
=== PAUSE TestAccActionResource_basic
=== CONT  TestAccActionResource_basic
--- PASS: TestAccActionResource_basic (156.84s)
=== RUN   TestAccActionResource_registerResourceProvider
=== PAUSE TestAccActionResource_registerResourceProvider
=== CONT  TestAccActionResource_registerResourceProvider
--- PASS: TestAccActionResource_registerResourceProvider (35.90s)
=== RUN   TestAccActionResource_providerAction
=== PAUSE TestAccActionResource_providerAction
=== CONT  TestAccActionResource_providerAction
--- PASS: TestAccActionResource_providerAction (45.06s)
PASS


=== RUN   TestAccActionDataSource_basic
=== PAUSE TestAccActionDataSource_basic
=== CONT  TestAccActionDataSource_basic
=== RUN   TestAccActionDataSource_providerPermissions
=== PAUSE TestAccActionDataSource_providerPermissions
=== CONT  TestAccActionDataSource_providerPermissions
--- PASS: TestAccActionDataSource_providerPermissions (46.08s)
=== RUN   TestAccActionDataSource_providerAction
=== PAUSE TestAccActionDataSource_providerAction
=== CONT  TestAccActionDataSource_providerAction
--- PASS: TestAccActionDataSource_providerAction (35.63s)
--- PASS: TestAccActionDataSource_basic (150.61s)
PASS


```