### PR TITLE
`azapi_resource` - `parent_id` is optional for resource groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 FEATURES:
 - **New Data Source**: azapi_resource_list
 
+ENHANCEMENTS:
+- `azapi_resource` resource/data source: When creating `Microsoft.Resources/resourceGroups`, `parent_id` is optional and defaults to the ID of the default subscription.
+
 ## v1.8.0
 FEATURES:
 

--- a/docs/data-sources/azapi_resource.md
+++ b/docs/data-sources/azapi_resource.md
@@ -73,6 +73,8 @@ The following arguments are supported:
 
   For child level resources, the `parent_id` should be the ID of its parent resource, for example, subnet resource's `parent_id` is the ID of the vnet.
 
+  For type `Microsoft.Resources/resourceGroups`, the `parent_id` could be omitted, it defaults to subscription ID specified in provider or the default subscription(You could check the default subscription by azure cli command: `az account show`).
+
 * `resource_id` - (Optional) The ID of an existing azure source.
 
 ~> **Note:** Configuring `name` and `parent_id` is an alternative way to configure `resource_id`.

--- a/docs/resources/azapi_resource.md
+++ b/docs/resources/azapi_resource.md
@@ -90,6 +90,8 @@ The following arguments are supported:
     - tenant scope: `parent_id` should be `/`
 
   For child level resources, the `parent_id` should be the ID of its parent resource, for example, subnet resource's `parent_id` is the ID of the vnet.
+  
+  For type `Microsoft.Resources/resourceGroups`, the `parent_id` could be omitted, it defaults to subscription ID specified in provider or the default subscription(You could check the default subscription by azure cli command: `az account show`).
 
 * `type` - (Required) It is in a format like `<resource-type>@<api-version>`. `<resource-type>` is the Azure resource type, for example, `Microsoft.Storage/storageAccounts`.
   `<api-version>` is version of the API used to manage this azure resource.

--- a/internal/clients/account.go
+++ b/internal/clients/account.go
@@ -1,0 +1,88 @@
+package clients
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os/exec"
+	"strings"
+	"sync"
+)
+
+type ResourceManagerAccount struct {
+	subscriptionId *string
+	mutex          sync.Mutex
+}
+
+func NewResourceManagerAccount(subscriptionId string) ResourceManagerAccount {
+	if subscriptionId == "" {
+		return ResourceManagerAccount{}
+	}
+	return ResourceManagerAccount{
+		subscriptionId: &subscriptionId,
+	}
+}
+
+func (account ResourceManagerAccount) GetSubscriptionId() string {
+	account.mutex.Lock()
+	defer account.mutex.Unlock()
+	if account.subscriptionId != nil {
+		return *account.subscriptionId
+	}
+
+	subscriptionId, err := getDefaultSubscriptionID()
+	if err != nil {
+		log.Printf("[DEBUG] Error getting default subscription ID: %s", err)
+	}
+
+	account.subscriptionId = &subscriptionId
+
+	return *account.subscriptionId
+}
+
+// getDefaultSubscriptionID tries to determine the default subscription
+func getDefaultSubscriptionID() (string, error) {
+	var account struct {
+		SubscriptionID string `json:"id"`
+	}
+	err := jsonUnmarshalAzCmd(&account, "account", "show")
+	if err != nil {
+		return "", fmt.Errorf("obtaining subscription ID: %s", err)
+	}
+
+	return account.SubscriptionID, nil
+}
+
+// jsonUnmarshalAzCmd executes an Azure CLI command and unmarshalls the JSON output.
+func jsonUnmarshalAzCmd(i interface{}, arg ...string) error {
+	var stderr bytes.Buffer
+	var stdout bytes.Buffer
+
+	arg = append(arg, "-o=json")
+	cmd := exec.Command("az", arg...)
+	cmd.Stderr = &stderr
+	cmd.Stdout = &stdout
+
+	if err := cmd.Start(); err != nil {
+		err := fmt.Errorf("launching Azure CLI: %+v", err)
+		if stdErrStr := stderr.String(); stdErrStr != "" {
+			err = fmt.Errorf("%s: %s", err, strings.TrimSpace(stdErrStr))
+		}
+		return err
+	}
+
+	if err := cmd.Wait(); err != nil {
+		err := fmt.Errorf("running Azure CLI: %+v", err)
+		if stdErrStr := stderr.String(); stdErrStr != "" {
+			err = fmt.Errorf("%s: %s", err, strings.TrimSpace(stdErrStr))
+		}
+		return err
+	}
+
+	if err := json.Unmarshal(stdout.Bytes(), &i); err != nil {
+		return fmt.Errorf("unmarshaling the output of Azure CLI: %v", err)
+	}
+
+	return nil
+}

--- a/internal/clients/account.go
+++ b/internal/clients/account.go
@@ -12,15 +12,18 @@ import (
 
 type ResourceManagerAccount struct {
 	subscriptionId *string
-	mutex          sync.Mutex
+	mutex          *sync.Mutex
 }
 
 func NewResourceManagerAccount(subscriptionId string) ResourceManagerAccount {
 	if subscriptionId == "" {
-		return ResourceManagerAccount{}
+		return ResourceManagerAccount{
+			mutex: &sync.Mutex{},
+		}
 	}
 	return ResourceManagerAccount{
 		subscriptionId: &subscriptionId,
+		mutex:          &sync.Mutex{},
 	}
 }
 

--- a/internal/clients/client.go
+++ b/internal/clients/client.go
@@ -21,6 +21,8 @@ type Client struct {
 
 	ResourceClient  *ResourceClient
 	DataPlaneClient *DataPlaneClient
+
+	Account ResourceManagerAccount
 }
 
 type Option struct {
@@ -31,6 +33,7 @@ type Option struct {
 	DisableCorrelationRequestID bool
 	CloudCfg                    cloud.Configuration
 	CustomCorrelationRequestID  string
+	SubscriptionId              string
 }
 
 // NOTE: it should be possible for this method to become Private once the top level Client's removed
@@ -122,6 +125,8 @@ func (client *Client) Build(ctx context.Context, o *Option) error {
 		return err
 	}
 	client.DataPlaneClient = dataPlaneClient
+
+	client.Account = NewResourceManagerAccount(o.SubscriptionId)
 
 	return nil
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -303,6 +303,7 @@ func providerConfigure(p *schema.Provider) schema.ConfigureContextFunc {
 			SkipProviderRegistration:    d.Get("skip_provider_registration").(bool),
 			DisableCorrelationRequestID: d.Get("disable_correlation_request_id").(bool),
 			CustomCorrelationRequestID:  d.Get("custom_correlation_request_id").(string),
+			SubscriptionId:              d.Get("subscription_id").(string),
 		}
 
 		//lint:ignore SA1019 SDKv2 migration - staticcheck's own linter directives are currently being ignored under golanci-lint

--- a/internal/services/azapi_resource_test.go
+++ b/internal/services/azapi_resource_test.go
@@ -251,6 +251,23 @@ func TestAccGenericResource_defaultLocation(t *testing.T) {
 	})
 }
 
+func TestAccGenericResource_defaultParentId(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azapi_resource", "test")
+	r := GenericResource{}
+
+	subscriptionId := os.Getenv("ARM_SUBSCRIPTION_ID")
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.defaultParentId(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("parent_id").HasValue(fmt.Sprintf("/subscriptions/%s", subscriptionId)),
+			),
+		},
+		data.ImportStep(defaultIgnores()...),
+	})
+}
+
 func TestAccGenericResource_defaultsNaming(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azapi_resource", "test")
 	r := GenericResource{}
@@ -853,6 +870,19 @@ resource "azapi_resource" "test" {
 
 }
 `, r.template(data), data.RandomString, data.LocationPrimary, data.LocationSecondary)
+}
+
+func (r GenericResource) defaultParentId(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azapi" {
+}
+
+resource "azapi_resource" "test" {
+  type     = "Microsoft.Resources/resourceGroups@2022-09-01"
+  name     = "acctest-%[2]d"
+  location = "%[1]s"
+}
+`, data.LocationPrimary, data.RandomInteger)
 }
 
 func (r GenericResource) defaultNaming(data acceptance.TestData) string {


### PR DESCRIPTION
fixes https://github.com/Azure/terraform-provider-azapi/issues/322

Tests
```
=== RUN   TestAccGenericResource_defaultParentId
=== PAUSE TestAccGenericResource_defaultParentId
=== CONT  TestAccGenericResource_defaultParentId
--- PASS: TestAccGenericResource_defaultParentId (37.84s)
PASS

=== RUN   TestAccGenericDataSource_defaultParentId
=== PAUSE TestAccGenericDataSource_defaultParentId
=== CONT  TestAccGenericDataSource_defaultParentId
--- PASS: TestAccGenericDataSource_defaultParentId (44.13s)
PASS
```