### PR TITLE
bugfix: `azapi_resource` can't handle unknown payload

### DIFF
--- a/internal/services/azapi_resource.go
+++ b/internal/services/azapi_resource.go
@@ -361,7 +361,7 @@ func (r *AzapiResource) ModifyPlan(ctx context.Context, request resource.ModifyP
 		}
 	}
 
-	if plan.Body.IsUnknown() || plan.Payload.IsUnknown() {
+	if plan.Body.IsUnknown() || !dynamic.IsFullyKnown(plan.Payload) {
 		if config.Tags.IsNull() {
 			plan.Tags = basetypes.NewMapUnknown(types.StringType)
 		}

--- a/internal/services/dynamic/dynamic.go
+++ b/internal/services/dynamic/dynamic.go
@@ -363,3 +363,56 @@ func SemanticallyEqual(a, b types.Dynamic) bool {
 	}
 	return utils.NormalizeJson(string(aJson)) == utils.NormalizeJson(string(bJson))
 }
+
+// IsFullyKnown returns true if `val` is known. If `val` is an aggregate type,
+// IsFullyKnown only returns true if all elements and attributes are known, as
+// well.
+func IsFullyKnown(val attr.Value) bool {
+	if val == nil {
+		return true
+	}
+	if val.IsUnknown() {
+		return false
+	}
+	switch v := val.(type) {
+	case types.Dynamic:
+		return IsFullyKnown(v.UnderlyingValue())
+	case types.List:
+		for _, e := range v.Elements() {
+			if !IsFullyKnown(e) {
+				return false
+			}
+		}
+		return true
+	case types.Set:
+		for _, e := range v.Elements() {
+			if !IsFullyKnown(e) {
+				return false
+			}
+		}
+		return true
+	case types.Tuple:
+		for _, e := range v.Elements() {
+			if !IsFullyKnown(e) {
+				return false
+			}
+		}
+		return true
+	case types.Map:
+		for _, e := range v.Elements() {
+			if !IsFullyKnown(e) {
+				return false
+			}
+		}
+		return true
+	case types.Object:
+		for _, e := range v.Attributes() {
+			if !IsFullyKnown(e) {
+				return false
+			}
+		}
+		return true
+	default:
+		return true
+	}
+}


### PR DESCRIPTION
The `payload` might have some unknown value, in modify plan phase, it couldn't be parsed to the JSON correctly. We'll improve it in the future, to support schema validation based on attr.Value