### PR TITLE
`azapi_*` - the `body` and `output` fields support dynamic schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,17 @@
 ## v1.13.0 (unreleased)
+BREAKING CHANGES:
+- Provider field `default_naming_prefix` and `default_naming_suffix` are deprecated. It will not work in this release and will be removed in the next major release.
+  Please specify the naming prefix and suffix in the resource's `name` field instead.
+- The `azapi_resource`'s `removing_special_chars` field is deprecated. It will not work in this release and will be removed in the next major release.
+  Please specify the `name` field and remove the special characters in the `name` field instead.
+- Defining the `identity` inside the `body` field is not recommended. In this release, it will not sync the `identity` inside the `body` field to `identity` block.
+  Please define the `identity` block instead.
+- `azapi_resource` data source: The `output` field changes from JSON string to HCL object. Users can use access the fields in the output as an HCL object. Please remove the `jsondecode` function when using the `output` field.
+- `azapi_resource_list` data source: The `output` field changes from JSON string to HCL object. Users can use access the fields in the output as an HCL object. Please remove the `jsondecode` function when using the `output` field.
+
 ENHANCEMENTS:
-- `azapi_resource` resource: Support for the `payload` and `output_payload` fields, which are dynamic schema and used to specify the payload and read the output payload.
-- `azapi_update_resource` resource: Support for the `payload` and `output_payload` fields, which are dynamic schema and used to specify the payload and read the output payload.
-- `azapi_resource_action` resource: Support for the `payload` and `output_payload` fields, which are dynamic schema and used to specify the payload and read the output payload.
-- `azapi_data_plane_resource` resource: Support for the `payload` and `output_payload` fields, which are dynamic schema and used to specify the payload and read the output payload.
-- `azapi_resource` data source: Support for the `output_payload` field, which is dynamic schema and used to read the output payload.
-- `azapi_resource_action` data source: Support for the `payload` and `output_payload` fields, which are dynamic schema and used to specify the payload and read the output payload.
-- `azapi_resource_list` data source: Support for the `output_payload` field, which is dynamic schema and used to read the output payload.
+- `azapi_resource` resource, `azapi_update_resource` resource, `azapi_resource_action` resource, `azapi_data_plane_resource` resource, `azapi_resource_action` data source: The `body` field supports the dynamic schema and allows user to use the HCL object to specify the body.
+- `azapi_resource` resource, `azapi_update_resource` resource, `azapi_resource_action` resource, `azapi_data_plane_resource` resource, `azapi_resource_action` data source, `azapi_resource` data source, `azapi_resource_list` data source: The `output` field supports the dynamic schema and allows user to read the output as an HCL object.
 - `azapi` provider: Support `client_id_file_path`and `client_secret_file_path` fields, which are used to specify the file path of the client id and client secret.
 - `azapi_data_plane_resource` resource: Support `Microsoft.Synapse/workspaces/databases` type.
 

--- a/docs/data-sources/azapi_resource.md
+++ b/docs/data-sources/azapi_resource.md
@@ -51,12 +51,12 @@ data "azapi_resource" "example" {
 
 // it will output "registry1.azurecr.io"
 output "login_server" {
-  value = data.azapi_resource.example.output_payload.properties.loginServer
+  value = data.azapi_resource.example.output.properties.loginServer
 }
 
 // it will output "disabled"
 output "quarantine_policy" {
-  value = data.azapi_resource.example.output_payload.properties.policies.quarantinePolicy.status
+  value = data.azapi_resource.example.output.properties.policies.quarantinePolicy.status
 }
 ```
 
@@ -86,7 +86,7 @@ The following arguments are supported:
 
 * `response_export_values` - (Optional) A list of path that needs to be exported from response body.
   Setting it to `["*"]` will export the full response body.
-  Here's an example. If it sets to `["properties.loginServer", "properties.policies.quarantinePolicy.status"]`, it will set the HCL object to computed property `output_payload`.
+  Here's an example. If it sets to `["properties.loginServer", "properties.policies.quarantinePolicy.status"]`, it will set the HCL object to computed property `output`.
 ```
 {
   properties = {
@@ -110,16 +110,16 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `location` - The Azure Region where the azure resource should exist.
 
-* `output_payload` - The output HCL object containing the properties specified in `response_export_values`. Here are some examples to use the values.
+* `output` - The output HCL object containing the properties specified in `response_export_values`. Here are some examples to use the values.
 ```
 // it will output "registry1.azurecr.io"
 output "login_server" {
-  value = azapi_resource.example.output_payload.properties.loginServer
+  value = azapi_resource.example.output.properties.loginServer
 }
 
 // it will output "disabled"
 output "quarantine_policy" {
-  value = azapi_resource.example.output_payload.properties.policies.quarantinePolicy.status
+  value = azapi_resource.example.output.properties.policies.quarantinePolicy.status
 }
 ```
 

--- a/docs/data-sources/azapi_resource_action.md
+++ b/docs/data-sources/azapi_resource_action.md
@@ -82,7 +82,7 @@ resource "azapi_resource_action" "test" {
   type        = "Microsoft.Cache@2023-04-01"
   resource_id = "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache"
   action      = "CheckNameAvailability"
-  payload = {
+  body = {
     type = "Microsoft.Cache/Redis"
     name = "cacheName"
   }
@@ -101,13 +101,13 @@ The following arguments are supported:
 * `action` - (Optional) The name of the resource action. It's also possible to make Http requests towards the resource ID if leave this field empty.
 
 ---
-* `payload` - (Optional) A dynamic attribute that contains the request body.
+* `body` - (Optional) A dynamic attribute that contains the request body.
 
 * `method` - (Optional) Specifies the Http method of the azure resource action. Allowed values are `POST` and `GET`. Defaults to `POST`.
 
 * `response_export_values` - (Optional) A list of path that needs to be exported from response body.
   Setting it to `["*"]` will export the full response body.
-  Here's an example. If it sets to `["keys"]`, it will set the following HCL object to computed property `output_payload`.
+  Here's an example. If it sets to `["keys"]`, it will set the following HCL object to computed property `output`.
 ```
 {
   keys = [
@@ -135,12 +135,12 @@ In addition to the Arguments listed above - the following Attributes are exporte
 ```hcl
 // it will output "nHGYNd******i4wdug=="
 output "primary_key" {
-  value = azapi_resource_action.test.output_payload.keys.0.Value
+  value = azapi_resource_action.test.output.keys.0.Value
 }
 
 // it will output "6yoCad******SLzKzg=="
 output "secondary_key" {
-  value = azapi_resource_action.test.output_payload.keys.1.Value
+  value = azapi_resource_action.test.output.keys.1.Value
 }
 ```
 

--- a/docs/data-sources/azapi_resource_list.md
+++ b/docs/data-sources/azapi_resource_list.md
@@ -57,7 +57,7 @@ The following arguments are supported:
 
 * `response_export_values` - (Optional) A list of path that needs to be exported from response body.
   Setting it to `["*"]` will export the full response body.
-  Here's an example. If it sets to `["value"]`, it will set the following HCL object to computed property `output_payload`.
+  Here's an example. If it sets to `["value"]`, it will set the following HCL object to computed property `output`.
 ```
 {
   value = [
@@ -79,7 +79,7 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `id` - The ID of the azure resource list.
 
-* `output_payload` - The output HCL object containing the properties specified in `response_export_values`. Here are some examples to use the values.
+* `output` - The output HCL object containing the properties specified in `response_export_values`. Here are some examples to use the values.
 
 
 ## Timeouts

--- a/docs/resources/azapi_data_plane_resource.md
+++ b/docs/resources/azapi_data_plane_resource.md
@@ -37,7 +37,7 @@ resource "azapi_data_plane_resource" "dataset" {
   type      = "Microsoft.Synapse/workspaces/datasets@2020-12-01"
   parent_id = trimprefix(data.azurerm_synapse_workspace.example.connectivity_endpoints.dev, "https://")
   name      = "example-dataset"
-  payload = {
+  body = {
     properties = {
       type = "AzureBlob",
       typeProperties = {
@@ -79,13 +79,13 @@ The following arguments are supported:
 
 -> **Note** For the available resource types and parent IDs, please refer to the `Available Resources` section below.
 
-* `payload` - (Required) A dynamic attribute that contains the request body used to create and update data plane resource. 
+* `body` - (Required) A dynamic attribute that contains the request body used to create and update data plane resource. 
 
 ---
 
 * `response_export_values` - (Optional) A list of path that needs to be exported from response body.
   Setting it to `["*"]` will export the full response body.
-  Here's an example. If it sets to `["properties.loginServer", "properties.policies.quarantinePolicy.status"]`, it will set the following HCL object to computed property `output_payload`.
+  Here's an example. If it sets to `["properties.loginServer", "properties.policies.quarantinePolicy.status"]`, it will set the following HCL object to computed property `output`.
 ```
 {
   "properties" : {
@@ -101,7 +101,7 @@ The following arguments are supported:
 
 * `locks` - (Optional) A list of ARM resource IDs which are used to avoid create/modify/delete azapi resources at the same time.
 
-* `ignore_missing_property` - (Optional) Whether ignore not returned properties like credentials in `payload` to suppress plan-diff. Defaults to `true`. 
+* `ignore_missing_property` - (Optional) Whether ignore not returned properties like credentials in `body` to suppress plan-diff. Defaults to `true`. 
 It's recommend to enable this option when some sensitive properties are not returned in response body, instead of setting them in `lifecycle.ignore_changes` because it will make the sensitive fields unable to update.
 
 ## Attributes Reference
@@ -110,16 +110,16 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `id` - The ID of the azure resource.
 
-* `output_payload` - The output HCL object containing the properties specified in `response_export_values`. Here are some examples to use the values.
+* `output` - The output HCL object containing the properties specified in `response_export_values`. Here are some examples to use the values.
 ```
 // it will output "registry1.azurecr.io"
 output "login_server" {
-  value = azapi_data_plane_resource.example.output_payload.properties.loginServer
+  value = azapi_data_plane_resource.example.output.properties.loginServer
 }
 
 // it will output "disabled"
 output "quarantine_policy" {
-  value = azapi_data_plane_resource.example.output_payload.properties.policies.quarantinePolicy.status
+  value = azapi_data_plane_resource.example.output.properties.policies.quarantinePolicy.status
 }
 ```
 

--- a/docs/resources/azapi_resource.md
+++ b/docs/resources/azapi_resource.md
@@ -51,7 +51,7 @@ resource "azapi_resource" "example" {
     identity_ids = [azurerm_user_assigned_identity.example.id]
   }
 
-  payload = {
+  body = {
     sku = {
       name = "Standard"
     }
@@ -69,12 +69,12 @@ resource "azapi_resource" "example" {
 
 // it will output "registry1.azurecr.io"
 output "login_server" {
-  value = azapi_resource.example.output_payload.properties.loginServer
+  value = azapi_resource.example.output.properties.loginServer
 }
 
 // it will output "disabled"
 output "quarantine_policy" {
-  value = azapi_resource.example.output_payload.properties.policies.quarantinePolicy.status
+  value = azapi_resource.example.output.properties.policies.quarantinePolicy.status
 }
 ```
 
@@ -96,7 +96,7 @@ The following arguments are supported:
 * `type` - (Required) It is in a format like `<resource-type>@<api-version>`. `<resource-type>` is the Azure resource type, for example, `Microsoft.Storage/storageAccounts`.
   `<api-version>` is version of the API used to manage this azure resource.
 
-* `payload` - (Required) A dynamic attribute that contains the request body used to create and update azure resource. 
+* `body` - (Required) A dynamic attribute that contains the request body used to create and update azure resource. 
 
 * `removing_special_chars` - (Optional) Whether to remove special characters in resource name. Defaults to `false`.
 
@@ -110,7 +110,7 @@ The following arguments are supported:
 
 * `response_export_values` - (Optional) A list of path that needs to be exported from response body.
   Setting it to `["*"]` will export the full response body.
-  Here's an example. If it sets to `["properties.loginServer", "properties.policies.quarantinePolicy.status"]`, it will set the following HCL object to computed property `output_payload`.
+  Here's an example. If it sets to `["properties.loginServer", "properties.policies.quarantinePolicy.status"]`, it will set the following HCL object to computed property `output`.
 ```
 {
   properties = {
@@ -126,10 +126,10 @@ The following arguments are supported:
 
 * `locks` - (Optional) A list of ARM resource IDs which are used to avoid create/modify/delete azapi resources at the same time.
 
-* `ignore_missing_property` - (Optional) Whether ignore not returned properties like credentials in `payload` to suppress plan-diff. Defaults to `true`.
+* `ignore_missing_property` - (Optional) Whether ignore not returned properties like credentials in `body` to suppress plan-diff. Defaults to `true`.
   It's recommend to enable this option when some sensitive properties are not returned in response body, instead of setting them in `lifecycle.ignore_changes` because it will make the sensitive fields unable to update.
 
-* `schema_validation_enabled` - (Optional) Whether enabled the validation on `type` and `payload` with embedded schema. Defaults to `true`.
+* `schema_validation_enabled` - (Optional) Whether enabled the validation on `type` and `body` with embedded schema. Defaults to `true`.
 
 ---
 
@@ -148,16 +148,16 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `identity` - An `identity` block as defined below, which contains the Managed Service Identity information for this azure resource.
 
-* `output_payload` - The output HCL object containing the properties specified in `response_export_values`. Here are some examples use the values.
+* `output` - The output HCL object containing the properties specified in `response_export_values`. Here are some examples use the values.
 ```
 // it will output "registry1.azurecr.io"
 output "login_server" {
-  value = azapi_resource.example.output_payload.properties.loginServer
+  value = azapi_resource.example.output.properties.loginServer
 }
 
 // it will output "disabled"
 output "quarantine_policy" {
-  value = azapi_resource.example.output_payload.properties.policies.quarantinePolicy.status
+  value = azapi_resource.example.output.properties.policies.quarantinePolicy.status
 }
 ```
 

--- a/docs/resources/azapi_resource_action.md
+++ b/docs/resources/azapi_resource_action.md
@@ -101,7 +101,7 @@ data "azapi_resource_action" "test" {
   type        = "Microsoft.ResourceGraph@2020-04-01-preview"
   resource_id = "/providers/Microsoft.ResourceGraph"
   action      = "resources"
-  payload = {
+  body = {
     query = "resources| where name contains \"test\""
   }
   response_export_values = ["*"]
@@ -121,7 +121,7 @@ The following arguments are supported:
 
 ---
 
-* `payload` - (Optional) A dynamic attribute that contains the request body.
+* `body` - (Optional) A dynamic attribute that contains the request body.
 
 * `locks` - (Optional) A list of ARM resource IDs which are used to avoid modify azapi resources at the same time.
 
@@ -129,7 +129,7 @@ The following arguments are supported:
 
 * `response_export_values` - (Optional) A list of path that needs to be exported from response body.
   Setting it to `["*"]` will export the full response body.
-  Here's an example. If it sets to `["keys"]`, it will set the following HCL object to computed property `output_payload`.
+  Here's an example. If it sets to `["keys"]`, it will set the following HCL object to computed property `output`.
 
 ```
 {
@@ -156,17 +156,17 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `id` - The ID of the azure resource action.
 
-* `output_payload` - The HCL object containing the properties specified in `response_export_values`. Here are some examples to use the values.
+* `output` - The HCL object containing the properties specified in `response_export_values`. Here are some examples to use the values.
 
 ```hcl
 // it will output "nHGYNd******i4wdug=="
 output "primary_key" {
-  value = azapi_resource_action.test.output_payload.keys.0.Value
+  value = azapi_resource_action.test.output.keys.0.Value
 }
 
 // it will output "6yoCad******SLzKzg=="
 output "secondary_key" {
-  value = azapi_resource_action.test.output_payload.keys.1.Value
+  value = azapi_resource_action.test.output.keys.1.Value
 }
 ```
 

--- a/docs/resources/azapi_update_resource.md
+++ b/docs/resources/azapi_update_resource.md
@@ -69,7 +69,7 @@ resource "azapi_update_resource" "example" {
   type        = "Microsoft.Network/loadBalancers@2021-03-01"
   resource_id = azurerm_lb.example.id
 
-  payload = {
+  body = {
     properties = {
       inboundNatRules = [
         {
@@ -109,13 +109,13 @@ The following arguments are supported:
 * `type` - (Required) It is in a format like `<resource-type>@<api-version>`. `<resource-type>` is the Azure resource type, for example, `Microsoft.Storage/storageAccounts`.
   `<api-version>` is version of the API used to manage this azure resource.
 
-* `payload` - (Required) A dynamic attribute that contains the request body used to add on an existing azure resource. 
+* `body` - (Required) A dynamic attribute that contains the request body used to add on an existing azure resource. 
 
 ---
 
 * `response_export_values` - (Optional) A list of path that needs to be exported from response body.
   Setting it to `["*"]` will export the full response body.
-  Here's an example. If it sets to `["properties.loginServer", "properties.policies.quarantinePolicy.status"]`, it will set the following HCL object to computed property `output_payload`.
+  Here's an example. If it sets to `["properties.loginServer", "properties.policies.quarantinePolicy.status"]`, it will set the following HCL object to computed property `output`.
 ```
 {
   properties = {
@@ -131,7 +131,7 @@ The following arguments are supported:
 
 * `locks` - (Optional) A list of ARM resource IDs which are used to avoid create/modify/delete azapi resources at the same time.
 
-* `ignore_missing_property` - (Optional) Whether ignore not returned properties like credentials in `payload` to suppress plan-diff. Defaults to `true`.
+* `ignore_missing_property` - (Optional) Whether ignore not returned properties like credentials in `body` to suppress plan-diff. Defaults to `true`.
   It's recommend to enable this option when some sensitive properties are not returned in response body, instead of setting them in `lifecycle.ignore_changes` because it will make the sensitive fields unable to update.
 
 ## Attributes Reference
@@ -140,16 +140,16 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `id` - The ID of the azure resource.
 
-* `output_payload` - The HCL object containing the properties specified in `response_export_values`. Here are some examples to use the values.
+* `output` - The HCL object containing the properties specified in `response_export_values`. Here are some examples to use the values.
 ```
 // it will output "registry1.azurecr.io"
 output "login_server" {
-  value = azapi_resource.example.output_payload.properties.loginServer
+  value = azapi_resource.example.output.properties.loginServer
 }
 
 // it will output "disabled"
 output "quarantine_policy" {
-  value = azapi_resource.example.output_payload.properties.policies.quarantinePolicy.status
+  value = azapi_resource.example.output.properties.policies.quarantinePolicy.status
 }
 ```
 

--- a/internal/services/azapi_data_plane_resource.go
+++ b/internal/services/azapi_data_plane_resource.go
@@ -241,7 +241,7 @@ func (r *DataPlaneResource) CreateUpdate(ctx context.Context, plan tfsdk.Plan, s
 	}
 
 	model.ID = basetypes.NewStringValue(id.ID())
-	if isBodyJSON(model.Body) {
+	if dynamicIsString(model.Body) {
 		model.Output = types.DynamicValue(types.StringValue(flattenOutput(responseBody, AsStringList(model.ResponseExportValues))))
 	} else {
 		model.Output = types.DynamicValue(flattenOutputPayload(responseBody, AsStringList(model.ResponseExportValues)))
@@ -300,7 +300,7 @@ func (r *DataPlaneResource) Read(ctx context.Context, request resource.ReadReque
 		response.Diagnostics.AddError("Invalid body", err.Error())
 		return
 	}
-	if isBodyJSON(model.Body) {
+	if dynamicIsString(model.Body) {
 		model.Body = types.DynamicValue(types.StringValue(string(data)))
 		model.Output = types.DynamicValue(types.StringValue(flattenOutput(responseBody, AsStringList(model.ResponseExportValues))))
 	} else {

--- a/internal/services/azapi_data_plane_resource.go
+++ b/internal/services/azapi_data_plane_resource.go
@@ -119,7 +119,7 @@ func (r *DataPlaneResource) Schema(ctx context.Context, request resource.SchemaR
 				Optional:           true,
 				Computed:           true,
 				Default:            defaults.BoolDefault(false),
-				DeprecationMessage: "This feature is deprecated and will be removed in a major release. Please use the `lifecycle.ignore_changes` argument to specify the fields in `payload` to ignore.",
+				DeprecationMessage: "This feature is deprecated and will be removed in a major release. Please use the `lifecycle.ignore_changes` argument to specify the fields in `body` to ignore.",
 			},
 
 			"ignore_missing_property": schema.BoolAttribute{

--- a/internal/services/azapi_data_plane_resource_test.go
+++ b/internal/services/azapi_data_plane_resource_test.go
@@ -187,7 +187,7 @@ resource "azapi_data_plane_resource" "test" {
   type      = "Microsoft.Purview/accounts/Scanning/classificationrules@2022-07-01-preview"
   parent_id = replace(azurerm_purview_account.example.scan_endpoint, "https://", "")
   name      = "acctest%[2]s"
-  payload = {
+  body = {
     kind = "Custom"
     properties = {
       description        = "Let's put a cool desc here"

--- a/internal/services/azapi_resource.go
+++ b/internal/services/azapi_resource.go
@@ -160,14 +160,14 @@ func (r *AzapiResource) Schema(ctx context.Context, _ resource.SchemaRequest, re
 				Validators: []validator.List{
 					listvalidator.ValueStringsAre(myvalidator.StringIsNotEmpty()),
 				},
-				DeprecationMessage: "This feature is deprecated and will be removed in a major release. Please use the `lifecycle.ignore_changes` argument to specify the fields in `payload` to ignore.",
+				DeprecationMessage: "This feature is deprecated and will be removed in a major release. Please use the `lifecycle.ignore_changes` argument to specify the fields in `body` to ignore.",
 			},
 
 			"ignore_casing": schema.BoolAttribute{
 				Optional:           true,
 				Computed:           true,
 				Default:            defaults.BoolDefault(false),
-				DeprecationMessage: "This feature is deprecated and will be removed in a major release. Please use the `lifecycle.ignore_changes` argument to specify the fields in `payload` to ignore.",
+				DeprecationMessage: "This feature is deprecated and will be removed in a major release. Please use the `lifecycle.ignore_changes` argument to specify the fields in `body` to ignore.",
 			},
 
 			"ignore_missing_property": schema.BoolAttribute{

--- a/internal/services/azapi_resource.go
+++ b/internal/services/azapi_resource.go
@@ -507,7 +507,7 @@ func (r *AzapiResource) CreateUpdate(ctx context.Context, requestPlan tfsdk.Plan
 
 	// generate the computed fields
 	plan.ID = types.StringValue(id.ID())
-	if isBodyJSON(plan.Body) {
+	if dynamicIsString(plan.Body) {
 		plan.Output = types.DynamicValue(types.StringValue(flattenOutput(responseBody, AsStringList(plan.ResponseExportValues))))
 	} else {
 		plan.Output = types.DynamicValue(flattenOutputPayload(responseBody, AsStringList(plan.ResponseExportValues)))
@@ -637,7 +637,7 @@ func (r *AzapiResource) Read(ctx context.Context, request resource.ReadRequest, 
 		return
 	}
 
-	if isBodyJSON(model.Body) {
+	if dynamicIsString(model.Body) {
 		state.Body = types.DynamicValue(types.StringValue(string(data)))
 		state.Output = types.DynamicValue(types.StringValue(flattenOutput(responseBody, AsStringList(model.ResponseExportValues))))
 	} else {

--- a/internal/services/azapi_resource_action_data_source.go
+++ b/internal/services/azapi_resource_action_data_source.go
@@ -148,7 +148,7 @@ func (r *ResourceActionDataSource) Read(ctx context.Context, request datasource.
 	}
 
 	model.ID = basetypes.NewStringValue(id.ID())
-	if isBodyJSON(model.Body) {
+	if dynamicIsString(model.Body) {
 		model.Output = types.DynamicValue(basetypes.NewStringValue(flattenOutput(responseBody, AsStringList(model.ResponseExportValues))))
 	} else {
 		model.Output = types.DynamicValue(flattenOutputPayload(responseBody, AsStringList(model.ResponseExportValues)))

--- a/internal/services/azapi_resource_action_resource.go
+++ b/internal/services/azapi_resource_action_resource.go
@@ -274,7 +274,7 @@ func (r *ActionResource) Action(ctx context.Context, model ActionResourceModel, 
 		resourceId = fmt.Sprintf("%s/%s", id.ID(), actionName)
 	}
 	model.ID = basetypes.NewStringValue(resourceId)
-	if isBodyJSON(model.Body) {
+	if dynamicIsString(model.Body) {
 		model.Output = types.DynamicValue(types.StringValue(flattenOutput(responseBody, AsStringList(model.ResponseExportValues))))
 	} else {
 		model.Output = types.DynamicValue(flattenOutputPayload(responseBody, AsStringList(model.ResponseExportValues)))

--- a/internal/services/azapi_resource_action_resource_test.go
+++ b/internal/services/azapi_resource_action_resource_test.go
@@ -191,7 +191,7 @@ resource "azapi_resource_action" "test" {
   type        = "Microsoft.Cache@2023-04-01"
   resource_id = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/providers/Microsoft.Cache"
   action      = "CheckNameAvailability"
-  payload = {
+  body = {
     type = "Microsoft.Cache/Redis"
     name = "cacheName"
   }

--- a/internal/services/azapi_resource_data_source.go
+++ b/internal/services/azapi_resource_data_source.go
@@ -32,8 +32,7 @@ type AzapiResourceDataSourceModel struct {
 	ResponseExportValues types.List     `tfsdk:"response_export_values"`
 	Location             types.String   `tfsdk:"location"`
 	Identity             types.List     `tfsdk:"identity"`
-	Output               types.String   `tfsdk:"output"`
-	OutputPayload        types.Dynamic  `tfsdk:"output_payload"`
+	Output               types.Dynamic  `tfsdk:"output"`
 	Tags                 types.Map      `tfsdk:"tags"`
 	Timeouts             timeouts.Value `tfsdk:"timeouts"`
 }
@@ -129,12 +128,7 @@ func (r *AzapiResourceDataSource) Schema(ctx context.Context, request datasource
 				},
 			},
 
-			"output": schema.StringAttribute{
-				Computed:           true,
-				DeprecationMessage: "This feature is deprecated and will be removed in a major release. Please use the `output_payload` argument to output the response of the resource.",
-			},
-
-			"output_payload": schema.DynamicAttribute{
+			"output": schema.DynamicAttribute{
 				Computed: true,
 			},
 
@@ -220,8 +214,7 @@ func (r *AzapiResourceDataSource) Read(ctx context.Context, request datasource.R
 			model.Identity = identity.ToList(*v)
 		}
 	}
-	model.Output = basetypes.NewStringValue(flattenOutput(responseBody, AsStringList(model.ResponseExportValues)))
-	model.OutputPayload = types.DynamicValue(flattenOutputPayload(responseBody, AsStringList(model.ResponseExportValues)))
+	model.Output = types.DynamicValue(flattenOutputPayload(responseBody, AsStringList(model.ResponseExportValues)))
 
 	response.Diagnostics.Append(response.State.Set(ctx, &model)...)
 }

--- a/internal/services/azapi_resource_list_data_source.go
+++ b/internal/services/azapi_resource_list_data_source.go
@@ -23,8 +23,7 @@ type ResourceListDataSourceModel struct {
 	Type                 types.String   `tfsdk:"type"`
 	ParentID             types.String   `tfsdk:"parent_id"`
 	ResponseExportValues types.List     `tfsdk:"response_export_values"`
-	Output               types.String   `tfsdk:"output"`
-	OutputPayload        types.Dynamic  `tfsdk:"output_payload"`
+	Output               types.Dynamic  `tfsdk:"output"`
 	Timeouts             timeouts.Value `tfsdk:"timeouts"`
 }
 
@@ -74,12 +73,7 @@ func (r *ResourceListDataSource) Schema(ctx context.Context, request datasource.
 				},
 			},
 
-			"output": schema.StringAttribute{
-				Computed:           true,
-				DeprecationMessage: "This feature is deprecated and will be removed in a major release. Please use the `payload` argument to specify the body of the resource.",
-			},
-
-			"output_payload": schema.DynamicAttribute{
+			"output": schema.DynamicAttribute{
 				Computed: true,
 			},
 		},
@@ -123,8 +117,7 @@ func (r *ResourceListDataSource) Read(ctx context.Context, request datasource.Re
 	}
 
 	model.ID = basetypes.NewStringValue(listUrl)
-	model.Output = basetypes.NewStringValue(flattenOutput(responseBody, AsStringList(model.ResponseExportValues)))
-	model.OutputPayload = types.DynamicValue(flattenOutputPayload(responseBody, AsStringList(model.ResponseExportValues)))
+	model.Output = types.DynamicValue(flattenOutputPayload(responseBody, AsStringList(model.ResponseExportValues)))
 
 	response.Diagnostics.Append(response.State.Set(ctx, &model)...)
 }

--- a/internal/services/azapi_resource_test.go
+++ b/internal/services/azapi_resource_test.go
@@ -22,7 +22,7 @@ import (
 type GenericResource struct{}
 
 func defaultIgnores() []string {
-	return []string{"ignore_casing", "ignore_missing_property", "schema_validation_enabled", "body", "locks", "removing_special_chars", "payload"}
+	return []string{"ignore_casing", "ignore_missing_property", "schema_validation_enabled", "body", "locks", "removing_special_chars", "output"}
 }
 
 var testCertRaw, _ = os.ReadFile(filepath.Join("testdata", "automation_certificate_test.pfx"))
@@ -563,7 +563,7 @@ resource "azapi_resource" "test" {
   name      = "acctest%[2]s"
   parent_id = azurerm_automation_account.test.id
 
-  payload = {
+  body = {
     properties = {
       base64Value = "%[3]s"
     }

--- a/internal/services/azapi_update_resource.go
+++ b/internal/services/azapi_update_resource.go
@@ -335,7 +335,7 @@ func (r *AzapiUpdateResource) CreateUpdate(ctx context.Context, plan tfsdk.Plan,
 	model.Name = basetypes.NewStringValue(id.Name)
 	model.ParentID = basetypes.NewStringValue(id.ParentId)
 	model.ResourceID = basetypes.NewStringValue(id.AzureResourceId)
-	if isBodyJSON(model.Body) {
+	if dynamicIsString(model.Body) {
 		model.Output = types.DynamicValue(types.StringValue(flattenOutput(responseBody, AsStringList(model.ResponseExportValues))))
 	} else {
 		model.Output = types.DynamicValue(flattenOutputPayload(responseBody, AsStringList(model.ResponseExportValues)))
@@ -407,7 +407,7 @@ func (r *AzapiUpdateResource) Read(ctx context.Context, request resource.ReadReq
 		response.Diagnostics.AddError("Invalid body", err.Error())
 		return
 	}
-	if isBodyJSON(model.Body) {
+	if dynamicIsString(model.Body) {
 		state.Body = types.DynamicValue(types.StringValue(string(data)))
 		state.Output = types.DynamicValue(types.StringValue(flattenOutput(responseBody, AsStringList(model.ResponseExportValues))))
 	} else {

--- a/internal/services/azapi_update_resource.go
+++ b/internal/services/azapi_update_resource.go
@@ -139,14 +139,14 @@ func (r *AzapiUpdateResource) Schema(ctx context.Context, request resource.Schem
 				Validators: []validator.List{
 					listvalidator.ValueStringsAre(myvalidator.StringIsNotEmpty()),
 				},
-				DeprecationMessage: "This feature is deprecated and will be removed in a major release. Please use the `lifecycle.ignore_changes` argument to specify the fields in `payload` to ignore.",
+				DeprecationMessage: "This feature is deprecated and will be removed in a major release. Please use the `lifecycle.ignore_changes` argument to specify the fields in `body` to ignore.",
 			},
 
 			"ignore_casing": schema.BoolAttribute{
 				Optional:           true,
 				Computed:           true,
 				Default:            defaults.BoolDefault(false),
-				DeprecationMessage: "This feature is deprecated and will be removed in a major release. Please use the `lifecycle.ignore_changes` argument to specify the fields in `payload` to ignore.",
+				DeprecationMessage: "This feature is deprecated and will be removed in a major release. Please use the `lifecycle.ignore_changes` argument to specify the fields in `body` to ignore.",
 			},
 
 			"ignore_missing_property": schema.BoolAttribute{

--- a/internal/services/azapi_update_resource.go
+++ b/internal/services/azapi_update_resource.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/terraform-provider-azapi/internal/locks"
 	"github.com/Azure/terraform-provider-azapi/internal/services/defaults"
 	"github.com/Azure/terraform-provider-azapi/internal/services/dynamic"
+	"github.com/Azure/terraform-provider-azapi/internal/services/migration"
 	"github.com/Azure/terraform-provider-azapi/internal/services/myplanmodifier"
 	"github.com/Azure/terraform-provider-azapi/internal/services/myvalidator"
 	"github.com/Azure/terraform-provider-azapi/internal/services/parse"
@@ -34,15 +35,13 @@ type AzapiUpdateResourceModel struct {
 	ParentID              types.String   `tfsdk:"parent_id"`
 	ResourceID            types.String   `tfsdk:"resource_id"`
 	Type                  types.String   `tfsdk:"type"`
-	Body                  types.String   `tfsdk:"body"`
-	Payload               types.Dynamic  `tfsdk:"payload"`
+	Body                  types.Dynamic  `tfsdk:"body"`
 	IgnoreCasing          types.Bool     `tfsdk:"ignore_casing"`
 	IgnoreBodyChanges     types.List     `tfsdk:"ignore_body_changes"`
 	IgnoreMissingProperty types.Bool     `tfsdk:"ignore_missing_property"`
 	ResponseExportValues  types.List     `tfsdk:"response_export_values"`
 	Locks                 types.List     `tfsdk:"locks"`
-	Output                types.String   `tfsdk:"output"`
-	OutputPayload         types.Dynamic  `tfsdk:"output_payload"`
+	Output                types.Dynamic  `tfsdk:"output"`
 	Timeouts              timeouts.Value `tfsdk:"timeouts"`
 }
 
@@ -54,14 +53,22 @@ var _ resource.Resource = &AzapiUpdateResource{}
 var _ resource.ResourceWithConfigure = &AzapiUpdateResource{}
 var _ resource.ResourceWithValidateConfig = &AzapiUpdateResource{}
 var _ resource.ResourceWithModifyPlan = &AzapiUpdateResource{}
+var _ resource.ResourceWithUpgradeState = &AzapiUpdateResource{}
 
 func (r *AzapiUpdateResource) Configure(ctx context.Context, request resource.ConfigureRequest, response *resource.ConfigureResponse) {
 	if v, ok := request.ProviderData.(*clients.Client); ok {
 		r.ProviderData = v
 	}
 }
+
 func (r *AzapiUpdateResource) Metadata(ctx context.Context, request resource.MetadataRequest, response *resource.MetadataResponse) {
 	response.TypeName = request.ProviderTypeName + "_update_resource"
+}
+
+func (r *AzapiUpdateResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
+	return map[int64]resource.StateUpgrader{
+		0: migration.AzapiUpdateResourceMigrationV0ToV1(ctx),
+	}
 }
 
 func (r *AzapiUpdateResource) Schema(ctx context.Context, request resource.SchemaRequest, response *resource.SchemaResponse) {
@@ -114,25 +121,15 @@ func (r *AzapiUpdateResource) Schema(ctx context.Context, request resource.Schem
 				},
 			},
 
-			"body": schema.StringAttribute{
+			// The body attribute is a dynamic attribute that allows users to specify the resource body as an HCL object or a JSON string.
+			// If the body is specified as a JSON string, the underlying value will be a string
+			// TODO: Remove the support for JSON string in the next major release
+			"body": schema.DynamicAttribute{
 				Optional: true,
 				Computed: true,
-				Default:  defaults.StringDefault("{}"),
-				Validators: []validator.String{
-					myvalidator.StringIsJSON(),
-				},
-				PlanModifiers: []planmodifier.String{
-					myplanmodifier.UseStateWhen(func(a, b types.String) bool {
-						return utils.NormalizeJson(a.ValueString()) == utils.NormalizeJson(b.ValueString())
-					}),
-				},
-				DeprecationMessage: "This feature is deprecated and will be removed in a major release. Please use the `payload` argument to specify the body of the resource.",
-			},
-
-			"payload": schema.DynamicAttribute{
-				Optional: true,
+				Default:  defaults.DynamicDefault(types.StringValue("{}")),
 				PlanModifiers: []planmodifier.Dynamic{
-					myplanmodifier.DynamicUseStateWhen(dynamic.SemanticallyEqual),
+					myplanmodifier.DynamicUseStateWhen(bodySemanticallyEqual),
 				},
 			},
 
@@ -174,12 +171,7 @@ func (r *AzapiUpdateResource) Schema(ctx context.Context, request resource.Schem
 				},
 			},
 
-			"output": schema.StringAttribute{
-				Computed:           true,
-				DeprecationMessage: "This feature is deprecated and will be removed in a major release. Please use the `payload` argument to specify the body of the resource.",
-			},
-
-			"output_payload": schema.DynamicAttribute{
+			"output": schema.DynamicAttribute{
 				Computed: true,
 			},
 		},
@@ -191,6 +183,8 @@ func (r *AzapiUpdateResource) Schema(ctx context.Context, request resource.Schem
 				Delete: true,
 			}),
 		},
+
+		Version: 1,
 	}
 }
 
@@ -202,11 +196,6 @@ func (r *AzapiUpdateResource) ValidateConfig(ctx context.Context, request resour
 
 	if config == nil {
 		return
-	}
-
-	// can't specify both body and payload
-	if !config.Body.IsNull() && !config.Payload.IsNull() {
-		response.Diagnostics.AddError("Invalid config", "can't specify both body and payload")
 	}
 
 	if config.Name.IsNull() && !config.ParentID.IsNull() {
@@ -254,9 +243,8 @@ func (r *AzapiUpdateResource) ModifyPlan(ctx context.Context, request resource.M
 		return
 	}
 
-	if state == nil || !plan.ResponseExportValues.Equal(state.ResponseExportValues) || utils.NormalizeJson(plan.Body.ValueString()) != utils.NormalizeJson(state.Body.ValueString()) || !plan.Payload.Equal(state.Payload) {
-		plan.Output = types.StringUnknown()
-		plan.OutputPayload = basetypes.NewDynamicUnknown()
+	if state == nil || !plan.ResponseExportValues.Equal(state.ResponseExportValues) || !bodySemanticallyEqual(plan.Body, state.Body) {
+		plan.Output = basetypes.NewDynamicUnknown()
 		response.Diagnostics.Append(response.Plan.Set(ctx, plan)...)
 	}
 }
@@ -313,23 +301,9 @@ func (r *AzapiUpdateResource) CreateUpdate(ctx context.Context, plan tfsdk.Plan,
 	}
 
 	var requestBody interface{}
-	switch {
-	case !model.Payload.IsNull():
-		out, err := expandPayload(model.Payload)
-		if err != nil {
-			diagnostics.AddError("Invalid payload", err.Error())
-			return
-		}
-		requestBody = out
-	case !model.Body.IsNull():
-		bodyValueString := model.Body.ValueString()
-		err := json.Unmarshal([]byte(bodyValueString), &requestBody)
-		if err != nil {
-			diagnostics.AddError("Invalid JSON string", fmt.Sprintf(`The argument "body" is invalid: value: %s, err: %+v`, model.Body.ValueString(), err))
-			return
-		}
-	default:
-		requestBody = map[string]interface{}{}
+	if err := unmarshalBody(model.Body, &requestBody); err != nil {
+		diagnostics.AddError("Invalid body", fmt.Sprintf(`The argument "body" is invalid: err: %+v`, err))
+		return
 	}
 
 	requestBody = utils.MergeObject(existing, requestBody)
@@ -361,9 +335,11 @@ func (r *AzapiUpdateResource) CreateUpdate(ctx context.Context, plan tfsdk.Plan,
 	model.Name = basetypes.NewStringValue(id.Name)
 	model.ParentID = basetypes.NewStringValue(id.ParentId)
 	model.ResourceID = basetypes.NewStringValue(id.AzureResourceId)
-	model.Output = basetypes.NewStringValue(flattenOutput(responseBody, AsStringList(model.ResponseExportValues)))
-	model.OutputPayload = types.DynamicValue(flattenOutputPayload(responseBody, AsStringList(model.ResponseExportValues)))
-
+	if isBodyJSON(model.Body) {
+		model.Output = types.DynamicValue(types.StringValue(flattenOutput(responseBody, AsStringList(model.ResponseExportValues))))
+	} else {
+		model.Output = types.DynamicValue(flattenOutputPayload(responseBody, AsStringList(model.ResponseExportValues)))
+	}
 	diagnostics.Append(state.Set(ctx, model)...)
 }
 
@@ -407,27 +383,10 @@ func (r *AzapiUpdateResource) Read(ctx context.Context, request resource.ReadReq
 	state.ResourceID = basetypes.NewStringValue(id.AzureResourceId)
 	state.Type = basetypes.NewStringValue(fmt.Sprintf("%s@%s", id.AzureResourceType, id.ApiVersion))
 
-	var requestBody map[string]interface{}
-	var useBody bool
-	switch {
-	case !model.Payload.IsNull():
-		useBody = false
-		out, err := expandPayload(model.Payload)
-		if err != nil {
-			response.Diagnostics.AddError("Invalid payload", err.Error())
-			return
-		}
-		requestBody = out
-	case !model.Body.IsNull():
-		useBody = true
-		bodyValueString := model.Body.ValueString()
-		err := json.Unmarshal([]byte(bodyValueString), &requestBody)
-		if err != nil {
-			response.Diagnostics.AddError("Invalid JSON string", fmt.Sprintf(`The argument "body" is invalid: value: %s, err: %+v`, model.Body.ValueString(), err))
-			return
-		}
-	default:
-		requestBody = map[string]interface{}{}
+	requestBody := make(map[string]interface{})
+	if err := unmarshalBody(model.Body, &requestBody); err != nil {
+		response.Diagnostics.AddError("Invalid body", fmt.Sprintf(`The argument "body" is invalid: %s`, err.Error()))
+		return
 	}
 
 	if out, err := overrideWithPaths(responseBody, requestBody, AsStringList(model.IgnoreBodyChanges)); err == nil {
@@ -448,23 +407,24 @@ func (r *AzapiUpdateResource) Read(ctx context.Context, request resource.ReadReq
 		response.Diagnostics.AddError("Invalid body", err.Error())
 		return
 	}
-	if useBody {
-		state.Body = types.StringValue(string(data))
+	if isBodyJSON(model.Body) {
+		state.Body = types.DynamicValue(types.StringValue(string(data)))
+		state.Output = types.DynamicValue(types.StringValue(flattenOutput(responseBody, AsStringList(model.ResponseExportValues))))
 	} else {
-		payload, err := dynamic.FromJSON(data, model.Payload.UnderlyingValue().Type(ctx))
-		if err != nil {
-			tflog.Warn(ctx, fmt.Sprintf("Failed to parse payload: %s", err.Error()))
-			payload, err = dynamic.FromJSONImplied(data)
+		state.Output = types.DynamicValue(flattenOutputPayload(responseBody, AsStringList(model.ResponseExportValues)))
+		if !model.Body.IsNull() {
+			payload, err := dynamic.FromJSON(data, model.Body.UnderlyingValue().Type(ctx))
 			if err != nil {
-				response.Diagnostics.AddError("Invalid payload", err.Error())
-				return
+				tflog.Warn(ctx, fmt.Sprintf("Failed to parse payload: %s", err.Error()))
+				payload, err = dynamic.FromJSONImplied(data)
+				if err != nil {
+					response.Diagnostics.AddError("Invalid payload", err.Error())
+					return
+				}
 			}
+			state.Body = payload
 		}
-		state.Payload = payload
 	}
-
-	state.Output = basetypes.NewStringValue(flattenOutput(responseBody, AsStringList(model.ResponseExportValues)))
-	state.OutputPayload = types.DynamicValue(flattenOutputPayload(responseBody, AsStringList(model.ResponseExportValues)))
 
 	response.Diagnostics.Append(response.State.Set(ctx, state)...)
 }

--- a/internal/services/azapi_update_resource_test.go
+++ b/internal/services/azapi_update_resource_test.go
@@ -185,7 +185,7 @@ resource "azurerm_automation_account" "test" {
 resource "azapi_update_resource" "test" {
   type        = "Microsoft.Automation/automationAccounts@2023-11-01"
   resource_id = azurerm_automation_account.test.id
-  payload = {
+  body = {
     properties = {
       publicNetworkAccess = true
     }

--- a/internal/services/defaults/dynamic_default.go
+++ b/internal/services/defaults/dynamic_default.go
@@ -1,0 +1,29 @@
+package defaults
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/defaults"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+)
+
+type dynamicDefault struct {
+	defaultValue attr.Value
+}
+
+func (s dynamicDefault) Description(ctx context.Context) string {
+	return "Return the default value"
+}
+
+func (s dynamicDefault) MarkdownDescription(ctx context.Context) string {
+	return "Return the default value"
+}
+
+func (s dynamicDefault) DefaultDynamic(ctx context.Context, request defaults.DynamicRequest, response *defaults.DynamicResponse) {
+	response.PlanValue = basetypes.NewDynamicValue(s.defaultValue)
+}
+
+func DynamicDefault(defaultValue attr.Value) defaults.Dynamic {
+	return dynamicDefault{defaultValue: defaultValue}
+}

--- a/internal/services/migration/azapi_data_plane_resource_migration_v0_to_v1.go
+++ b/internal/services/migration/azapi_data_plane_resource_migration_v0_to_v1.go
@@ -1,0 +1,121 @@
+package migration
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func AzapiDataPlaneResourceMigrationV0ToV1(ctx context.Context) resource.StateUpgrader {
+	return resource.StateUpgrader{
+		PriorSchema: &schema.Schema{
+			Attributes: map[string]schema.Attribute{
+				"id": schema.StringAttribute{
+					Computed: true,
+				},
+
+				"name": schema.StringAttribute{
+					Required: true,
+				},
+
+				"parent_id": schema.StringAttribute{
+					Required: true,
+				},
+
+				"type": schema.StringAttribute{
+					Required: true,
+				},
+
+				"body": schema.StringAttribute{
+					Optional: true,
+					Computed: true,
+				},
+
+				"ignore_casing": schema.BoolAttribute{
+					Optional: true,
+					Computed: true},
+
+				"ignore_missing_property": schema.BoolAttribute{
+					Optional: true,
+					Computed: true,
+				},
+
+				"response_export_values": schema.ListAttribute{
+					ElementType: types.StringType,
+					Optional:    true,
+				},
+
+				"locks": schema.ListAttribute{
+					ElementType: types.StringType,
+					Optional:    true,
+				},
+
+				"output": schema.StringAttribute{
+					Computed: true,
+				},
+			},
+
+			Blocks: map[string]schema.Block{
+				"timeouts": timeouts.Block(ctx, timeouts.Opts{
+					Create: true,
+					Read:   true,
+					Delete: true,
+				}),
+			},
+
+			Version: 0,
+		},
+		StateUpgrader: func(ctx context.Context, request resource.UpgradeStateRequest, response *resource.UpgradeStateResponse) {
+			type OldModel struct {
+				ID                    types.String   `tfsdk:"id"`
+				Name                  types.String   `tfsdk:"name"`
+				ParentID              types.String   `tfsdk:"parent_id"`
+				Type                  types.String   `tfsdk:"type"`
+				Body                  types.String   `tfsdk:"body"`
+				IgnoreCasing          types.Bool     `tfsdk:"ignore_casing"`
+				IgnoreMissingProperty types.Bool     `tfsdk:"ignore_missing_property"`
+				ResponseExportValues  types.List     `tfsdk:"response_export_values"`
+				Locks                 types.List     `tfsdk:"locks"`
+				Output                types.String   `tfsdk:"output"`
+				Timeouts              timeouts.Value `tfsdk:"timeouts"`
+			}
+			type newModel struct {
+				ID                    types.String   `tfsdk:"id"`
+				Name                  types.String   `tfsdk:"name"`
+				ParentID              types.String   `tfsdk:"parent_id"`
+				Type                  types.String   `tfsdk:"type"`
+				Body                  types.Dynamic  `tfsdk:"body"`
+				IgnoreCasing          types.Bool     `tfsdk:"ignore_casing"`
+				IgnoreMissingProperty types.Bool     `tfsdk:"ignore_missing_property"`
+				ResponseExportValues  types.List     `tfsdk:"response_export_values"`
+				Locks                 types.List     `tfsdk:"locks"`
+				Output                types.Dynamic  `tfsdk:"output"`
+				Timeouts              timeouts.Value `tfsdk:"timeouts"`
+			}
+
+			var oldState OldModel
+			if response.Diagnostics.Append(request.State.Get(ctx, &oldState)...); response.Diagnostics.HasError() {
+				return
+			}
+
+			newState := newModel{
+				ID:                    oldState.ID,
+				Name:                  oldState.Name,
+				ParentID:              oldState.ParentID,
+				Type:                  oldState.Type,
+				Body:                  types.DynamicValue(types.StringValue(oldState.Body.ValueString())),
+				Locks:                 oldState.Locks,
+				IgnoreCasing:          oldState.IgnoreCasing,
+				IgnoreMissingProperty: oldState.IgnoreMissingProperty,
+				ResponseExportValues:  oldState.ResponseExportValues,
+				Output:                types.DynamicValue(types.StringValue(oldState.Output.ValueString())),
+				Timeouts:              oldState.Timeouts,
+			}
+
+			response.Diagnostics.Append(response.State.Set(ctx, newState)...)
+		},
+	}
+}

--- a/internal/services/migration/azapi_resource_action_migration_v0_to_v1.go
+++ b/internal/services/migration/azapi_resource_action_migration_v0_to_v1.go
@@ -2,6 +2,7 @@ package migration
 
 import (
 	"context"
+
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"

--- a/internal/services/migration/azapi_resource_action_migration_v0_to_v1.go
+++ b/internal/services/migration/azapi_resource_action_migration_v0_to_v1.go
@@ -1,0 +1,118 @@
+package migration
+
+import (
+	"context"
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func AzapiResourceActionMigrationV0ToV1(ctx context.Context) resource.StateUpgrader {
+	return resource.StateUpgrader{
+		PriorSchema: &schema.Schema{
+			Attributes: map[string]schema.Attribute{
+				"id": schema.StringAttribute{
+					Computed: true,
+				},
+
+				"type": schema.StringAttribute{
+					Required: true,
+				},
+
+				"resource_id": schema.StringAttribute{
+					Required: true,
+				},
+
+				"action": schema.StringAttribute{
+					Optional: true,
+				},
+
+				"method": schema.StringAttribute{
+					Optional: true,
+					Computed: true,
+				},
+
+				"body": schema.StringAttribute{
+					Optional: true},
+
+				"when": schema.StringAttribute{
+					Optional: true,
+					Computed: true,
+				},
+
+				"locks": schema.ListAttribute{
+					ElementType: types.StringType,
+					Optional:    true,
+				},
+
+				"response_export_values": schema.ListAttribute{
+					ElementType: types.StringType,
+					Optional:    true,
+				},
+
+				"output": schema.StringAttribute{
+					Computed: true,
+				},
+			},
+
+			Blocks: map[string]schema.Block{
+				"timeouts": timeouts.Block(ctx, timeouts.Opts{
+					Create: true,
+					Read:   true,
+					Delete: true,
+				}),
+			},
+			Version: 0,
+		},
+		StateUpgrader: func(ctx context.Context, request resource.UpgradeStateRequest, response *resource.UpgradeStateResponse) {
+			type OldModel struct {
+				ID                   types.String   `tfsdk:"id"`
+				Type                 types.String   `tfsdk:"type"`
+				ResourceId           types.String   `tfsdk:"resource_id"`
+				Action               types.String   `tfsdk:"action"`
+				Method               types.String   `tfsdk:"method"`
+				Body                 types.String   `tfsdk:"body"`
+				When                 types.String   `tfsdk:"when"`
+				Locks                types.List     `tfsdk:"locks"`
+				ResponseExportValues types.List     `tfsdk:"response_export_values"`
+				Output               types.String   `tfsdk:"output"`
+				Timeouts             timeouts.Value `tfsdk:"timeouts"`
+			}
+			type newModel struct {
+				ID                   types.String   `tfsdk:"id"`
+				Type                 types.String   `tfsdk:"type"`
+				ResourceId           types.String   `tfsdk:"resource_id"`
+				Action               types.String   `tfsdk:"action"`
+				Method               types.String   `tfsdk:"method"`
+				Body                 types.Dynamic  `tfsdk:"body"`
+				When                 types.String   `tfsdk:"when"`
+				Locks                types.List     `tfsdk:"locks"`
+				ResponseExportValues types.List     `tfsdk:"response_export_values"`
+				Output               types.Dynamic  `tfsdk:"output"`
+				Timeouts             timeouts.Value `tfsdk:"timeouts"`
+			}
+
+			var oldState OldModel
+			if response.Diagnostics.Append(request.State.Get(ctx, &oldState)...); response.Diagnostics.HasError() {
+				return
+			}
+
+			newState := newModel{
+				ID:                   oldState.ID,
+				Type:                 oldState.Type,
+				ResourceId:           oldState.ResourceId,
+				Action:               oldState.Action,
+				Method:               oldState.Method,
+				Body:                 types.DynamicValue(types.StringValue(oldState.Body.ValueString())),
+				When:                 oldState.When,
+				Locks:                oldState.Locks,
+				ResponseExportValues: oldState.ResponseExportValues,
+				Output:               types.DynamicValue(types.StringValue(oldState.Output.ValueString())),
+				Timeouts:             oldState.Timeouts,
+			}
+
+			response.Diagnostics.Append(response.State.Set(ctx, newState)...)
+		},
+	}
+}

--- a/internal/services/migration/azapi_resource_migration_v0_to_v1.go
+++ b/internal/services/migration/azapi_resource_migration_v0_to_v1.go
@@ -1,0 +1,188 @@
+package migration
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func AzapiResourceMigrationV0ToV1(ctx context.Context) resource.StateUpgrader {
+	return resource.StateUpgrader{
+		PriorSchema: &schema.Schema{
+			Attributes: map[string]schema.Attribute{
+				"id": schema.StringAttribute{
+					Computed: true,
+				},
+
+				"name": schema.StringAttribute{
+					Optional: true,
+					Computed: true,
+				},
+
+				"removing_special_chars": schema.BoolAttribute{
+					Optional: true,
+					Computed: true,
+				},
+
+				"parent_id": schema.StringAttribute{
+					Optional: true,
+					Computed: true,
+				},
+
+				"type": schema.StringAttribute{
+					Required: true,
+				},
+
+				"location": schema.StringAttribute{
+					Optional: true,
+					Computed: true,
+				},
+
+				"body": schema.StringAttribute{
+					Optional: true,
+				},
+
+				"ignore_body_changes": schema.ListAttribute{
+					ElementType: types.StringType,
+					Optional:    true,
+				},
+
+				"ignore_casing": schema.BoolAttribute{
+					Optional: true,
+					Computed: true,
+				},
+
+				"ignore_missing_property": schema.BoolAttribute{
+					Optional: true,
+					Computed: true,
+				},
+
+				"response_export_values": schema.ListAttribute{
+					ElementType: types.StringType,
+					Optional:    true,
+				},
+
+				"locks": schema.ListAttribute{
+					ElementType: types.StringType,
+					Optional:    true,
+				},
+
+				"schema_validation_enabled": schema.BoolAttribute{
+					Optional: true,
+					Computed: true,
+				},
+
+				"output": schema.StringAttribute{
+					Computed: true,
+				},
+
+				"tags": schema.MapAttribute{
+					ElementType: types.StringType,
+					Optional:    true,
+					Computed:    true,
+				},
+			},
+			Blocks: map[string]schema.Block{
+				"identity": schema.ListNestedBlock{
+					NestedObject: schema.NestedBlockObject{
+						Attributes: map[string]schema.Attribute{
+							"type": schema.StringAttribute{
+								Required: true,
+							},
+
+							"identity_ids": schema.ListAttribute{
+								ElementType: types.StringType,
+								Optional:    true,
+							},
+
+							"principal_id": schema.StringAttribute{
+								Computed: true,
+							},
+
+							"tenant_id": schema.StringAttribute{
+								Computed: true,
+							},
+						},
+					},
+				},
+
+				"timeouts": timeouts.Block(ctx, timeouts.Opts{
+					Create: true,
+					Read:   true,
+					Delete: true,
+				}),
+			},
+			Version: 0,
+		},
+		StateUpgrader: func(ctx context.Context, request resource.UpgradeStateRequest, response *resource.UpgradeStateResponse) {
+			type OldModel struct {
+				ID                      types.String   `tfsdk:"id"`
+				Name                    types.String   `tfsdk:"name"`
+				ParentID                types.String   `tfsdk:"parent_id"`
+				Type                    types.String   `tfsdk:"type"`
+				Location                types.String   `tfsdk:"location"`
+				Identity                types.List     `tfsdk:"identity"`
+				Body                    types.String   `tfsdk:"body"`
+				Locks                   types.List     `tfsdk:"locks"`
+				RemovingSpecialChars    types.Bool     `tfsdk:"removing_special_chars"`
+				SchemaValidationEnabled types.Bool     `tfsdk:"schema_validation_enabled"`
+				IgnoreBodyChanges       types.List     `tfsdk:"ignore_body_changes"`
+				IgnoreCasing            types.Bool     `tfsdk:"ignore_casing"`
+				IgnoreMissingProperty   types.Bool     `tfsdk:"ignore_missing_property"`
+				ResponseExportValues    types.List     `tfsdk:"response_export_values"`
+				Output                  types.String   `tfsdk:"output"`
+				Tags                    types.Map      `tfsdk:"tags"`
+				Timeouts                timeouts.Value `tfsdk:"timeouts"`
+			}
+			type newModel struct {
+				ID                      types.String   `tfsdk:"id"`
+				Name                    types.String   `tfsdk:"name"`
+				ParentID                types.String   `tfsdk:"parent_id"`
+				Type                    types.String   `tfsdk:"type"`
+				Location                types.String   `tfsdk:"location"`
+				Identity                types.List     `tfsdk:"identity"`
+				Body                    types.Dynamic  `tfsdk:"body"`
+				Locks                   types.List     `tfsdk:"locks"`
+				RemovingSpecialChars    types.Bool     `tfsdk:"removing_special_chars"`
+				SchemaValidationEnabled types.Bool     `tfsdk:"schema_validation_enabled"`
+				IgnoreBodyChanges       types.List     `tfsdk:"ignore_body_changes"`
+				IgnoreCasing            types.Bool     `tfsdk:"ignore_casing"`
+				IgnoreMissingProperty   types.Bool     `tfsdk:"ignore_missing_property"`
+				ResponseExportValues    types.List     `tfsdk:"response_export_values"`
+				Output                  types.Dynamic  `tfsdk:"output"`
+				Tags                    types.Map      `tfsdk:"tags"`
+				Timeouts                timeouts.Value `tfsdk:"timeouts"`
+			}
+
+			var oldState OldModel
+			if response.Diagnostics.Append(request.State.Get(ctx, &oldState)...); response.Diagnostics.HasError() {
+				return
+			}
+
+			newState := newModel{
+				ID:                      oldState.ID,
+				Name:                    oldState.Name,
+				ParentID:                oldState.ParentID,
+				Type:                    oldState.Type,
+				Location:                oldState.Location,
+				Identity:                oldState.Identity,
+				Body:                    types.DynamicValue(types.StringValue(oldState.Body.ValueString())),
+				Locks:                   oldState.Locks,
+				RemovingSpecialChars:    oldState.RemovingSpecialChars,
+				SchemaValidationEnabled: oldState.SchemaValidationEnabled,
+				IgnoreBodyChanges:       oldState.IgnoreBodyChanges,
+				IgnoreCasing:            oldState.IgnoreCasing,
+				IgnoreMissingProperty:   oldState.IgnoreMissingProperty,
+				ResponseExportValues:    oldState.ResponseExportValues,
+				Output:                  types.DynamicValue(types.StringValue(oldState.Output.ValueString())),
+				Tags:                    oldState.Tags,
+				Timeouts:                oldState.Timeouts,
+			}
+
+			response.Diagnostics.Append(response.State.Set(ctx, newState)...)
+		},
+	}
+}

--- a/internal/services/migration/azapi_update_resource_migration_v0_to_v1.go
+++ b/internal/services/migration/azapi_update_resource_migration_v0_to_v1.go
@@ -1,0 +1,139 @@
+package migration
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func AzapiUpdateResourceMigrationV0ToV1(ctx context.Context) resource.StateUpgrader {
+	return resource.StateUpgrader{
+		PriorSchema: &schema.Schema{
+			Attributes: map[string]schema.Attribute{
+				"id": schema.StringAttribute{
+					Computed: true,
+				},
+
+				"name": schema.StringAttribute{
+					Optional: true,
+					Computed: true,
+				},
+
+				"parent_id": schema.StringAttribute{
+					Optional: true,
+					Computed: true,
+				},
+
+				"resource_id": schema.StringAttribute{
+					Optional: true,
+					Computed: true,
+				},
+
+				"type": schema.StringAttribute{
+					Required: true,
+				},
+
+				"body": schema.StringAttribute{
+					Optional: true,
+					Computed: true,
+				},
+
+				"ignore_body_changes": schema.ListAttribute{
+					ElementType: types.StringType,
+					Optional:    true,
+				},
+
+				"ignore_casing": schema.BoolAttribute{
+					Optional: true,
+					Computed: true,
+				},
+
+				"ignore_missing_property": schema.BoolAttribute{
+					Optional: true,
+					Computed: true,
+				},
+
+				"response_export_values": schema.ListAttribute{
+					ElementType: types.StringType,
+					Optional:    true,
+				},
+
+				"locks": schema.ListAttribute{
+					ElementType: types.StringType,
+					Optional:    true,
+				},
+
+				"output": schema.StringAttribute{
+					Computed: true,
+				},
+			},
+
+			Blocks: map[string]schema.Block{
+				"timeouts": timeouts.Block(ctx, timeouts.Opts{
+					Create: true,
+					Read:   true,
+					Delete: true,
+				}),
+			},
+			Version: 0,
+		},
+		StateUpgrader: func(ctx context.Context, request resource.UpgradeStateRequest, response *resource.UpgradeStateResponse) {
+			type OldModel struct {
+				ID                    types.String   `tfsdk:"id"`
+				Name                  types.String   `tfsdk:"name"`
+				ParentID              types.String   `tfsdk:"parent_id"`
+				ResourceID            types.String   `tfsdk:"resource_id"`
+				Type                  types.String   `tfsdk:"type"`
+				Body                  types.String   `tfsdk:"body"`
+				IgnoreCasing          types.Bool     `tfsdk:"ignore_casing"`
+				IgnoreBodyChanges     types.List     `tfsdk:"ignore_body_changes"`
+				IgnoreMissingProperty types.Bool     `tfsdk:"ignore_missing_property"`
+				ResponseExportValues  types.List     `tfsdk:"response_export_values"`
+				Locks                 types.List     `tfsdk:"locks"`
+				Output                types.String   `tfsdk:"output"`
+				Timeouts              timeouts.Value `tfsdk:"timeouts"`
+			}
+			type newModel struct {
+				ID                    types.String   `tfsdk:"id"`
+				Name                  types.String   `tfsdk:"name"`
+				ParentID              types.String   `tfsdk:"parent_id"`
+				ResourceID            types.String   `tfsdk:"resource_id"`
+				Type                  types.String   `tfsdk:"type"`
+				Body                  types.Dynamic  `tfsdk:"body"`
+				IgnoreCasing          types.Bool     `tfsdk:"ignore_casing"`
+				IgnoreBodyChanges     types.List     `tfsdk:"ignore_body_changes"`
+				IgnoreMissingProperty types.Bool     `tfsdk:"ignore_missing_property"`
+				ResponseExportValues  types.List     `tfsdk:"response_export_values"`
+				Locks                 types.List     `tfsdk:"locks"`
+				Output                types.Dynamic  `tfsdk:"output"`
+				Timeouts              timeouts.Value `tfsdk:"timeouts"`
+			}
+
+			var oldState OldModel
+			if response.Diagnostics.Append(request.State.Get(ctx, &oldState)...); response.Diagnostics.HasError() {
+				return
+			}
+
+			newState := newModel{
+				ID:                    oldState.ID,
+				Name:                  oldState.Name,
+				ParentID:              oldState.ParentID,
+				ResourceID:            oldState.ResourceID,
+				Type:                  oldState.Type,
+				Body:                  types.DynamicValue(types.StringValue(oldState.Body.ValueString())),
+				Locks:                 oldState.Locks,
+				IgnoreBodyChanges:     oldState.IgnoreBodyChanges,
+				IgnoreCasing:          oldState.IgnoreCasing,
+				IgnoreMissingProperty: oldState.IgnoreMissingProperty,
+				ResponseExportValues:  oldState.ResponseExportValues,
+				Output:                types.DynamicValue(types.StringValue(oldState.Output.ValueString())),
+				Timeouts:              oldState.Timeouts,
+			}
+
+			response.Diagnostics.Append(response.State.Set(ctx, newState)...)
+		},
+	}
+}

--- a/internal/services/resource.go
+++ b/internal/services/resource.go
@@ -196,7 +196,7 @@ func unmarshalBody(input types.Dynamic, out interface{}) error {
 	}
 }
 
-func isBodyJSON(input types.Dynamic) bool {
+func dynamicIsString(input types.Dynamic) bool {
 	if input.IsNull() || input.IsUnknown() || input.IsUnderlyingValueUnknown() {
 		return false
 	}


### PR DESCRIPTION
This PR makes the `body` and `output` fields supports dynamic schema and removes the `payload` and `output_payload` fields.