### PR TITLE
ignore the order of the elements in a list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ ENHANCEMENTS:
 - `azapi_resource` resource, `azapi_update_resource` resource, `azapi_resource_action` resource, `azapi_data_plane_resource` resource, `azapi_resource_action` data source, `azapi_resource` data source, `azapi_resource_list` data source: The `output` field supports the dynamic schema and allows user to read the output as an HCL object.
 - `azapi` provider: Support `client_id_file_path`and `client_secret_file_path` fields, which are used to specify the file path of the client id and client secret.
 - `azapi_data_plane_resource` resource: Support `Microsoft.Synapse/workspaces/databases` type.
+- `azapi_resource` resource, `azapi_update_resource` resource: Ignore the order of the elements in a list if the element has a `name` field as identifier.
 
 BUG FIXES:
 - Fix a bug that `azapi_resource_action` doesn't support 204 status code as a success response.

--- a/utils/json_test.go
+++ b/utils/json_test.go
@@ -19,6 +19,125 @@ func Test_UpdateObject(t *testing.T) {
 			OldJson: `
 {
   "properties": {
+    "addressSpace": {
+      "addressPrefixes": [
+        "10.0.0.0/16"
+      ]
+    },
+    "dhcpOptions": {
+      "dnsServers": null
+    },
+    "subnets": [
+      {
+        "name": "default",
+        "properties": {
+          "addressPrefix": "10.0.3.0/24"
+        }
+      }
+    ]
+  }
+}
+`,
+			NewJson: `
+{
+  "etag": "W/\"5633f421-aaa4-4cf3-b9a6-40625807bd75\"",
+  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/henglu422/providers/Microsoft.Network/virtualNetworks/henglu422",
+  "location": "westus",
+  "name": "henglu422",
+  "properties": {
+    "addressSpace": {
+      "addressPrefixes": [
+        "10.0.0.0/16"
+      ]
+    },
+    "dhcpOptions": {
+      "dnsServers": []
+    },
+    "enableDdosProtection": false,
+    "provisioningState": "Succeeded",
+    "resourceGuid": "86ec5186-a958-4b83-b5e7-3b88a728c34c",
+    "subnets": [
+      {
+        "etag": "W/\"5633f421-aaa4-4cf3-b9a6-40625807bd75\"",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/henglu422/providers/Microsoft.Network/virtualNetworks/henglu422/subnets/henglu422",
+        "name": "henglu422",
+        "properties": {
+          "addressPrefix": "10.0.2.0/24",
+          "delegations": [],
+          "networkSecurityGroup": {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/henglu422/providers/Microsoft.Network/networkSecurityGroups/NRMS-zpedr2ai6dglmhenglu422"
+          },
+          "privateEndpointNetworkPolicies": "Disabled",
+          "privateLinkServiceNetworkPolicies": "Enabled",
+          "provisioningState": "Succeeded"
+        },
+        "type": "Microsoft.Network/virtualNetworks/subnets"
+      },
+      {
+        "etag": "W/\"5633f421-aaa4-4cf3-b9a6-40625807bd75\"",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/henglu422/providers/Microsoft.Network/virtualNetworks/henglu422/subnets/default",
+        "name": "default",
+        "properties": {
+          "addressPrefix": "10.0.3.0/24",
+          "delegations": [],
+          "networkSecurityGroup": {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/henglu422/providers/Microsoft.Network/networkSecurityGroups/NRMS-zpedr2ai6dglmhenglu422"
+          },
+          "privateEndpointNetworkPolicies": "Disabled",
+          "privateLinkServiceNetworkPolicies": "Enabled",
+          "provisioningState": "Succeeded"
+        },
+        "type": "Microsoft.Network/virtualNetworks/subnets"
+      }
+    ],
+    "virtualNetworkPeerings": []
+  },
+  "type": "Microsoft.Network/virtualNetworks"
+}
+`,
+			ExpectJson: `
+{
+  "properties": {
+    "addressSpace": {
+      "addressPrefixes": [
+        "10.0.0.0/16"
+      ]
+    },
+    "dhcpOptions": {
+      "dnsServers": []
+    },
+    "subnets": [
+      {
+        "name": "default",
+        "properties": {
+          "addressPrefix": "10.0.3.0/24"
+        }
+      },
+      {
+        "etag": "W/\"5633f421-aaa4-4cf3-b9a6-40625807bd75\"",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/henglu422/providers/Microsoft.Network/virtualNetworks/henglu422/subnets/henglu422",
+        "name": "henglu422",
+        "properties": {
+          "addressPrefix": "10.0.2.0/24",
+          "delegations": [],
+          "networkSecurityGroup": {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/henglu422/providers/Microsoft.Network/networkSecurityGroups/NRMS-zpedr2ai6dglmhenglu422"
+          },
+          "privateEndpointNetworkPolicies": "Disabled",
+          "privateLinkServiceNetworkPolicies": "Enabled",
+          "provisioningState": "Succeeded"
+        },
+        "type": "Microsoft.Network/virtualNetworks/subnets"
+      }
+    ]
+  }
+}
+`,
+		},
+		{
+			OldJson: `
+{
+  "properties": {
     "compression": "None",
     "consumerGroup": "acctesteventhubcg",
     "dataFormat": "",


### PR DESCRIPTION
fixes https://github.com/Azure/terraform-provider-azapi/issues/445

This PR ignores the order of the elements in a list if the element has a name field as identifier. It also suppress the diff of the existing items between config and remote if the array in remote has more elements.

For example:

In config:

```hcl
subnets = [
{
          name = "default"
          properties = {
            addressPrefix = "10.0.3.0/24"
          }
    }
]
```

But in remote:
```hcl
subnets = [
 {
                "name": "default",
                "id": "id2,
                "etag": "W/\"d0338b06-c645-4b66-a502-3452eeca0aeb\"",
                "properties": {
                    "provisioningState": "Succeeded",
                    "addressPrefix": "10.0.3.0/24",
                    "delegations": [],
                    "privateEndpointNetworkPolicies": "Disabled",
                    "privateLinkServiceNetworkPolicies": "Enabled"
                },
                "type": "Microsoft.Network/virtualNetworks/subnets"
            },
{
                "name": "second",
                "id":"id1,
                "properties": {
                    "provisioningState": "Succeeded",
                    "addressPrefix": "10.0.4.0/24",
                    "delegations": [],
                    "privateEndpointNetworkPolicies": "Disabled",
                    "privateLinkServiceNetworkPolicies": "Enabled"
                },
                "type": "Microsoft.Network/virtualNetworks/subnets"
            }
           
]
```
This PR will make the diff of element whose name = "default" to be suppressed. It will make it easier for users to use `lifecycle.ignore_changes` to ignore the newly added element.