### PR TITLE
bugfix: null value can't pass schema validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v1.13.1
+
+BUG FIXES:
+- Fix a bug that `null` value can't pass the schema validation.
+
 ## v1.13.0
 BREAKING CHANGES:
 - Provider field `default_naming_prefix` and `default_naming_suffix` are deprecated. It will not work in this release and will be removed in the next major release.

--- a/internal/azure/types/integer_type.go
+++ b/internal/azure/types/integer_type.go
@@ -21,6 +21,9 @@ func (t *IntegerType) AsTypeBase() *TypeBase {
 }
 
 func (t *IntegerType) Validate(body interface{}, path string) []error {
+	if body == nil {
+		return nil
+	}
 	var v int
 	switch input := body.(type) {
 	case float64:

--- a/internal/azure/types/string_type.go
+++ b/internal/azure/types/string_type.go
@@ -24,6 +24,9 @@ func (s *StringType) AsTypeBase() *TypeBase {
 }
 
 func (s *StringType) Validate(body interface{}, path string) []error {
+	if body == nil {
+		return nil
+	}
 	v, ok := body.(string)
 	if !ok {
 		return []error{utils.ErrorMismatch(path, "string", fmt.Sprintf("%T", body))}


### PR DESCRIPTION
The PR fixes the validation error like the following config:

```hcl

/*
│ embedded schema validation failed: the argument "body" is invalid:
│ `properties.distribution` is invalid, expect `string` but got `<nil>`
│ `properties.infrastructure` is invalid, expect `string` but got `<nil>`
│  You can try to update `azapi` provider to the latest version or disable the validation using the feature flag `schema_validation_enabled = false` within the resource block
*/

resource "azapi_resource" "connectedCluster" {
  type = "Microsoft.Kubernetes/connectedClusters@2024-01-01"
  name      = var.aksArcName
  parent_id = var.resourceGroup.id

  body = {
    kind = "ProvisionedCluster"
    properties = {
      aadProfile = {
        adminGroupObjectIDs = flatten(var.rbacAdminGroupObjectIds)
        enableAzureRBAC     = true
        tenantID            = var.azureRBACTenantId
      }
      agentPublicKeyCertificate = "" 
      azureHybridBenefit        = null
      distribution              = null
      infrastructure            = null
      privateLinkState          = null
      provisioningState         = null
    }
  }

  identity {
    type = "SystemAssigned"
  }

  location = var.resourceGroup.location
  }

  timeouts {}
}
```