### PR TITLE
bugfix: skip setting empty tags in request body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v1.13.1
+
+BUG FIXES:
+- Fix a bug when upgrading from previous provider `azapi_resource` resource will set `tags` for resources that don't have `tags` in the configuration.
+
 ## v1.13.0
 BREAKING CHANGES:
 - Provider field `default_naming_prefix` and `default_naming_suffix` are deprecated. It will not work in this release and will be removed in the next major release.

--- a/internal/services/azapi_resource.go
+++ b/internal/services/azapi_resource.go
@@ -909,7 +909,7 @@ func expandBody(body map[string]interface{}, model AzapiResourceModel) diag.Diag
 	if body["location"] == nil && !model.Location.IsNull() && !model.Location.IsUnknown() {
 		body["location"] = model.Location.ValueString()
 	}
-	if body["tags"] == nil && !model.Tags.IsNull() && !model.Tags.IsUnknown() {
+	if body["tags"] == nil && !model.Tags.IsNull() && !model.Tags.IsUnknown() && len(model.Tags.Elements()) != 0 {
 		body["tags"] = tags.ExpandTags(model.Tags)
 	}
 	if body["identity"] == nil && !model.Identity.IsNull() && !model.Identity.IsUnknown() {


### PR DESCRIPTION
fixes https://github.com/Azure/terraform-provider-azapi/issues/462

In the following function, to suppress the diff of config: tags = null and state: tags = {}, it'll set plan.tags to {} even if it's not defined in config when upgrading from previous provider.

And this will fail the schema validation if the resource doesn't support "tags". And bypassing the validation won't mitigate this, because the empty tags will be set in the request body and user will get a bad request error.

The fix is adding tags to the request body only if it's not empty.

https://github.com/Azure/terraform-provider-azapi/blob/192e61be293b5e71814063e57c96ca7dd7e5024c/internal/services/azapi_resource.go#L858-L880