### PR TITLE
bugfix: skip validating the float number in the body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v1.13.1
+
+BUG FIXES:
+- Fix a bug that schema validation fails to validate the float number in the body.
+
 ## v1.13.0
 BREAKING CHANGES:
 - Provider field `default_naming_prefix` and `default_naming_suffix` are deprecated. It will not work in this release and will be removed in the next major release.

--- a/internal/azure/types/integer_type.go
+++ b/internal/azure/types/integer_type.go
@@ -23,7 +23,7 @@ func (t *IntegerType) Validate(body interface{}, path string) []error {
 	switch input := body.(type) {
 	case float64, float32:
 		// TODO: skip validation for now because of the following issue:
-		// the bicep-types-az parses double as integer type and it should be fixed: https://github.com/Azure/bicep-types-az/issues/1404
+		// the bicep-types-az parses float as integer type and it should be fixed: https://github.com/Azure/bicep-types-az/issues/1404
 		return nil
 	case int64:
 		v = int(input)

--- a/internal/azure/types/integer_type.go
+++ b/internal/azure/types/integer_type.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"fmt"
+
 	"github.com/Azure/terraform-provider-azapi/internal/azure/utils"
 )
 

--- a/internal/azure/types/integer_type.go
+++ b/internal/azure/types/integer_type.go
@@ -2,8 +2,6 @@ package types
 
 import (
 	"fmt"
-	"math"
-
 	"github.com/Azure/terraform-provider-azapi/internal/azure/utils"
 )
 
@@ -23,16 +21,10 @@ func (t *IntegerType) AsTypeBase() *TypeBase {
 func (t *IntegerType) Validate(body interface{}, path string) []error {
 	var v int
 	switch input := body.(type) {
-	case float64:
-		if math.Round(input) != input {
-			return []error{utils.ErrorMismatch(path, "integer", fmt.Sprintf("%T", body))}
-		}
-		v = int(input)
-	case float32:
-		if math.Round(float64(input)) != float64(input) {
-			return []error{utils.ErrorMismatch(path, "integer", fmt.Sprintf("%T", body))}
-		}
-		v = int(input)
+	case float64, float32:
+		// TODO: skip validation for now because of the following issue:
+		// the bicep-types-az parses double as integer type and it should be fixed: https://github.com/Azure/bicep-types-az/issues/1404
+		return nil
 	case int64:
 		v = int(input)
 	case int32:

--- a/internal/azure/validator_test.go
+++ b/internal/azure/validator_test.go
@@ -187,7 +187,10 @@ func Test_BodyValidation(t *testing.T) {
     }
 }
 `,
-			Error: true,
+			// TODO: change the error to true once the validation is enabled
+			// the validation is disabled for now, because of the following issue:
+			// the bicep-types-az parses float as integer type and it should be fixed: https://github.com/Azure/bicep-types-az/issues/1404
+			Error: false,
 		},
 	}
 


### PR DESCRIPTION
fixes https://github.com/Azure/terraform-provider-azapi/issues/468

It's a dependency issue because it parses double as integer type. We'll skip the validation if the number is float.