### PR TITLE
add upgrade tests to detect breaking changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ BUG FIXES:
 - Fix a bug that schema validation fails to validate the float number in the body.
 - Fix a bug that client certificate authentication doesn't work.
 - Fix a bug that auxiliary tenant ids are not passed to the client.
+- Fix a bug that `azapi_resource_action` resource shows the plan diff when upgrading from the previous provider.
 
 ## v1.13.0
 BREAKING CHANGES:

--- a/internal/acceptance/steps.go
+++ b/internal/acceptance/steps.go
@@ -30,6 +30,25 @@ func (td TestData) ImportStep(ignore ...string) resource.TestStep {
 	return td.ImportStepFor(td.ResourceName, ignore...)
 }
 
+// ImportStep returns a Test Step which Imports the Resource, optionally
+// ignoring any fields which may not be imported (for example, as they're
+// not returned from the API)
+func (td TestData) ImportStepWithImportStateIdFunc(importStateIdFunc resource.ImportStateIdFunc, ignore ...string) resource.TestStep {
+	resourceName := td.ResourceName
+	step := resource.TestStep{
+		ResourceName:      resourceName,
+		ImportState:       true,
+		ImportStateVerify: true,
+		ImportStateIdFunc: importStateIdFunc,
+	}
+
+	if len(ignore) > 0 {
+		step.ImportStateVerifyIgnore = ignore
+	}
+
+	return step
+}
+
 // ImportStepFor returns a Test Step which Imports a given resource by name,
 // optionally ignoring any fields which may not be imported (for example, as they're
 // not returned from the API)

--- a/internal/services/azapi_data_plane_resource_test.go
+++ b/internal/services/azapi_data_plane_resource_test.go
@@ -134,6 +134,7 @@ resource "azurerm_app_configuration" "appconf" {
   name                = "acctest%[2]s"
   resource_group_name = azurerm_resource_group.example.name
   location            = azurerm_resource_group.example.location
+  sku                 = "standard"
 }
 
 data "azurerm_client_config" "current" {}

--- a/internal/services/azapi_data_plane_resource_upgrade_test.go
+++ b/internal/services/azapi_data_plane_resource_upgrade_test.go
@@ -1,0 +1,94 @@
+package services_test
+
+import (
+	"testing"
+
+	"github.com/Azure/terraform-provider-azapi/internal/acceptance"
+	"github.com/Azure/terraform-provider-azapi/internal/acceptance/check"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccAzapiDataPlaneResourceUpgrade_appConfigKeyValues(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azapi_data_plane_resource", "test")
+	r := DataPlaneResource{}
+
+	data.UpgradeTest(t, r, []resource.TestStep{
+		data.UpgradeTestDeployStep(resource.TestStep{
+			Config: r.appConfigKeyValues(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		}, PreviousVersion),
+		data.UpgradeTestPlanStep(resource.TestStep{
+			Config: r.appConfigKeyValues(data),
+		}),
+	})
+}
+
+func TestAccAzapiDataPlaneResourceUpgrade_purviewClassification(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azapi_data_plane_resource", "test")
+	r := DataPlaneResource{}
+
+	data.UpgradeTest(t, r, []resource.TestStep{
+		data.UpgradeTestDeployStep(resource.TestStep{
+			Config: r.purviewClassification(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		}, PreviousVersion),
+		data.UpgradeTestPlanStep(resource.TestStep{
+			Config: r.purviewClassification(data),
+		}),
+	})
+}
+
+func TestAccAzapiDataPlaneResourceUpgrade_purviewCollection(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azapi_data_plane_resource", "test")
+	r := DataPlaneResource{}
+
+	data.UpgradeTest(t, r, []resource.TestStep{
+		data.UpgradeTestDeployStep(resource.TestStep{
+			Config: r.purviewCollection(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		}, PreviousVersion),
+		data.UpgradeTestPlanStep(resource.TestStep{
+			Config: r.purviewCollection(data),
+		}),
+	})
+}
+
+func TestAccAzapiDataPlaneResourceUpgrade_keyVaultIssuer(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azapi_data_plane_resource", "test")
+	r := DataPlaneResource{}
+
+	data.UpgradeTest(t, r, []resource.TestStep{
+		data.UpgradeTestDeployStep(resource.TestStep{
+			Config: r.keyVaultIssuer(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		}, PreviousVersion),
+		data.UpgradeTestPlanStep(resource.TestStep{
+			Config: r.keyVaultIssuer(data),
+		}),
+	})
+}
+
+func TestAccAzapiDataPlaneResourceUpgrade_iotAppsUser(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azapi_data_plane_resource", "test")
+	r := DataPlaneResource{}
+
+	data.UpgradeTest(t, r, []resource.TestStep{
+		data.UpgradeTestDeployStep(resource.TestStep{
+			Config: r.iotAppsUser(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		}, PreviousVersion),
+		data.UpgradeTestPlanStep(resource.TestStep{
+			Config: r.iotAppsUser(data),
+		}),
+	})
+}

--- a/internal/services/azapi_resource.go
+++ b/internal/services/azapi_resource.go
@@ -897,6 +897,10 @@ func (r *AzapiResource) locationWithDefaultLocation(config types.String, body ma
 					return state.Location
 				}
 			}
+		// To suppress the diff of config: location = null and state: location = ""
+		// This case happens when upgrading resources which doesn't support location from terraform-plugin-sdk built azapi provider
+		case state != nil && !state.Location.IsUnknown() && state.Location.ValueString() == "":
+			return state.Location
 		}
 	}
 	return config
@@ -906,7 +910,7 @@ func expandBody(body map[string]interface{}, model AzapiResourceModel) diag.Diag
 	if body == nil {
 		return diag.Diagnostics{}
 	}
-	if body["location"] == nil && !model.Location.IsNull() && !model.Location.IsUnknown() {
+	if body["location"] == nil && !model.Location.IsNull() && !model.Location.IsUnknown() && len(model.Location.ValueString()) != 0 {
 		body["location"] = model.Location.ValueString()
 	}
 	if body["tags"] == nil && !model.Tags.IsNull() && !model.Tags.IsUnknown() && len(model.Tags.Elements()) != 0 {

--- a/internal/services/azapi_resource_action_resource.go
+++ b/internal/services/azapi_resource_action_resource.go
@@ -116,8 +116,6 @@ func (r *ActionResource) Schema(ctx context.Context, request resource.SchemaRequ
 			// TODO: Remove the support for JSON string in the next major release
 			"body": schema.DynamicAttribute{
 				Optional: true,
-				Computed: true,
-				Default:  defaults.DynamicDefault(types.StringValue("{}")),
 				Validators: []validator.Dynamic{
 					myvalidator.BodyValidator(),
 				},
@@ -238,7 +236,16 @@ func (r *ActionResource) Delete(ctx context.Context, request resource.DeleteRequ
 }
 
 func (r *ActionResource) Read(ctx context.Context, request resource.ReadRequest, response *resource.ReadResponse) {
+	var state ActionResourceModel
+	if response.Diagnostics.Append(request.State.Get(ctx, &state)...); response.Diagnostics.HasError() {
+		return
+	}
 
+	if state.When.IsNull() {
+		state.When = basetypes.NewStringValue("apply")
+	}
+
+	response.Diagnostics.Append(response.State.Set(ctx, state)...)
 }
 
 func (r *ActionResource) Action(ctx context.Context, model ActionResourceModel, state *tfsdk.State, diagnostics *diag.Diagnostics) {

--- a/internal/services/azapi_resource_action_resource_test.go
+++ b/internal/services/azapi_resource_action_resource_test.go
@@ -1,14 +1,22 @@
 package services_test
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
 	"github.com/Azure/terraform-provider-azapi/internal/acceptance"
+	"github.com/Azure/terraform-provider-azapi/internal/clients"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 type ActionResource struct{}
+
+func (r ActionResource) Exists(ctx context.Context, client *clients.Client, state *terraform.InstanceState) (*bool, error) {
+	out := false
+	return &out, nil
+}
 
 func TestAccActionResource_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azapi_resource_action", "test")
@@ -109,7 +117,7 @@ resource "azapi_resource_action" "test" {
     data.azapi_resource_action.list
   ]
 }
-`, GenericResource{}.defaultTag(data))
+`, GenericResource{}.identityNone(data))
 }
 
 func (r ActionResource) basicWhenDestroy(data acceptance.TestData) string {
@@ -136,7 +144,7 @@ resource "azapi_resource_action" "test" {
   ]
   response_export_values = ["*"]
 }
-`, GenericResource{}.defaultTag(data))
+`, GenericResource{}.identityNone(data))
 }
 
 func (r ActionResource) registerResourceProvider() string {
@@ -262,9 +270,5 @@ resource "azapi_resource_action" "test" {
     }
   })
 }
-
-
-
-
-`, data.LocationPrimary, data.RandomStringOfLength(10))
+`, data.LocationPrimary, data.RandomString)
 }

--- a/internal/services/azapi_resource_action_resource_upgrade_test.go
+++ b/internal/services/azapi_resource_action_resource_upgrade_test.go
@@ -1,0 +1,83 @@
+package services_test
+
+import (
+	"testing"
+
+	"github.com/Azure/terraform-provider-azapi/internal/acceptance"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccAzapiActionResourceUpgrade_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azapi_resource_action", "test")
+	r := ActionResource{}
+
+	data.UpgradeTest(t, r, []resource.TestStep{
+		data.UpgradeTestDeployStep(resource.TestStep{
+			Config: r.basic(data),
+			Check:  resource.ComposeTestCheckFunc(),
+		}, PreviousVersion),
+		data.UpgradeTestPlanStep(resource.TestStep{
+			Config: r.basic(data),
+		}),
+	})
+}
+
+func TestAccAzapiActionResourceUpgrade_basicWhenDestroy(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azapi_resource_action", "test")
+	r := ActionResource{}
+
+	data.UpgradeTest(t, r, []resource.TestStep{
+		data.UpgradeTestDeployStep(resource.TestStep{
+			Config: r.basicWhenDestroy(data),
+			Check:  resource.ComposeTestCheckFunc(),
+		}, PreviousVersion),
+		data.UpgradeTestPlanStep(resource.TestStep{
+			Config: r.basicWhenDestroy(data),
+		}),
+	})
+}
+
+func TestAccAzapiActionResourceUpgrade_registerResourceProvider(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azapi_resource_action", "test")
+	r := ActionResource{}
+
+	data.UpgradeTest(t, r, []resource.TestStep{
+		data.UpgradeTestDeployStep(resource.TestStep{
+			Config: r.registerResourceProvider(),
+			Check:  resource.ComposeTestCheckFunc(),
+		}, PreviousVersion),
+		data.UpgradeTestPlanStep(resource.TestStep{
+			Config: r.registerResourceProvider(),
+		}),
+	})
+}
+
+func TestAccAzapiActionResourceUpgrade_providerAction(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azapi_resource_action", "test")
+	r := ActionResource{}
+
+	data.UpgradeTest(t, r, []resource.TestStep{
+		data.UpgradeTestDeployStep(resource.TestStep{
+			Config: r.providerAction(),
+			Check:  resource.ComposeTestCheckFunc(),
+		}, PreviousVersion),
+		data.UpgradeTestPlanStep(resource.TestStep{
+			Config: r.providerAction(),
+		}),
+	})
+}
+
+func TestAccAzapiActionResourceUpgrade_nonstandardLRO(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azapi_resource_action", "test")
+	r := ActionResource{}
+
+	data.UpgradeTest(t, r, []resource.TestStep{
+		data.UpgradeTestDeployStep(resource.TestStep{
+			Config: r.nonstandardLRO(data),
+			Check:  resource.ComposeTestCheckFunc(),
+		}, PreviousVersion),
+		data.UpgradeTestPlanStep(resource.TestStep{
+			Config: r.nonstandardLRO(data),
+		}),
+	})
+}

--- a/internal/services/azapi_resource_action_resource_upgrade_test.go
+++ b/internal/services/azapi_resource_action_resource_upgrade_test.go
@@ -52,6 +52,21 @@ func TestAccAzapiActionResourceUpgrade_registerResourceProvider(t *testing.T) {
 	})
 }
 
+func TestAccAzapiActionResourceUpgrade_upgradeFromVeryOldVersion(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azapi_resource_action", "test")
+	r := ActionResource{}
+
+	data.UpgradeTest(t, r, []resource.TestStep{
+		data.UpgradeTestDeployStep(resource.TestStep{
+			Config: r.registerResourceProvider(),
+			Check:  resource.ComposeTestCheckFunc(),
+		}, "1.8.0"),
+		data.UpgradeTestPlanStep(resource.TestStep{
+			Config: r.registerResourceProvider(),
+		}),
+	})
+}
+
 func TestAccAzapiActionResourceUpgrade_providerAction(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azapi_resource_action", "test")
 	r := ActionResource{}

--- a/internal/services/azapi_resource_test.go
+++ b/internal/services/azapi_resource_test.go
@@ -282,7 +282,7 @@ func TestAccGenericResource_defaultParentId(t *testing.T) {
 				check.That(data.ResourceName).Key("parent_id").HasValue(fmt.Sprintf("/subscriptions/%s", subscriptionId)),
 			),
 		},
-		data.ImportStep(defaultIgnores()...),
+		data.ImportStepWithImportStateIdFunc(r.ImportIdFunc, defaultIgnores()...),
 	})
 }
 
@@ -338,7 +338,7 @@ func TestAccGenericResource_subscriptionScope(t *testing.T) {
 				check.That(data.ResourceName).Key("location").HasValue(location.Normalize(data.LocationPrimary)),
 			),
 		},
-		data.ImportStep(defaultIgnores()...),
+		data.ImportStepWithImportStateIdFunc(r.ImportIdFunc, defaultIgnores()...),
 	})
 }
 
@@ -370,7 +370,7 @@ func TestAccGenericResource_ignoreMissingProperty(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep(defaultIgnores()...),
+		data.ImportStepWithImportStateIdFunc(r.ImportIdFunc, defaultIgnores()...),
 	})
 }
 
@@ -415,7 +415,7 @@ func TestAccGenericResource_locks(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep(defaultIgnores()...),
+		data.ImportStepWithImportStateIdFunc(r.ImportIdFunc, defaultIgnores()...),
 	})
 }
 
@@ -962,7 +962,7 @@ provider "azapi" {
 }
 
 resource "azapi_resource" "test" {
-  type     = "Microsoft.Resources/resourceGroups@2024-03-01"
+  type     = "Microsoft.Resources/resourceGroups@2023-07-01"
   name     = "acctest-%[2]d"
   location = "%[1]s"
 }
@@ -1080,7 +1080,7 @@ provider "azurerm" {
 }
 
 resource "azapi_resource" "test" {
-  type      = "Microsoft.Resources/resourceGroups@2024-03-01"
+  type      = "Microsoft.Resources/resourceGroups@2023-07-01"
   name      = "acctestRG-%[1]d"
   parent_id = "/subscriptions/%[2]s"
 
@@ -1094,7 +1094,7 @@ func (r GenericResource) extensionScope(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %[1]s
 
-resource "azapi_resource" "locks" {
+resource "azapi_resource" "test" {
   type      = "Microsoft.Authorization/locks@2015-01-01"
   name      = "acctest-%[2]d"
   parent_id = azurerm_resource_group.test.id
@@ -1127,7 +1127,7 @@ resource "azurerm_spring_cloud_service" "test" {
 }
 
 resource "azapi_resource" "test" {
-  type      = "Microsoft.AppPlatform/spring/storages@2024-05-01-preview"
+  type      = "Microsoft.AppPlatform/spring/storages@2023-12-01"
   name      = "acctest-ss-%[2]d"
   parent_id = azurerm_spring_cloud_service.test.id
 
@@ -1141,7 +1141,7 @@ resource "azapi_resource" "test" {
 
   ignore_missing_property = true
 }
-`, r.template(data), data.RandomInteger, data.RandomStringOfLength(10))
+`, r.template(data), data.RandomInteger, data.RandomString)
 }
 
 func (r GenericResource) ignoreCasing(data acceptance.TestData) string {
@@ -1179,7 +1179,7 @@ resource "azapi_resource" "test" {
   ignore_casing             = true
   ignore_missing_property   = true
 }
-`, r.template(data), data.RandomInteger, data.RandomStringOfLength(10))
+`, r.template(data), data.RandomInteger, data.RandomString)
 }
 
 func (r GenericResource) deleteLROEndsWithNotFoundError(data acceptance.TestData) string {
@@ -1198,7 +1198,7 @@ resource "azapi_resource" "test" {
   })
 }
 
-`, r.template(data), data.RandomInteger, data.RandomStringOfLength(10))
+`, r.template(data), data.RandomInteger, data.RandomString)
 }
 
 func (r GenericResource) locks(data acceptance.TestData) string {
@@ -1213,7 +1213,7 @@ resource "azurerm_route_table" "test" {
 }
 
 resource "azapi_resource" "test" {
-  type      = "Microsoft.Network/routeTables/routes@2023-11-01"
+  type      = "Microsoft.Network/routeTables/routes@2023-09-01"
   name      = "first%[2]d"
   parent_id = azurerm_route_table.test.id
   body = jsonencode({
@@ -1227,7 +1227,7 @@ resource "azapi_resource" "test" {
 }
 
 resource "azapi_resource" "test2" {
-  type      = "Microsoft.Network/routeTables/routes@2023-11-01"
+  type      = "Microsoft.Network/routeTables/routes@2023-09-01"
   name      = "second%[2]d"
   parent_id = azurerm_route_table.test.id
   body = jsonencode({
@@ -1239,7 +1239,7 @@ resource "azapi_resource" "test2" {
 
   locks = [azurerm_route_table.test.id, azurerm_resource_group.test.id]
 }
-`, r.template(data), data.RandomInteger, data.RandomStringOfLength(10))
+`, r.template(data), data.RandomInteger, data.RandomString)
 }
 
 func (r GenericResource) secretsInAsterisks(data acceptance.TestData, clientId, clientSecret string) string {
@@ -1280,7 +1280,7 @@ resource "azapi_resource" "test" {
   })
   ignore_casing = true
 }
-`, r.template(data), data.RandomInteger, data.RandomStringOfLength(10), clientId, clientSecret)
+`, r.template(data), data.RandomInteger, data.RandomString, clientId, clientSecret)
 }
 
 func (r GenericResource) ignoreChanges(data acceptance.TestData) string {
@@ -1304,7 +1304,7 @@ resource "azapi_resource" "test" {
 }
 
 
-`, r.template(data), data.RandomInt())
+`, r.template(data), data.RandomInteger)
 }
 
 func (r GenericResource) ignoreChangesArray(data acceptance.TestData) string {
@@ -1350,7 +1350,7 @@ resource "azapi_resource" "subnet" {
   schema_validation_enabled = false
   response_export_values    = ["*"]
 }
-`, r.template(data), data.RandomInt())
+`, r.template(data), data.RandomInteger)
 }
 
 func (r GenericResource) nonstandardLRO(data acceptance.TestData) string {
@@ -1401,7 +1401,7 @@ resource "azapi_resource" "test" {
     }
   })
 }
-`, r.template(data), data.RandomStringOfLength(10))
+`, r.template(data), data.RandomString)
 }
 
 func (GenericResource) template(data acceptance.TestData) string {
@@ -1414,5 +1414,5 @@ resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%[1]d"
   location = "%[2]s"
 }
-`, data.RandomInteger, data.LocationPrimary, data.RandomStringOfLength(10))
+`, data.RandomInteger, data.LocationPrimary, data.RandomString)
 }

--- a/internal/services/azapi_resource_upgrade_test.go
+++ b/internal/services/azapi_resource_upgrade_test.go
@@ -1,0 +1,482 @@
+package services_test
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/Azure/terraform-provider-azapi/internal/acceptance"
+	"github.com/Azure/terraform-provider-azapi/internal/acceptance/check"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+const PreviousVersion = "1.12.0"
+
+func TestAccAzapiResourceUpgrade_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azapi_resource", "test")
+	r := GenericResource{}
+
+	data.UpgradeTest(t, r, []resource.TestStep{
+		data.UpgradeTestDeployStep(resource.TestStep{
+			Config: r.basic(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		}, PreviousVersion),
+		data.UpgradeTestPlanStep(resource.TestStep{
+			Config: r.basic(data),
+		}),
+	})
+}
+
+func TestAccAzapiResourceUpgrade_complete(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azapi_resource", "test")
+	r := GenericResource{}
+
+	data.UpgradeTest(t, r, []resource.TestStep{
+		data.UpgradeTestDeployStep(resource.TestStep{
+			Config: r.complete(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		}, PreviousVersion),
+		data.UpgradeTestPlanStep(resource.TestStep{
+			Config: r.complete(data),
+		}),
+	})
+}
+
+func TestAccAzapiResourceUpgrade_identityNone(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azapi_resource", "test")
+	r := GenericResource{}
+
+	data.UpgradeTest(t, r, []resource.TestStep{
+		data.UpgradeTestDeployStep(resource.TestStep{
+			Config: r.identityNone(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		}, PreviousVersion),
+		data.UpgradeTestPlanStep(resource.TestStep{
+			Config: r.identityNone(data),
+		}),
+	})
+}
+
+func TestAccAzapiResourceUpgrade_identitySystemAssigned(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azapi_resource", "test")
+	r := GenericResource{}
+
+	updatedConfig := strings.ReplaceAll(r.identitySystemAssigned(data),
+		`  identity {
+    type = "SystemAssigned"
+  }`,
+		`  identity {
+    type = "SystemAssigned"
+    identity_ids = []
+  }`)
+
+	data.UpgradeTest(t, r, []resource.TestStep{
+		data.UpgradeTestDeployStep(resource.TestStep{
+			Config: r.identitySystemAssigned(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		}, PreviousVersion),
+		data.UpgradeTestPlanStep(resource.TestStep{
+			Config: updatedConfig,
+		}),
+	})
+}
+
+func TestAccAzapiResourceUpgrade_identityUserAssigned(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azapi_resource", "test")
+	r := GenericResource{}
+
+	data.UpgradeTest(t, r, []resource.TestStep{
+		data.UpgradeTestDeployStep(resource.TestStep{
+			Config: r.identityUserAssigned(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		}, PreviousVersion),
+		data.UpgradeTestPlanStep(resource.TestStep{
+			Config: r.identityUserAssigned(data),
+		}),
+	})
+}
+
+func TestAccAzapiResourceUpgrade_completeBody(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azapi_resource", "test")
+	r := GenericResource{}
+
+	data.UpgradeTest(t, r, []resource.TestStep{
+		data.UpgradeTestDeployStep(resource.TestStep{
+			Config: r.completeBody(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		}, PreviousVersion),
+		data.UpgradeTestPlanStep(resource.TestStep{
+			Config: r.completeBody(data),
+			// It's a known breaking change that identity in the body will not be synced to the top-level identity block
+			ExpectNonEmptyPlan: true,
+		}),
+	})
+}
+
+func TestAccAzapiResourceUpgrade_defaultTag(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azapi_resource", "test")
+	r := GenericResource{}
+
+	updatedConfig := strings.ReplaceAll(r.defaultTag(data),
+		`  identity {
+    type = "SystemAssigned"
+  }`,
+		`  identity {
+    type = "SystemAssigned"
+    identity_ids = []
+  }`)
+
+	data.UpgradeTest(t, r, []resource.TestStep{
+		data.UpgradeTestDeployStep(resource.TestStep{
+			Config: r.defaultTag(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		}, PreviousVersion),
+		data.UpgradeTestPlanStep(resource.TestStep{
+			Config: updatedConfig,
+		}),
+	})
+}
+
+func TestAccAzapiResourceUpgrade_defaultTagOverrideInBody(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azapi_resource", "test")
+	r := GenericResource{}
+
+	updatedConfig := strings.ReplaceAll(r.defaultTagOverrideInBody(data),
+		`  identity {
+    type = "SystemAssigned"
+  }`,
+		`  identity {
+    type = "SystemAssigned"
+    identity_ids = []
+  }`)
+
+	data.UpgradeTest(t, r, []resource.TestStep{
+		data.UpgradeTestDeployStep(resource.TestStep{
+			Config: r.defaultTagOverrideInBody(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		}, PreviousVersion),
+		data.UpgradeTestPlanStep(resource.TestStep{
+			Config: updatedConfig,
+		}),
+	})
+}
+
+func TestAccAzapiResourceUpgrade_defaultTagOverrideInHcl(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azapi_resource", "test")
+	r := GenericResource{}
+
+	updatedConfig := strings.ReplaceAll(r.defaultTagOverrideInHcl(data),
+		`  identity {
+    type = "SystemAssigned"
+  }`,
+		`  identity {
+    type = "SystemAssigned"
+    identity_ids = []
+  }`)
+
+	data.UpgradeTest(t, r, []resource.TestStep{
+		data.UpgradeTestDeployStep(resource.TestStep{
+			Config: r.defaultTagOverrideInHcl(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		}, PreviousVersion),
+		data.UpgradeTestPlanStep(resource.TestStep{
+			Config: updatedConfig,
+		}),
+	})
+}
+
+func TestAccAzapiResourceUpgrade_defaultLocation(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azapi_resource", "test")
+	r := GenericResource{}
+
+	updatedConfig := strings.ReplaceAll(r.defaultLocation(data),
+		`  identity {
+    type = "SystemAssigned"
+  }`,
+		`  identity {
+    type = "SystemAssigned"
+    identity_ids = []
+  }`)
+
+	data.UpgradeTest(t, r, []resource.TestStep{
+		data.UpgradeTestDeployStep(resource.TestStep{
+			Config: r.defaultLocation(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		}, PreviousVersion),
+		data.UpgradeTestPlanStep(resource.TestStep{
+			Config: updatedConfig,
+		}),
+	})
+}
+
+func TestAccAzapiResourceUpgrade_defaultLocationOverrideInHcl(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azapi_resource", "test")
+	r := GenericResource{}
+
+	updatedConfig := strings.ReplaceAll(r.defaultLocationOverrideInHcl(data),
+		`  identity {
+    type = "SystemAssigned"
+  }`,
+		`  identity {
+    type = "SystemAssigned"
+    identity_ids = []
+  }`)
+
+	data.UpgradeTest(t, r, []resource.TestStep{
+		data.UpgradeTestDeployStep(resource.TestStep{
+			Config: r.defaultLocationOverrideInHcl(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		}, PreviousVersion),
+		data.UpgradeTestPlanStep(resource.TestStep{
+			Config: updatedConfig,
+		}),
+	})
+}
+
+func TestAccAzapiResourceUpgrade_defaultParentId(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azapi_resource", "test")
+	r := GenericResource{}
+
+	data.UpgradeTest(t, r, []resource.TestStep{
+		data.UpgradeTestDeployStep(resource.TestStep{
+			Config: r.defaultParentId(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		}, PreviousVersion),
+		data.UpgradeTestPlanStep(resource.TestStep{
+			Config: r.defaultParentId(data),
+		}),
+	})
+}
+
+func TestAccAzapiResourceUpgrade_defaultNaming(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azapi_resource", "test")
+	r := GenericResource{}
+
+	data.UpgradeTest(t, r, []resource.TestStep{
+		data.UpgradeTestDeployStep(resource.TestStep{
+			Config: r.defaultNaming(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		}, PreviousVersion),
+		data.UpgradeTestPlanStep(resource.TestStep{
+			Config: r.defaultNaming(data),
+		}),
+	})
+}
+
+func TestAccAzapiResourceUpgrade_defaultNamingOverrideInHcl(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azapi_resource", "test")
+	r := GenericResource{}
+
+	data.UpgradeTest(t, r, []resource.TestStep{
+		data.UpgradeTestDeployStep(resource.TestStep{
+			Config: r.defaultNamingOverrideInHcl(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		}, PreviousVersion),
+		data.UpgradeTestPlanStep(resource.TestStep{
+			Config: r.defaultNamingOverrideInHcl(data),
+		}),
+	})
+}
+
+func TestAccAzapiResourceUpgrade_defaultsNotApplicable(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azapi_resource", "test")
+	r := GenericResource{}
+
+	data.UpgradeTest(t, r, []resource.TestStep{
+		data.UpgradeTestDeployStep(resource.TestStep{
+			Config: r.defaultsNotApplicable(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		}, PreviousVersion),
+		data.UpgradeTestPlanStep(resource.TestStep{
+			Config: r.defaultsNotApplicable(data),
+		}),
+	})
+}
+
+func TestAccAzapiResourceUpgrade_subscriptionScope(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azapi_resource", "test")
+	r := GenericResource{}
+
+	subscriptionId := os.Getenv("ARM_SUBSCRIPTION_ID")
+
+	data.UpgradeTest(t, r, []resource.TestStep{
+		data.UpgradeTestDeployStep(resource.TestStep{
+			Config: r.subscriptionScope(data, subscriptionId),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		}, PreviousVersion),
+		data.UpgradeTestPlanStep(resource.TestStep{
+			Config: r.subscriptionScope(data, subscriptionId),
+		}),
+	})
+}
+
+func TestAccAzapiResourceUpgrade_extensionScope(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azapi_resource", "test")
+	r := GenericResource{}
+
+	data.UpgradeTest(t, r, []resource.TestStep{
+		data.UpgradeTestDeployStep(resource.TestStep{
+			Config: r.extensionScope(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		}, PreviousVersion),
+		data.UpgradeTestPlanStep(resource.TestStep{
+			Config: r.extensionScope(data),
+		}),
+	})
+}
+
+func TestAccAzapiResourceUpgrade_ignoreMissingProperty(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azapi_resource", "test")
+	r := GenericResource{}
+
+	data.UpgradeTest(t, r, []resource.TestStep{
+		data.UpgradeTestDeployStep(resource.TestStep{
+			Config: r.ignoreMissingProperty(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		}, PreviousVersion),
+		data.UpgradeTestPlanStep(resource.TestStep{
+			Config: r.ignoreMissingProperty(data),
+		}),
+	})
+}
+
+func TestAccAzapiResourceUpgrade_ignoreCasing(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azapi_resource", "test")
+	r := GenericResource{}
+
+	data.UpgradeTest(t, r, []resource.TestStep{
+		data.UpgradeTestDeployStep(resource.TestStep{
+			Config: r.ignoreCasing(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		}, PreviousVersion),
+		data.UpgradeTestPlanStep(resource.TestStep{
+			Config: r.ignoreCasing(data),
+		}),
+	})
+}
+
+func TestAccAzapiResourceUpgrade_deleteLROEndsWithNotFoundError(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azapi_resource", "test")
+	r := GenericResource{}
+
+	data.UpgradeTest(t, r, []resource.TestStep{
+		data.UpgradeTestDeployStep(resource.TestStep{
+			Config: r.deleteLROEndsWithNotFoundError(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		}, PreviousVersion),
+		data.UpgradeTestPlanStep(resource.TestStep{
+			Config: r.deleteLROEndsWithNotFoundError(data),
+		}),
+	})
+}
+
+func TestAccAzapiResourceUpgrade_locks(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azapi_resource", "test")
+	r := GenericResource{}
+
+	data.UpgradeTest(t, r, []resource.TestStep{
+		data.UpgradeTestDeployStep(resource.TestStep{
+			Config: r.locks(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		}, PreviousVersion),
+		data.UpgradeTestPlanStep(resource.TestStep{
+			Config: r.locks(data),
+		}),
+	})
+}
+
+func TestAccAzapiResourceUpgrade_secretsInAsterisks(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azapi_resource", "test")
+	r := GenericResource{}
+
+	clientId := os.Getenv("ARM_CLIENT_ID")
+	clientSecret := os.Getenv("ARM_CLIENT_SECRET")
+
+	data.UpgradeTest(t, r, []resource.TestStep{
+		data.UpgradeTestDeployStep(resource.TestStep{
+			Config: r.secretsInAsterisks(data, clientId, clientSecret),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		}, PreviousVersion),
+		data.UpgradeTestPlanStep(resource.TestStep{
+			Config: r.secretsInAsterisks(data, clientId, clientSecret),
+		}),
+	})
+}
+
+func TestAccAzapiResourceUpgrade_ignoreChanges(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azapi_resource", "test")
+	r := GenericResource{}
+
+	data.UpgradeTest(t, r, []resource.TestStep{
+		data.UpgradeTestDeployStep(resource.TestStep{
+			Config: r.ignoreChanges(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		}, PreviousVersion),
+		data.UpgradeTestPlanStep(resource.TestStep{
+			Config: r.ignoreChanges(data),
+		}),
+	})
+}
+
+func TestAccAzapiResourceUpgrade_ignoreChangesArray(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azapi_resource", "test")
+	r := GenericResource{}
+
+	data.UpgradeTest(t, r, []resource.TestStep{
+		data.UpgradeTestDeployStep(resource.TestStep{
+			Config: r.ignoreChangesArray(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		}, PreviousVersion),
+		data.UpgradeTestPlanStep(resource.TestStep{
+			Config: r.ignoreChangesArray(data),
+		}),
+	})
+}

--- a/internal/services/azapi_update_resource_test.go
+++ b/internal/services/azapi_update_resource_test.go
@@ -182,7 +182,7 @@ resource "azapi_update_resource" "test" {
     }
   })
 }
-`, r.template(data), data.RandomStringOfLength(5))
+`, r.template(data), data.RandomString)
 }
 
 func (r GenericUpdateResource) dynamicSchema(data acceptance.TestData) string {
@@ -205,7 +205,7 @@ resource "azapi_update_resource" "test" {
     }
   }
 }
-`, r.template(data), data.RandomStringOfLength(5))
+`, r.template(data), data.RandomString)
 }
 
 func (r GenericUpdateResource) automationAccountWithNameParentId(data acceptance.TestData) string {
@@ -229,7 +229,7 @@ resource "azapi_update_resource" "test" {
     }
   })
 }
-`, r.template(data), data.RandomStringOfLength(5))
+`, r.template(data), data.RandomString)
 }
 
 func (r GenericUpdateResource) siteConfigSlotConfigNames(data acceptance.TestData) string {
@@ -281,7 +281,7 @@ resource "azapi_update_resource" "test" {
     }
   })
 }
-`, r.template(data), data.RandomStringOfLength(5))
+`, r.template(data), data.RandomString)
 }
 
 func (r GenericUpdateResource) locks(data acceptance.TestData) string {
@@ -316,7 +316,7 @@ resource "azapi_update_resource" "test" {
   })
   locks = [azurerm_automation_account.test.id]
 }
-`, r.template(data), data.RandomStringOfLength(5))
+`, r.template(data), data.RandomString)
 }
 
 func (r GenericUpdateResource) ignoreChanges(data acceptance.TestData) string {
@@ -343,7 +343,7 @@ resource "azapi_update_resource" "test" {
 
   ignore_body_changes = ["properties.sku.name"]
 }
-`, r.template(data), data.RandomStringOfLength(5))
+`, r.template(data), data.RandomString)
 }
 
 func (r GenericUpdateResource) ignoreChangesArray(data acceptance.TestData) string {
@@ -383,7 +383,7 @@ resource "azapi_update_resource" "test" {
   ignore_body_changes = ["properties.subnets"]
   depends_on          = [azurerm_subnet.test]
 }
-`, r.template(data), data.RandomInt())
+`, r.template(data), data.RandomInteger)
 }
 
 func (r GenericUpdateResource) ignoreOrderInArray(data acceptance.TestData) string {
@@ -446,20 +446,11 @@ resource "azapi_update_resource" "test" {
     }
   }
 }
-`, r.template(data), data.RandomInt())
+`, r.template(data), data.RandomInteger)
 }
 
 func (GenericUpdateResource) template(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-terraform {
-  required_providers {
-    azurerm = {
-      version = "= 3.90.0"
-      source  = "hashicorp/azurerm"
-    }
-  }
-}
-
 provider "azurerm" {
   features {}
 }
@@ -468,5 +459,5 @@ resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%[1]d"
   location = "%[2]s"
 }
-`, data.RandomInteger, data.LocationPrimary, data.RandomStringOfLength(10))
+`, data.RandomInteger, data.LocationPrimary, data.RandomString)
 }

--- a/internal/services/azapi_update_resource_upgrade_test.go
+++ b/internal/services/azapi_update_resource_upgrade_test.go
@@ -1,0 +1,111 @@
+package services_test
+
+import (
+	"testing"
+
+	"github.com/Azure/terraform-provider-azapi/internal/acceptance"
+	"github.com/Azure/terraform-provider-azapi/internal/acceptance/check"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccAzapiUpdateResourceUpgrade_automationAccount(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azapi_update_resource", "test")
+	r := GenericUpdateResource{}
+
+	data.UpgradeTest(t, r, []resource.TestStep{
+		data.UpgradeTestDeployStep(resource.TestStep{
+			Config: r.automationAccount(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		}, PreviousVersion),
+		data.UpgradeTestPlanStep(resource.TestStep{
+			Config: r.automationAccount(data),
+		}),
+	})
+}
+
+func TestAccAzapiUpdateResourceUpgrade_automationAccountWithNameParentId(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azapi_update_resource", "test")
+	r := GenericUpdateResource{}
+
+	data.UpgradeTest(t, r, []resource.TestStep{
+		data.UpgradeTestDeployStep(resource.TestStep{
+			Config: r.automationAccountWithNameParentId(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		}, PreviousVersion),
+		data.UpgradeTestPlanStep(resource.TestStep{
+			Config: r.automationAccountWithNameParentId(data),
+		}),
+	})
+}
+
+func TestAccAzapiUpdateResourceUpgrade_siteConfigSlotConfigNames(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azapi_update_resource", "test")
+	r := GenericUpdateResource{}
+
+	data.UpgradeTest(t, r, []resource.TestStep{
+		data.UpgradeTestDeployStep(resource.TestStep{
+			Config: r.siteConfigSlotConfigNames(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		}, PreviousVersion),
+		data.UpgradeTestPlanStep(resource.TestStep{
+			Config: r.siteConfigSlotConfigNames(data),
+		}),
+	})
+}
+
+func TestAccAzapiUpdateResourceUpgrade_locks(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azapi_update_resource", "test")
+	r := GenericUpdateResource{}
+
+	data.UpgradeTest(t, r, []resource.TestStep{
+		data.UpgradeTestDeployStep(resource.TestStep{
+			Config: r.locks(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		}, PreviousVersion),
+		data.UpgradeTestPlanStep(resource.TestStep{
+			Config: r.locks(data),
+		}),
+	})
+}
+
+func TestAccAzapiUpdateResourceUpgrade_ignoreChanges(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azapi_update_resource", "test")
+	r := GenericUpdateResource{}
+
+	data.UpgradeTest(t, r, []resource.TestStep{
+		data.UpgradeTestDeployStep(resource.TestStep{
+			Config: r.ignoreChanges(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		}, PreviousVersion),
+		data.UpgradeTestPlanStep(resource.TestStep{
+			Config: r.ignoreChanges(data),
+		}),
+	})
+}
+
+func TestAccAzapiUpdateResourceUpgrade_ignoreChangesArray(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azapi_update_resource", "test")
+	r := GenericUpdateResource{}
+
+	data.UpgradeTest(t, r, []resource.TestStep{
+		data.UpgradeTestDeployStep(resource.TestStep{
+			Config: r.ignoreChangesArray(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		}, PreviousVersion),
+		data.UpgradeTestPlanStep(resource.TestStep{
+			Config: r.ignoreChangesArray(data),
+		}),
+	})
+}

--- a/internal/services/migration/azapi_resource_action_migration_v0_to_v1.go
+++ b/internal/services/migration/azapi_resource_action_migration_v0_to_v1.go
@@ -99,14 +99,24 @@ func AzapiResourceActionMigrationV0ToV1(ctx context.Context) resource.StateUpgra
 				return
 			}
 
+			when := oldState.When
+			if when.IsNull() {
+				when = types.StringValue("apply")
+			}
+
+			body := types.DynamicNull()
+			if !oldState.Body.IsNull() && oldState.Body.ValueString() != "" {
+				body = types.DynamicValue(types.StringValue(oldState.Body.ValueString()))
+			}
+
 			newState := newModel{
 				ID:                   oldState.ID,
 				Type:                 oldState.Type,
 				ResourceId:           oldState.ResourceId,
 				Action:               oldState.Action,
 				Method:               oldState.Method,
-				Body:                 types.DynamicValue(types.StringValue(oldState.Body.ValueString())),
-				When:                 oldState.When,
+				Body:                 body,
+				When:                 when,
 				Locks:                oldState.Locks,
 				ResponseExportValues: oldState.ResponseExportValues,
 				Output:               types.DynamicValue(types.StringValue(oldState.Output.ValueString())),


### PR DESCRIPTION
This PR adds a new set of tests to detect breaking changes between the previous released provider and the developing one.

It will use the previous released provider to deploy the config, then run `terraform plan` with the developing provider to see if there's any plan diff. The expected behavior is getting no changes in the `terraform plan`.

With these tests, some potential breaking changes are detected:

1. Resource which doesn't support `location` will see a plan diff to set location to null after upgrading. (fixed in this PR)
2. Azapi resource action which doesn't have a `body` will see the body sets to `{}` after upgrading. (fixed in this PR)
3. Azapi resource action which doesn't specify `when` and upgrading from a very old provider version, will see the plan diff to add `when=apply`. (fixed in this PR, related issue: https://github.com/Azure/terraform-provider-azapi/issues/482)