### PR TITLE
`azapi`: Support `enable_hcl_output_for_data_source` field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
-## v1.13.1
+## v1.13.1 (Unreleased)
+
+ENHANCEMENTS:
+- `azapi` provider: Support `enable_hcl_output_for_data_source` field, which is used to enable the HCL output for the data source, the default value is `false`.
+  This could resolve the following breaking changes in the previous release:
+  - `azapi_resource` data source: The `output` field changes from JSON string to HCL object. Users can use access the fields in the output as an HCL object. Please remove the `jsondecode` function when using the `output` field.
+  - `azapi_resource_list` data source: The `output` field changes from JSON string to HCL object. Users can use access the fields in the output as an HCL object. Please remove the `jsondecode` function when using the `output` field.
 
 BUG FIXES:
 - Fix a bug when upgrading from previous provider `azapi_resource` resource will set `tags` for resources that don't have `tags` in the configuration.

--- a/docs/data-sources/azapi_resource.md
+++ b/docs/data-sources/azapi_resource.md
@@ -22,6 +22,7 @@ terraform {
 }
 
 provider "azapi" {
+  enable_hcl_output_for_data_source = true
 }
 
 provider "azurerm" {
@@ -110,16 +111,18 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `location` - The Azure Region where the azure resource should exist.
 
-* `output` - The output HCL object containing the properties specified in `response_export_values`. Here are some examples to use the values.
+* `output` - The output containing the properties specified in `response_export_values`. It supports both JSON and HCL object. By default, it will be in JSON format.
+  If specifying `enable_hcl_output_for_data_source` to `true` in the provider block, it will be in HCL format.
+  Here are some examples to use the values in HCL format:
 ```
 // it will output "registry1.azurecr.io"
 output "login_server" {
-  value = azapi_resource.example.output.properties.loginServer
+  value = data.azapi_resource.example.output.properties.loginServer
 }
 
 // it will output "disabled"
 output "quarantine_policy" {
-  value = azapi_resource.example.output.properties.policies.quarantinePolicy.status
+  value = data.azapi_resource.example.output.properties.policies.quarantinePolicy.status
 }
 ```
 

--- a/docs/data-sources/azapi_resource_action.md
+++ b/docs/data-sources/azapi_resource_action.md
@@ -24,6 +24,7 @@ terraform {
 }
 
 provider "azapi" {
+  enable_hcl_output_for_data_source = true
 }
 
 provider "azurerm" {
@@ -53,8 +54,20 @@ data "azapi_resource_action" "example" {
 Here's an example to use the `azapi_resource_action` data source to get a provider's permissions.
 
 ```hcl
+terraform {
+  required_providers {
+    azapi = {
+      source = "Azure/azapi"
+    }
+  }
+}
+
 provider "azurerm" {
   features {}
+}
+
+provider "azapi" {
+  enable_hcl_output_for_data_source = true
 }
 
 data "azurerm_client_config" "current" {}
@@ -76,6 +89,10 @@ terraform {
       source = "Azure/azapi"
     }
   }
+}
+
+provider "azapi" {
+  enable_hcl_output_for_data_source = true
 }
 
 resource "azapi_resource_action" "test" {
@@ -131,7 +148,9 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `id` - The ID of the azure resource action.
 
-* `output` - The output HCL object containing the properties specified in `response_export_values`. Here are some examples to use the values.
+* `output` - The output containing the properties specified in `response_export_values`. It supports both JSON and HCL object. By default, it will be in JSON format.
+  If specifying `enable_hcl_output_for_data_source` to `true` in the provider block, it will be in HCL format.
+  Here are some examples to use the values in HCL format:
 ```hcl
 // it will output "nHGYNd******i4wdug=="
 output "primary_key" {

--- a/docs/data-sources/azapi_resource_list.md
+++ b/docs/data-sources/azapi_resource_list.md
@@ -22,6 +22,7 @@ terraform {
 }
 
 provider "azapi" {
+  enable_hcl_output_for_data_source = true
 }
 
 data "azapi_resource_list" "listBySubscription" {
@@ -79,8 +80,14 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `id` - The ID of the azure resource list.
 
-* `output` - The output HCL object containing the properties specified in `response_export_values`. Here are some examples to use the values.
-
+* `output` - The output containing the properties specified in `response_export_values`. It supports both JSON and HCL object. By default, it will be in JSON format.
+  If specifying `enable_hcl_output_for_data_source` to `true` in the provider block, it will be in HCL format.
+  Here are some examples to use the values in HCL format:
+```hcl
+output "value" {
+  value = data.azapi_resource_list.example.output.value
+}
+```
 
 ## Timeouts
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -161,3 +161,5 @@ For some advanced scenarios, such as where more granular permissions are necessa
 * `skip_provider_registration` - (Optional) Should the Provider skip registering the Resource Providers it supports? This can also be sourced from the `ARM_SKIP_PROVIDER_REGISTRATION` Environment Variable. Defaults to `false`.
 
 -> By default, Terraform will attempt to register the Resource Providers that the provisioning resources belong to. If you're running in an environment with restricted permissions, or wish to manage Resource Provider Registration outside of Terraform you may wish to disable this flag; however, please note that the error messages returned from Azure may be confusing as a result (example: `API version 2019-01-01 was not found for Microsoft.Foo`).
+
+* `enable_hcl_output_for_data_source` - (Optional) Should the provider return the output in HCL format for data sources? Defaults to `false`. When set to `true`, the provider will return HCL output for data sources. When set to `false`, the provider will return JSON output for data sources.

--- a/internal/features/user_flags.go
+++ b/internal/features/user_flags.go
@@ -1,21 +1,23 @@
 package features
 
 type UserFeatures struct {
-	DefaultTags         map[string]string
-	DefaultLocation     string
-	DefaultNaming       string
-	DefaultNamingPrefix string
-	DefaultNamingSuffix string
-	CafEnabled          bool
+	DefaultTags                  map[string]string
+	DefaultLocation              string
+	DefaultNaming                string
+	DefaultNamingPrefix          string
+	DefaultNamingSuffix          string
+	CafEnabled                   bool
+	EnableHCLOutputForDataSource bool
 }
 
 func Default() UserFeatures {
 	return UserFeatures{
-		DefaultTags:         nil,
-		DefaultLocation:     "",
-		DefaultNaming:       "",
-		DefaultNamingPrefix: "",
-		DefaultNamingSuffix: "",
-		CafEnabled:          false,
+		DefaultTags:                  nil,
+		DefaultLocation:              "",
+		DefaultNaming:                "",
+		DefaultNamingPrefix:          "",
+		DefaultNamingSuffix:          "",
+		CafEnabled:                   false,
+		EnableHCLOutputForDataSource: false,
 	}
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -38,34 +38,35 @@ type Provider struct {
 }
 
 type providerData struct {
-	SubscriptionID              types.String `tfsdk:"subscription_id"`
-	ClientID                    types.String `tfsdk:"client_id"`
-	ClientIDFilePath            types.String `tfsdk:"client_id_file_path"`
-	TenantID                    types.String `tfsdk:"tenant_id"`
-	AuxiliaryTenantIDs          types.List   `tfsdk:"auxiliary_tenant_ids"`
-	Endpoint                    types.List   `tfsdk:"endpoint"`
-	Environment                 types.String `tfsdk:"environment"`
-	ClientCertificatePath       types.String `tfsdk:"client_certificate_path"`
-	ClientCertificatePassword   types.String `tfsdk:"client_certificate_password"`
-	ClientSecret                types.String `tfsdk:"client_secret"`
-	ClientSecretFilePath        types.String `tfsdk:"client_secret_file_path"`
-	SkipProviderRegistration    types.Bool   `tfsdk:"skip_provider_registration"`
-	OIDCRequestToken            types.String `tfsdk:"oidc_request_token"`
-	OIDCRequestURL              types.String `tfsdk:"oidc_request_url"`
-	OIDCToken                   types.String `tfsdk:"oidc_token"`
-	OIDCTokenFilePath           types.String `tfsdk:"oidc_token_file_path"`
-	UseOIDC                     types.Bool   `tfsdk:"use_oidc"`
-	UseCLI                      types.Bool   `tfsdk:"use_cli"`
-	UseMSI                      types.Bool   `tfsdk:"use_msi"`
-	PartnerID                   types.String `tfsdk:"partner_id"`
-	CustomCorrelationRequestID  types.String `tfsdk:"custom_correlation_request_id"`
-	DisableCorrelationRequestID types.Bool   `tfsdk:"disable_correlation_request_id"`
-	DisableTerraformPartnerID   types.Bool   `tfsdk:"disable_terraform_partner_id"`
-	DefaultName                 types.String `tfsdk:"default_name"`
-	DefaultNamingPrefix         types.String `tfsdk:"default_naming_prefix"`
-	DefaultNamingSuffix         types.String `tfsdk:"default_naming_suffix"`
-	DefaultLocation             types.String `tfsdk:"default_location"`
-	DefaultTags                 types.Map    `tfsdk:"default_tags"`
+	SubscriptionID               types.String `tfsdk:"subscription_id"`
+	ClientID                     types.String `tfsdk:"client_id"`
+	ClientIDFilePath             types.String `tfsdk:"client_id_file_path"`
+	TenantID                     types.String `tfsdk:"tenant_id"`
+	AuxiliaryTenantIDs           types.List   `tfsdk:"auxiliary_tenant_ids"`
+	Endpoint                     types.List   `tfsdk:"endpoint"`
+	Environment                  types.String `tfsdk:"environment"`
+	ClientCertificatePath        types.String `tfsdk:"client_certificate_path"`
+	ClientCertificatePassword    types.String `tfsdk:"client_certificate_password"`
+	ClientSecret                 types.String `tfsdk:"client_secret"`
+	ClientSecretFilePath         types.String `tfsdk:"client_secret_file_path"`
+	SkipProviderRegistration     types.Bool   `tfsdk:"skip_provider_registration"`
+	OIDCRequestToken             types.String `tfsdk:"oidc_request_token"`
+	OIDCRequestURL               types.String `tfsdk:"oidc_request_url"`
+	OIDCToken                    types.String `tfsdk:"oidc_token"`
+	OIDCTokenFilePath            types.String `tfsdk:"oidc_token_file_path"`
+	UseOIDC                      types.Bool   `tfsdk:"use_oidc"`
+	UseCLI                       types.Bool   `tfsdk:"use_cli"`
+	UseMSI                       types.Bool   `tfsdk:"use_msi"`
+	PartnerID                    types.String `tfsdk:"partner_id"`
+	CustomCorrelationRequestID   types.String `tfsdk:"custom_correlation_request_id"`
+	DisableCorrelationRequestID  types.Bool   `tfsdk:"disable_correlation_request_id"`
+	DisableTerraformPartnerID    types.Bool   `tfsdk:"disable_terraform_partner_id"`
+	DefaultName                  types.String `tfsdk:"default_name"`
+	DefaultNamingPrefix          types.String `tfsdk:"default_naming_prefix"`
+	DefaultNamingSuffix          types.String `tfsdk:"default_naming_suffix"`
+	DefaultLocation              types.String `tfsdk:"default_location"`
+	DefaultTags                  types.Map    `tfsdk:"default_tags"`
+	EnableHCLOutputForDataSource types.Bool   `tfsdk:"enable_hcl_output_for_data_source"`
 }
 
 func (model providerData) GetClientId() (*string, error) {
@@ -321,6 +322,11 @@ func (p Provider) Schema(ctx context.Context, request provider.SchemaRequest, re
 				},
 				Description: "The default tags which should be used for resources.",
 			},
+
+			"enable_hcl_output_for_data_source": schema.BoolAttribute{
+				Optional:    true,
+				Description: "Enable HCL output for data sources. The default is false. When set to true, the provider will return HCL output for data sources. When set to false, the provider will return JSON output for data sources.",
+			},
 		},
 	}
 }
@@ -508,6 +514,10 @@ func (p Provider) Configure(ctx context.Context, request provider.ConfigureReque
 		}
 	}
 
+	if model.EnableHCLOutputForDataSource.IsNull() {
+		model.EnableHCLOutputForDataSource = types.BoolValue(false)
+	}
+
 	var cloudConfig cloud.Configuration
 	env := model.Environment.ValueString()
 	switch strings.ToLower(env) {
@@ -598,11 +608,12 @@ func (p Provider) Configure(ctx context.Context, request provider.ConfigureReque
 		CloudCfg:             cloudConfig,
 		ApplicationUserAgent: buildUserAgent(request.TerraformVersion, model.PartnerID.ValueString(), model.DisableTerraformPartnerID.ValueBool()),
 		Features: features.UserFeatures{
-			DefaultTags:         tags.ExpandTags(model.DefaultTags),
-			DefaultLocation:     location.Normalize(model.DefaultLocation.ValueString()),
-			DefaultNaming:       model.DefaultName.ValueString(),
-			DefaultNamingPrefix: model.DefaultNamingPrefix.ValueString(),
-			DefaultNamingSuffix: model.DefaultNamingSuffix.ValueString(),
+			DefaultTags:                  tags.ExpandTags(model.DefaultTags),
+			DefaultLocation:              location.Normalize(model.DefaultLocation.ValueString()),
+			DefaultNaming:                model.DefaultName.ValueString(),
+			DefaultNamingPrefix:          model.DefaultNamingPrefix.ValueString(),
+			DefaultNamingSuffix:          model.DefaultNamingSuffix.ValueString(),
+			EnableHCLOutputForDataSource: model.EnableHCLOutputForDataSource.ValueBool(),
 		},
 		SkipProviderRegistration:    model.SkipProviderRegistration.ValueBool(),
 		DisableCorrelationRequestID: model.DisableCorrelationRequestID.ValueBool(),

--- a/internal/services/azapi_resource_action_data_source.go
+++ b/internal/services/azapi_resource_action_data_source.go
@@ -151,7 +151,7 @@ func (r *ResourceActionDataSource) Read(ctx context.Context, request datasource.
 	}
 
 	model.ID = basetypes.NewStringValue(id.ID())
-	if dynamicIsString(model.Body) {
+	if dynamicIsString(model.Body) || !r.ProviderData.Features.EnableHCLOutputForDataSource {
 		model.Output = types.DynamicValue(basetypes.NewStringValue(flattenOutput(responseBody, AsStringList(model.ResponseExportValues))))
 	} else {
 		model.Output = types.DynamicValue(flattenOutputPayload(responseBody, AsStringList(model.ResponseExportValues)))

--- a/internal/services/azapi_resource_action_data_source_test.go
+++ b/internal/services/azapi_resource_action_data_source_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/Azure/terraform-provider-azapi/internal/acceptance"
+	"github.com/Azure/terraform-provider-azapi/internal/acceptance/check"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
@@ -17,7 +18,9 @@ func TestAccActionDataSource_basic(t *testing.T) {
 	data.DataSourceTest(t, []resource.TestStep{
 		{
 			Config: r.basic(data),
-			Check:  resource.ComposeTestCheckFunc(),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("output").IsJson(),
+			),
 		},
 	})
 }
@@ -29,7 +32,9 @@ func TestAccActionDataSource_providerPermissions(t *testing.T) {
 	data.DataSourceTest(t, []resource.TestStep{
 		{
 			Config: r.providerPermissions(),
-			Check:  resource.ComposeTestCheckFunc(),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("output").IsJson(),
+			),
 		},
 	})
 }
@@ -41,7 +46,9 @@ func TestAccActionDataSource_providerAction(t *testing.T) {
 	data.DataSourceTest(t, []resource.TestStep{
 		{
 			Config: r.providerAction(),
-			Check:  resource.ComposeTestCheckFunc(),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("output").IsJson(),
+			),
 		},
 	})
 }
@@ -53,7 +60,23 @@ func TestAccActionDataSource_dynamicSchema(t *testing.T) {
 	data.DataSourceTest(t, []resource.TestStep{
 		{
 			Config: r.dynamicSchema(),
-			Check:  resource.ComposeTestCheckFunc(),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("output").IsJson(),
+			),
+		},
+	})
+}
+
+func TestAccActionDataSource_dynamicSchemaHclOutput(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azapi_resource_action", "test")
+	r := ActionDataSource{}
+
+	data.DataSourceTest(t, []resource.TestStep{
+		{
+			Config: r.dynamicSchemaHclOutput(),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("output.count").Exists(),
+			),
 		},
 	})
 }
@@ -108,9 +131,27 @@ data "azapi_resource_action" "test" {
   type        = "Microsoft.ResourceGraph@2020-04-01-preview"
   resource_id = "/providers/Microsoft.ResourceGraph"
   action      = "resources"
-  body = jsonencode({
+  body = {
     query = "resources| limit 1"
-  })
+  }
+  response_export_values = ["*"]
+}
+`
+}
+
+func (r ActionDataSource) dynamicSchemaHclOutput() string {
+	return `
+provider "azapi" {
+  enable_hcl_output_for_data_source = true
+}
+
+data "azapi_resource_action" "test" {
+  type        = "Microsoft.ResourceGraph@2020-04-01-preview"
+  resource_id = "/providers/Microsoft.ResourceGraph"
+  action      = "resources"
+  body = {
+    query = "resources| limit 1"
+  }
   response_export_values = ["*"]
 }
 `

--- a/internal/services/azapi_resource_data_source.go
+++ b/internal/services/azapi_resource_data_source.go
@@ -214,7 +214,10 @@ func (r *AzapiResourceDataSource) Read(ctx context.Context, request datasource.R
 			model.Identity = identity.ToList(*v)
 		}
 	}
-	model.Output = types.DynamicValue(flattenOutputPayload(responseBody, AsStringList(model.ResponseExportValues)))
-
+	if r.ProviderData.Features.EnableHCLOutputForDataSource {
+		model.Output = types.DynamicValue(flattenOutputPayload(responseBody, AsStringList(model.ResponseExportValues)))
+	} else {
+		model.Output = types.DynamicValue(types.StringValue(flattenOutput(responseBody, AsStringList(model.ResponseExportValues))))
+	}
 	response.Diagnostics.Append(response.State.Set(ctx, &model)...)
 }

--- a/internal/services/azapi_resource_data_source_test.go
+++ b/internal/services/azapi_resource_data_source_test.go
@@ -28,6 +28,7 @@ func TestAccGenericDataSource_basic(t *testing.T) {
 				check.That(data.ResourceName).Key("identity.0.tenant_id").Exists(),
 				check.That(data.ResourceName).Key("location").HasValue(location.Normalize(data.LocationPrimary)),
 				check.That(data.ResourceName).Key("tags.%").HasValue("1"),
+				check.That(data.ResourceName).Key("output").IsJson(),
 			),
 		},
 	})
@@ -48,6 +49,7 @@ func TestAccGenericDataSource_withResourceId(t *testing.T) {
 				check.That(data.ResourceName).Key("identity.0.tenant_id").Exists(),
 				check.That(data.ResourceName).Key("location").HasValue(location.Normalize(data.LocationPrimary)),
 				check.That(data.ResourceName).Key("tags.%").HasValue("1"),
+				check.That(data.ResourceName).Key("output").IsJson(),
 			),
 		},
 	})
@@ -63,6 +65,21 @@ func TestAccGenericDataSource_defaultParentId(t *testing.T) {
 			Config: r.defaultParentId(data),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).Key("parent_id").HasValue(fmt.Sprintf("/subscriptions/%s", subscriptionId)),
+				check.That(data.ResourceName).Key("output").IsJson(),
+			),
+		},
+	})
+}
+
+func TestAccGenericDataSource_hclOutput(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azapi_resource", "test")
+	r := GenericDataSource{}
+
+	data.DataSourceTest(t, []resource.TestStep{
+		{
+			Config: r.hclOutput(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("output.properties.%").Exists(),
 			),
 		},
 	})
@@ -73,9 +90,10 @@ func (r GenericDataSource) basic(data acceptance.TestData) string {
 %s
 
 data "azapi_resource" "test" {
-  name      = azapi_resource.test.name
-  parent_id = azapi_resource.test.parent_id
-  type      = azapi_resource.test.type
+  name                   = azapi_resource.test.name
+  parent_id              = azapi_resource.test.parent_id
+  type                   = azapi_resource.test.type
+  response_export_values = ["*"]
 }
 `, GenericResource{}.complete(data))
 }
@@ -85,8 +103,9 @@ func (r GenericDataSource) defaultParentId(data acceptance.TestData) string {
 %s
 
 data "azapi_resource" "test" {
-  type = "Microsoft.Resources/resourceGroups@2024-03-01"
-  name = azapi_resource.test.name
+  type                   = "Microsoft.Resources/resourceGroups@2024-03-01"
+  name                   = azapi_resource.test.name
+  response_export_values = ["*"]
 }
 `, GenericResource{}.defaultParentId(data))
 }
@@ -96,8 +115,25 @@ func (r GenericDataSource) withResourceId(data acceptance.TestData) string {
 %s
 
 data "azapi_resource" "test" {
-  type        = azapi_resource.test.type
-  resource_id = azapi_resource.test.id
+  type                   = azapi_resource.test.type
+  resource_id            = azapi_resource.test.id
+  response_export_values = ["*"]
+}
+`, GenericResource{}.complete(data))
+}
+
+func (r GenericDataSource) hclOutput(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+provider "azapi" {
+  enable_hcl_output_for_data_source = true
+}
+
+data "azapi_resource" "test" {
+  type                   = azapi_resource.test.type
+  resource_id            = azapi_resource.test.id
+  response_export_values = ["*"]
 }
 `, GenericResource{}.complete(data))
 }

--- a/internal/services/azapi_resource_list_data_source.go
+++ b/internal/services/azapi_resource_list_data_source.go
@@ -117,7 +117,10 @@ func (r *ResourceListDataSource) Read(ctx context.Context, request datasource.Re
 	}
 
 	model.ID = basetypes.NewStringValue(listUrl)
-	model.Output = types.DynamicValue(flattenOutputPayload(responseBody, AsStringList(model.ResponseExportValues)))
-
+	if r.ProviderData.Features.EnableHCLOutputForDataSource {
+		model.Output = types.DynamicValue(flattenOutputPayload(responseBody, AsStringList(model.ResponseExportValues)))
+	} else {
+		model.Output = types.DynamicValue(types.StringValue(flattenOutput(responseBody, AsStringList(model.ResponseExportValues))))
+	}
 	response.Diagnostics.Append(response.State.Set(ctx, &model)...)
 }

--- a/internal/services/azapi_resource_list_data_source_test.go
+++ b/internal/services/azapi_resource_list_data_source_test.go
@@ -1,6 +1,7 @@
 package services_test
 
 import (
+	"github.com/Azure/terraform-provider-azapi/internal/acceptance/check"
 	"testing"
 
 	"github.com/Azure/terraform-provider-azapi/internal/acceptance"
@@ -16,7 +17,23 @@ func TestAccListDataSource_basic(t *testing.T) {
 	data.DataSourceTest(t, []resource.TestStep{
 		{
 			Config: r.basic(),
-			Check:  resource.ComposeTestCheckFunc(),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("output").IsJson(),
+			),
+		},
+	})
+}
+
+func TestAccListDataSource_hclOutput(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azapi_resource_list", "test")
+	r := ListDataSource{}
+
+	data.DataSourceTest(t, []resource.TestStep{
+		{
+			Config: r.hclOutput(),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("output.value.#").Exists(),
+			),
 		},
 	})
 }
@@ -37,6 +54,26 @@ func (r ListDataSource) basic() string {
 	return `
 provider "azurerm" {
   features {}
+}
+
+data "azurerm_client_config" "current" {}
+
+data "azapi_resource_list" "test" {
+  type                   = "Microsoft.Resources/resourceGroups@2024-03-01"
+  parent_id              = "/subscriptions/${data.azurerm_client_config.current.subscription_id}"
+  response_export_values = ["*"]
+}
+`
+}
+
+func (r ListDataSource) hclOutput() string {
+	return `
+provider "azurerm" {
+  features {}
+}
+
+provider "azapi" {
+  enable_hcl_output_for_data_source = true
 }
 
 data "azurerm_client_config" "current" {}

--- a/internal/services/azapi_resource_list_data_source_test.go
+++ b/internal/services/azapi_resource_list_data_source_test.go
@@ -1,10 +1,10 @@
 package services_test
 
 import (
-	"github.com/Azure/terraform-provider-azapi/internal/acceptance/check"
 	"testing"
 
 	"github.com/Azure/terraform-provider-azapi/internal/acceptance"
+	"github.com/Azure/terraform-provider-azapi/internal/acceptance/check"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 


### PR DESCRIPTION
related issue: https://github.com/Azure/terraform-provider-azapi/issues/467

This PR will introduce a feature flag in the provider block to control the output format for data sources. The default value is `false` which means the output format defaults to JSON for data source. And this will resolve the breaking changes in previous release.