### PR TITLE
`azapi_*` - support for the `timeouts.update` field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## v1.14.0 (unreleased)
 
+ENHANCEMENTS:
+- `azapi_resource`, `azapi_update_resource`, `azapi_resource_action`, `azapi_data_plane_resource` resources: Support `timeouts.update` field, which is used to specify the timeout for the update operation.
+
 BUG FIXES:
 - Fix a bug that `azapi_resource` will crash when the `location` in GET response is null.
 - Fix a bug that schema validation fails to validate unknown string values.

--- a/docs/resources/azapi_data_plane_resource.md
+++ b/docs/resources/azapi_data_plane_resource.md
@@ -130,6 +130,7 @@ output "quarantine_policy" {
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the azure resource.
+* `update` - (Defaults to 30 minutes) Used when updating the azure resource.
 * `read` - (Defaults to 5 minutes) Used when retrieving the azure resource.
 * `delete` - (Defaults to 30 minutes) Used when deleting the azure resource.
 

--- a/docs/resources/azapi_resource.md
+++ b/docs/resources/azapi_resource.md
@@ -177,6 +177,7 @@ A `identity` block exports the following:
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the azure resource.
+* `update` - (Defaults to 30 minutes) Used when updating the azure resource.
 * `read` - (Defaults to 5 minutes) Used when retrieving the azure resource.
 * `delete` - (Defaults to 30 minutes) Used when deleting the azure resource.
 

--- a/docs/resources/azapi_resource_action.md
+++ b/docs/resources/azapi_resource_action.md
@@ -175,6 +175,6 @@ output "secondary_key" {
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the azure resource action.
-* `updating` - (Defaults to 30 minutes) Used when updating the azure resource action.
+* `update` - (Defaults to 30 minutes) Used when updating the azure resource action.
 * `read` - (Defaults to 5 minutes) Used when retrieving the azure resource action.
 * `delete` - (Defaults to 30 minutes) Used when deleting the azure resource action.

--- a/docs/resources/azapi_resource_action.md
+++ b/docs/resources/azapi_resource_action.md
@@ -174,6 +174,7 @@ output "secondary_key" {
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
-* `create` - (Defaults to 30 minutes) Used when creating the azure resource.
-* `read` - (Defaults to 5 minutes) Used when retrieving the azure resource.
-* `delete` - (Defaults to 30 minutes) Used when deleting the azure resource.
+* `create` - (Defaults to 30 minutes) Used when creating the azure resource action.
+* `updating` - (Defaults to 30 minutes) Used when updating the azure resource action.
+* `read` - (Defaults to 5 minutes) Used when retrieving the azure resource action.
+* `delete` - (Defaults to 30 minutes) Used when deleting the azure resource action.

--- a/docs/resources/azapi_update_resource.md
+++ b/docs/resources/azapi_update_resource.md
@@ -160,5 +160,6 @@ output "quarantine_policy" {
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the azure resource.
+* `update` - (Defaults to 30 minutes) Used when updating the azure resource.
 * `read` - (Defaults to 5 minutes) Used when retrieving the azure resource.
 * `delete` - (Defaults to 30 minutes) Used when deleting the azure resource.

--- a/internal/acceptance/testcase.go
+++ b/internal/acceptance/testcase.go
@@ -83,6 +83,13 @@ func (td TestData) UpgradeTestDeployStep(step resource.TestStep, upgradeFrom str
 	return step
 }
 
+// UpgradeTestApplyStep returns a test step used to run terraform apply with the development version
+func (td TestData) UpgradeTestApplyStep(applyStep resource.TestStep) resource.TestStep {
+	applyStep.ExternalProviders = td.externalProviders()
+	applyStep.ProtoV6ProviderFactories = td.providers()
+	return applyStep
+}
+
 // UpgradeTestPlanStep returns a test step used to run terraform plan with the development version to check if there's any changes
 func (td TestData) UpgradeTestPlanStep(planStep resource.TestStep) resource.TestStep {
 	planStep.PlanOnly = true

--- a/internal/services/azapi_data_plane_resource.go
+++ b/internal/services/azapi_data_plane_resource.go
@@ -154,6 +154,7 @@ func (r *DataPlaneResource) Schema(ctx context.Context, request resource.SchemaR
 		Blocks: map[string]schema.Block{
 			"timeouts": timeouts.Block(ctx, timeouts.Opts{
 				Create: true,
+				Update: true,
 				Read:   true,
 				Delete: true,
 			}),
@@ -200,15 +201,6 @@ func (r *DataPlaneResource) CreateUpdate(ctx context.Context, plan tfsdk.Plan, s
 		return
 	}
 
-	createUpdateTimeout, diags := model.Timeouts.Create(ctx, 30*time.Minute)
-	diagnostics.Append(diags...)
-	if diagnostics.HasError() {
-		return
-	}
-
-	ctx, cancel := context.WithTimeout(ctx, createUpdateTimeout)
-	defer cancel()
-
 	id, err := parse.NewDataPlaneResourceId(model.Name.ValueString(), model.ParentID.ValueString(), model.Type.ValueString())
 	if err != nil {
 		diagnostics.AddError("Invalid configuration", err.Error())
@@ -216,7 +208,25 @@ func (r *DataPlaneResource) CreateUpdate(ctx context.Context, plan tfsdk.Plan, s
 	}
 
 	client := r.ProviderData.DataPlaneClient
-	if isNewResource := state == nil || state.Raw.IsNull(); isNewResource {
+	isNewResource := state == nil || state.Raw.IsNull()
+
+	var timeout time.Duration
+	var diags diag.Diagnostics
+	if isNewResource {
+		timeout, diags = model.Timeouts.Create(ctx, 30*time.Minute)
+		if diagnostics.Append(diags...); diagnostics.HasError() {
+			return
+		}
+	} else {
+		timeout, diags = model.Timeouts.Update(ctx, 30*time.Minute)
+		if diagnostics.Append(diags...); diagnostics.HasError() {
+			return
+		}
+	}
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	if isNewResource {
 		_, err = client.Get(ctx, id)
 		if err == nil {
 			diagnostics.AddError("Resource already exists", tf.ImportAsExistsError("azapi_data_plane_resource", id.ID()).Error())

--- a/internal/services/azapi_data_plane_resource_test.go
+++ b/internal/services/azapi_data_plane_resource_test.go
@@ -100,6 +100,20 @@ func TestAccDataPlaneResource_iotAppsUser(t *testing.T) {
 	})
 }
 
+func TestAccDataPlaneResource_timeouts(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azapi_data_plane_resource", "test")
+	r := DataPlaneResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.timeouts(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+	})
+}
+
 func (DataPlaneResource) Exists(ctx context.Context, client *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	resourceType := state.Attributes["type"]
 	id, err := parse.DataPlaneResourceIDWithResourceType(state.ID, resourceType)
@@ -396,5 +410,56 @@ resource "azapi_data_plane_resource" "test" {
   })
 }
 
+`, data.LocationPrimary, data.RandomString)
+}
+
+func (r DataPlaneResource) timeouts(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "example" {
+  name     = "acctest%[2]s"
+  location = "%[1]s"
+}
+
+resource "azurerm_app_configuration" "appconf" {
+  name                = "acctest%[2]s"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+  sku                 = "standard"
+}
+
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_role_assignment" "test" {
+  scope                = azurerm_app_configuration.appconf.id
+  role_definition_name = "App Configuration Data Owner"
+  principal_id         = data.azurerm_client_config.current.object_id
+}
+
+resource "azapi_data_plane_resource" "test" {
+  type      = "Microsoft.AppConfiguration/configurationStores/keyValues@1.0"
+  parent_id = replace(azurerm_app_configuration.appconf.endpoint, "https://", "")
+  name      = "mykey"
+  body = jsonencode(
+    {
+      content_type = ""
+      value        = "myvalue"
+    }
+  )
+
+  depends_on = [
+    azurerm_role_assignment.test,
+  ]
+
+  timeouts {
+	create = "10m"
+	update = "10m"
+	delete = "10m"
+	read   = "10m"
+  }
+}
 `, data.LocationPrimary, data.RandomString)
 }

--- a/internal/services/azapi_data_plane_resource_test.go
+++ b/internal/services/azapi_data_plane_resource_test.go
@@ -455,10 +455,10 @@ resource "azapi_data_plane_resource" "test" {
   ]
 
   timeouts {
-	create = "10m"
-	update = "10m"
-	delete = "10m"
-	read   = "10m"
+    create = "10m"
+    update = "10m"
+    delete = "10m"
+    read   = "10m"
   }
 }
 `, data.LocationPrimary, data.RandomString)

--- a/internal/services/azapi_data_plane_resource_upgrade_test.go
+++ b/internal/services/azapi_data_plane_resource_upgrade_test.go
@@ -1,6 +1,7 @@
 package services_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/Azure/terraform-provider-azapi/internal/acceptance"
@@ -89,6 +90,43 @@ func TestAccAzapiDataPlaneResourceUpgrade_iotAppsUser(t *testing.T) {
 		}, PreviousVersion),
 		data.UpgradeTestPlanStep(resource.TestStep{
 			Config: r.iotAppsUser(data),
+		}),
+	})
+}
+
+func TestAccAzapiDataPlaneResourceUpgrade_timeouts(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azapi_data_plane_resource", "test")
+	r := DataPlaneResource{}
+
+	data.UpgradeTest(t, r, []resource.TestStep{
+		data.UpgradeTestDeployStep(resource.TestStep{
+			Config: r.timeouts(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		}, PreviousVersion),
+		data.UpgradeTestPlanStep(resource.TestStep{
+			Config: r.timeouts(data),
+		}),
+	})
+}
+
+func TestAccAzapiDataPlaneResourceUpgrade_timeouts_from_v1_13_1(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azapi_data_plane_resource", "test")
+	r := DataPlaneResource{}
+
+	data.UpgradeTest(t, r, []resource.TestStep{
+		data.UpgradeTestDeployStep(resource.TestStep{
+			Config: strings.ReplaceAll(r.timeouts(data), `update = "10m"`, ""),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		}, "1.13.1"),
+		data.UpgradeTestApplyStep(resource.TestStep{
+			Config: r.timeouts(data),
+		}),
+		data.UpgradeTestPlanStep(resource.TestStep{
+			Config: r.timeouts(data),
 		}),
 	})
 }

--- a/internal/services/azapi_resource_action_resource_test.go
+++ b/internal/services/azapi_resource_action_resource_test.go
@@ -307,10 +307,10 @@ resource "azapi_resource_action" "test" {
     data.azapi_resource_action.list
   ]
   timeouts {
-	create = "10m"
-	update = "10m"
-	delete = "10m"
-	read   = "10m"
+    create = "10m"
+    update = "10m"
+    delete = "10m"
+    read   = "10m"
   }
 }
 `, GenericResource{}.identityNone(data))

--- a/internal/services/azapi_resource_action_resource_upgrade_test.go
+++ b/internal/services/azapi_resource_action_resource_upgrade_test.go
@@ -1,9 +1,11 @@
 package services_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/Azure/terraform-provider-azapi/internal/acceptance"
+	"github.com/Azure/terraform-provider-azapi/internal/acceptance/check"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
@@ -93,6 +95,41 @@ func TestAccAzapiActionResourceUpgrade_nonstandardLRO(t *testing.T) {
 		}, PreviousVersion),
 		data.UpgradeTestPlanStep(resource.TestStep{
 			Config: r.nonstandardLRO(data),
+		}),
+	})
+}
+
+func TestAccAzapiActionResourceUpgrade_timeouts(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azapi_resource_action", "test")
+	r := ActionResource{}
+
+	data.UpgradeTest(t, r, []resource.TestStep{
+		data.UpgradeTestDeployStep(resource.TestStep{
+			Config: r.timeouts(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		}, PreviousVersion),
+		data.UpgradeTestPlanStep(resource.TestStep{
+			Config: r.timeouts(data),
+		}),
+	})
+}
+
+func TestAccAzapiActionResourceUpgrade_timeouts_from_v1_13_1(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azapi_resource_action", "test")
+	r := ActionResource{}
+
+	data.UpgradeTest(t, r, []resource.TestStep{
+		data.UpgradeTestDeployStep(resource.TestStep{
+			Config: strings.ReplaceAll(r.timeouts(data), `update = "10m"`, ""),
+			Check:  resource.ComposeTestCheckFunc(),
+		}, "1.13.1"),
+		data.UpgradeTestApplyStep(resource.TestStep{
+			Config: r.timeouts(data),
+		}),
+		data.UpgradeTestPlanStep(resource.TestStep{
+			Config: r.timeouts(data),
 		}),
 	})
 }

--- a/internal/services/azapi_resource_action_resource_upgrade_test.go
+++ b/internal/services/azapi_resource_action_resource_upgrade_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/Azure/terraform-provider-azapi/internal/acceptance"
-	"github.com/Azure/terraform-provider-azapi/internal/acceptance/check"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
@@ -106,9 +105,7 @@ func TestAccAzapiActionResourceUpgrade_timeouts(t *testing.T) {
 	data.UpgradeTest(t, r, []resource.TestStep{
 		data.UpgradeTestDeployStep(resource.TestStep{
 			Config: r.timeouts(data),
-			Check: resource.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
+			Check:  resource.ComposeTestCheckFunc(),
 		}, PreviousVersion),
 		data.UpgradeTestPlanStep(resource.TestStep{
 			Config: r.timeouts(data),

--- a/internal/services/azapi_resource_test.go
+++ b/internal/services/azapi_resource_test.go
@@ -1554,7 +1554,7 @@ resource "azapi_resource" "test" {
   type      = "Microsoft.Automation/automationAccounts@2023-11-01"
   name      = "acctest%[2]s"
   parent_id = azurerm_resource_group.test.id
-  location = azurerm_resource_group.test.location
+  location  = azurerm_resource_group.test.location
   body = jsonencode({
     properties = {
       sku = {
@@ -1563,10 +1563,10 @@ resource "azapi_resource" "test" {
     }
   })
   timeouts {
-	create = "10m"
-	update = "10m"
-	delete = "10m"
-	read   = "10m"
+    create = "10m"
+    update = "10m"
+    delete = "10m"
+    read   = "10m"
   }
 }
 `, r.template(data), data.RandomString)

--- a/internal/services/azapi_resource_test.go
+++ b/internal/services/azapi_resource_test.go
@@ -519,6 +519,19 @@ func TestAccGenericResource_unknownName(t *testing.T) {
 	})
 }
 
+func TestAccGenericResource_timeouts(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azapi_resource", "test")
+	r := GenericResource{}
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.timeouts(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+	})
+}
+
 func (GenericResource) Exists(ctx context.Context, client *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	resourceType := state.Attributes["type"]
 	id, err := parse.ResourceIDWithResourceType(state.ID, resourceType)
@@ -1531,6 +1544,32 @@ resource "azapi_resource" "test" {
   }
 }
 `, r.template(data))
+}
+
+func (r GenericResource) timeouts(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azapi_resource" "test" {
+  type      = "Microsoft.Automation/automationAccounts@2023-11-01"
+  name      = "acctest%[2]s"
+  parent_id = azurerm_resource_group.test.id
+  location = azurerm_resource_group.test.location
+  body = jsonencode({
+    properties = {
+      sku = {
+        name = "Basic"
+      }
+    }
+  })
+  timeouts {
+	create = "10m"
+	update = "10m"
+	delete = "10m"
+	read   = "10m"
+  }
+}
+`, r.template(data), data.RandomString)
 }
 
 func (GenericResource) template(data acceptance.TestData) string {

--- a/internal/services/azapi_resource_upgrade_test.go
+++ b/internal/services/azapi_resource_upgrade_test.go
@@ -497,3 +497,40 @@ func TestAccAzapiResourceUpgrade_nullLocation(t *testing.T) {
 		}),
 	})
 }
+
+func TestAccAzapiResourceUpgrade_timeouts(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azapi_resource", "test")
+	r := GenericResource{}
+
+	data.UpgradeTest(t, r, []resource.TestStep{
+		data.UpgradeTestDeployStep(resource.TestStep{
+			Config: r.timeouts(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		}, PreviousVersion),
+		data.UpgradeTestPlanStep(resource.TestStep{
+			Config: r.timeouts(data),
+		}),
+	})
+}
+
+func TestAccAzapiResourceUpgrade_timeouts_from_v1_13_1(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azapi_resource", "test")
+	r := GenericResource{}
+
+	data.UpgradeTest(t, r, []resource.TestStep{
+		data.UpgradeTestDeployStep(resource.TestStep{
+			Config: strings.ReplaceAll(r.timeouts(data), `update = "10m"`, ""),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		}, "1.13.1"),
+		data.UpgradeTestApplyStep(resource.TestStep{
+			Config: r.timeouts(data),
+		}),
+		data.UpgradeTestPlanStep(resource.TestStep{
+			Config: r.timeouts(data),
+		}),
+	})
+}

--- a/internal/services/azapi_update_resource.go
+++ b/internal/services/azapi_update_resource.go
@@ -184,6 +184,7 @@ func (r *AzapiUpdateResource) Schema(ctx context.Context, request resource.Schem
 		Blocks: map[string]schema.Block{
 			"timeouts": timeouts.Block(ctx, timeouts.Opts{
 				Create: true,
+				Update: true,
 				Read:   true,
 				Delete: true,
 			}),
@@ -271,13 +272,22 @@ func (r *AzapiUpdateResource) CreateUpdate(ctx context.Context, plan tfsdk.Plan,
 		return
 	}
 
-	createUpdateTimeout, diags := model.Timeouts.Create(ctx, 30*time.Minute)
-	diagnostics.Append(diags...)
-	if diagnostics.HasError() {
-		return
-	}
+	isNewResource := state == nil || state.Raw.IsNull()
 
-	ctx, cancel := context.WithTimeout(ctx, createUpdateTimeout)
+	var timeout time.Duration
+	var diags diag.Diagnostics
+	if isNewResource {
+		timeout, diags = model.Timeouts.Create(ctx, 30*time.Minute)
+		if diagnostics.Append(diags...); diagnostics.HasError() {
+			return
+		}
+	} else {
+		timeout, diags = model.Timeouts.Update(ctx, 30*time.Minute)
+		if diagnostics.Append(diags...); diagnostics.HasError() {
+			return
+		}
+	}
+	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
 	var id parse.ResourceId

--- a/internal/services/azapi_update_resource_test.go
+++ b/internal/services/azapi_update_resource_test.go
@@ -143,6 +143,20 @@ func TestAccGenericUpdateResource_ignoreOrderInArray(t *testing.T) {
 	})
 }
 
+func TestAccGenericUpdateResource_timeouts(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azapi_update_resource", "test")
+	r := GenericUpdateResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.timeouts(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+	})
+}
+
 func (r GenericUpdateResource) Exists(ctx context.Context, client *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	resourceType := state.Attributes["type"]
 	id, err := parse.ResourceIDWithResourceType(state.ID, resourceType)
@@ -460,4 +474,33 @@ resource "azurerm_resource_group" "test" {
   location = "%[2]s"
 }
 `, data.RandomInteger, data.LocationPrimary, data.RandomString)
+}
+
+func (r GenericUpdateResource) timeouts(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_automation_account" "test" {
+  name                = "acctest-%[2]s"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku_name            = "Basic"
+}
+
+resource "azapi_update_resource" "test" {
+  type        = "Microsoft.Automation/automationAccounts@2023-11-01"
+  resource_id = azurerm_automation_account.test.id
+  body = jsonencode({
+    properties = {
+      publicNetworkAccess = true
+    }
+  })
+  timeouts {
+	create = "10m"
+	update = "10m"
+	delete = "10m"
+	read   = "10m"
+  }
+}
+`, r.template(data), data.RandomString)
 }

--- a/internal/services/azapi_update_resource_test.go
+++ b/internal/services/azapi_update_resource_test.go
@@ -496,10 +496,10 @@ resource "azapi_update_resource" "test" {
     }
   })
   timeouts {
-	create = "10m"
-	update = "10m"
-	delete = "10m"
-	read   = "10m"
+    create = "10m"
+    update = "10m"
+    delete = "10m"
+    read   = "10m"
   }
 }
 `, r.template(data), data.RandomString)

--- a/internal/services/azapi_update_resource_upgrade_test.go
+++ b/internal/services/azapi_update_resource_upgrade_test.go
@@ -1,6 +1,7 @@
 package services_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/Azure/terraform-provider-azapi/internal/acceptance"
@@ -106,6 +107,43 @@ func TestAccAzapiUpdateResourceUpgrade_ignoreChangesArray(t *testing.T) {
 		}, PreviousVersion),
 		data.UpgradeTestPlanStep(resource.TestStep{
 			Config: r.ignoreChangesArray(data),
+		}),
+	})
+}
+
+func TestAccAzapiUpdateResourceUpgrade_timeouts(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azapi_update_resource", "test")
+	r := GenericUpdateResource{}
+
+	data.UpgradeTest(t, r, []resource.TestStep{
+		data.UpgradeTestDeployStep(resource.TestStep{
+			Config: r.timeouts(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		}, PreviousVersion),
+		data.UpgradeTestPlanStep(resource.TestStep{
+			Config: r.timeouts(data),
+		}),
+	})
+}
+
+func TestAccAzapiUpdateResourceUpgrade_timeouts_from_v1_13_1(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azapi_update_resource", "test")
+	r := GenericUpdateResource{}
+
+	data.UpgradeTest(t, r, []resource.TestStep{
+		data.UpgradeTestDeployStep(resource.TestStep{
+			Config: strings.ReplaceAll(r.timeouts(data), `update = "10m"`, ""),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		}, "1.13.1"),
+		data.UpgradeTestApplyStep(resource.TestStep{
+			Config: r.timeouts(data),
+		}),
+		data.UpgradeTestPlanStep(resource.TestStep{
+			Config: r.timeouts(data),
 		}),
 	})
 }

--- a/internal/services/migration/azapi_data_plane_resource_migration_v0_to_v1.go
+++ b/internal/services/migration/azapi_data_plane_resource_migration_v0_to_v1.go
@@ -61,6 +61,7 @@ func AzapiDataPlaneResourceMigrationV0ToV1(ctx context.Context) resource.StateUp
 			Blocks: map[string]schema.Block{
 				"timeouts": timeouts.Block(ctx, timeouts.Opts{
 					Create: true,
+					Update: true,
 					Read:   true,
 					Delete: true,
 				}),

--- a/internal/services/migration/azapi_resource_action_migration_v0_to_v1.go
+++ b/internal/services/migration/azapi_resource_action_migration_v0_to_v1.go
@@ -60,6 +60,7 @@ func AzapiResourceActionMigrationV0ToV1(ctx context.Context) resource.StateUpgra
 			Blocks: map[string]schema.Block{
 				"timeouts": timeouts.Block(ctx, timeouts.Opts{
 					Create: true,
+					Update: true,
 					Read:   true,
 					Delete: true,
 				}),

--- a/internal/services/migration/azapi_resource_migration_v0_to_v1.go
+++ b/internal/services/migration/azapi_resource_migration_v0_to_v1.go
@@ -111,6 +111,7 @@ func AzapiResourceMigrationV0ToV1(ctx context.Context) resource.StateUpgrader {
 
 				"timeouts": timeouts.Block(ctx, timeouts.Opts{
 					Create: true,
+					Update: true,
 					Read:   true,
 					Delete: true,
 				}),

--- a/internal/services/migration/azapi_update_resource_migration_v0_to_v1.go
+++ b/internal/services/migration/azapi_update_resource_migration_v0_to_v1.go
@@ -74,6 +74,7 @@ func AzapiUpdateResourceMigrationV0ToV1(ctx context.Context) resource.StateUpgra
 			Blocks: map[string]schema.Block{
 				"timeouts": timeouts.Block(ctx, timeouts.Opts{
 					Create: true,
+					Update: true,
 					Read:   true,
 					Delete: true,
 				}),


### PR DESCRIPTION
This PR adds `timeouts.update` field which is removed in v1.13.x by mistake.

To avoid potential breaking changes introduced by this PR, I've added more tests:

1. Upgrade from v1.12.1 to current version, the updated migration function will update the schema from v0 to v1 correctly.
2. Upgrade from v1.13.1 to current version, the schema is already updated to v0 to v1. But in v1.13.x, the update timeout is not supported, so upgrading will have no breaking changes. And users could still be able to add update timeout after using the latest version.