### PR TITLE
`azapi`: Support `client_certificate` field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## v1.14.0 (unreleased)
 
 ENHANCEMENTS:
+- `azapi` provider: Support `client_certificate` field, which specifies base64-encoded PKCS#12 bundle to be used as the client certificate for authentication.
 - `azapi_resource`, `azapi_update_resource`, `azapi_resource_action`, `azapi_data_plane_resource` resources: Support `timeouts.update` field, which is used to specify the timeout for the update operation.
 - `azapi_update_resource` resource: Improve the id build logic to honor user's input.
 

--- a/docs/guides/service_principal_client_certificate.md
+++ b/docs/guides/service_principal_client_certificate.md
@@ -74,7 +74,7 @@ At this point the newly created Azure Active Directory Application should be ass
 
 As we've obtained the credentials for this Service Principal - it's possible to configure them in a few different ways.
 
-When storing the credentials as Environment Variables, for example:
+*Reading the certificate bundle from the filesystem*
 
 ```bash
 export ARM_CLIENT_ID="00000000-0000-0000-0000-000000000000"
@@ -82,6 +82,15 @@ export ARM_CLIENT_CERTIFICATE_PATH="/path/to/my/client/certificate.pfx"
 export ARM_CLIENT_CERTIFICATE_PASSWORD="Pa55w0rd123"
 export ARM_SUBSCRIPTION_ID="00000000-0000-0000-0000-000000000000"
 export ARM_TENANT_ID="00000000-0000-0000-0000-000000000000"
+```
+
+*Passing the encoded certificate bundle directly*
+```bash
+$ export ARM_CLIENT_ID="00000000-0000-0000-0000-000000000000"
+$ export ARM_CLIENT_CERTIFICATE="$(base64 /path/to/my/client/certificate.pfx)"
+$ export ARM_CLIENT_CERTIFICATE_PASSWORD="Pa55w0rd123"
+$ export ARM_TENANT_ID="10000000-0000-0000-0000-000000000000"
+$ export ARM_SUBSCRIPTION_ID="20000000-0000-0000-0000-000000000000"
 ```
 
 The following Terraform and Provider blocks can be specified - where `0.1.0` is the version of the Azure Provider that you'd like to use:
@@ -110,6 +119,7 @@ It's also possible to configure these variables either in-line or from using var
 
 ~> **NOTE:** We'd recommend not defining these variables in-line since they could easily be checked into Source Control.
 
+*Reading the certificate bundle from the filesystem*
 ```hcl
 variable "client_certificate_path" {}
 variable "client_certificate_password" {}
@@ -129,6 +139,30 @@ provider "azapi" {
   client_certificate_path     = var.client_certificate_path
   client_certificate_password = var.client_certificate_password
   tenant_id                   = "00000000-0000-0000-0000-000000000000"
+}
+```
+
+*Passing the encoded certificate bundle directly*
+
+```hcl
+variable "client_certificate" {}
+variable "client_certificate_password" {}
+
+terraform {
+  required_providers {
+    azapi = {
+      source  = "azure/azapi"
+      version = "=0.1.0"
+    }
+  }
+}
+
+provider "azapi" {
+  client_id                   = "00000000-0000-0000-0000-000000000000"
+  client_certificate          = var.client_certificate
+  client_certificate_password = var.client_certificate_password
+  tenant_id                   = "10000000-0000-0000-0000-000000000000"
+  subscription_id             = "20000000-0000-0000-0000-000000000000"
 }
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -96,6 +96,8 @@ A `endpoint` block supports the following:
 
 When authenticating as a Service Principal using a Client Certificate, the following fields can be set:
 
+* `client_certificate` - A base64-encoded PKCS#12 bundle to be used as the client certificate for authentication. This can also be sourced from the `ARM_CLIENT_CERTIFICATE` environment variable.
+
 * `client_certificate_password` - (Optional) The password associated with the Client Certificate. This can also be sourced from the `ARM_CLIENT_CERTIFICATE_PASSWORD` Environment Variable.
 
 * `client_certificate_path` - (Optional) The path to the Client Certificate associated with the Service Principal which should be used. This can also be sourced from the `ARM_CLIENT_CERTIFICATE_PATH` Environment Variable.

--- a/internal/acceptance/testcase.go
+++ b/internal/acceptance/testcase.go
@@ -166,21 +166,33 @@ func (td TestData) externalProviders() map[string]resource.ExternalProvider {
 }
 
 func PreCheck(t *testing.T) {
-	variables := []string{
-		"ARM_CLIENT_ID",
-		"ARM_CLIENT_SECRET",
-		"ARM_SUBSCRIPTION_ID",
-		"ARM_TENANT_ID",
-		"ARM_TEST_LOCATION",
-		"ARM_TEST_LOCATION_ALT",
-		"ARM_TEST_LOCATION_ALT2",
-	}
+	if v := os.Getenv("TF_ACC"); v == "" {
+		t.Fatalf(`TF_ACC must be set for acceptance tests!
+For tests that authenticate with Azure by using a Service Principal, the following environment variables must be set:
+- ARM_CLIENT_ID
+- ARM_CLIENT_SECRET
+- ARM_SUBSCRIPTION_ID
+- ARM_TENANT_ID
+- ARM_TEST_LOCATION
+- ARM_TEST_LOCATION_ALT
+- ARM_TEST_LOCATION_ALT2
 
-	for _, variable := range variables {
-		value := os.Getenv(variable)
-		if value == "" {
-			t.Fatalf("`%s` must be set for acceptance tests!", variable)
-		}
+For tests that authenticate with Azure by OIDC in github action, the following environment variables must be set:
+- ARM_CLIENT_ID
+- ARM_TENANT_ID
+- ARM_TEST_LOCATION
+- ARM_TEST_LOCATION_ALT
+- ARM_TEST_LOCATION_ALT2
+
+For tests that authenticate with Azure by using a Service Principal with Certificate, the following environment variables must be set:
+- ARM_CLIENT_ID
+- ARM_CLIENT_CERTIFICATE_PATH
+- ARM_SUBSCRIPTION_ID
+- ARM_TENANT_ID
+- ARM_TEST_LOCATION
+- ARM_TEST_LOCATION_ALT
+- ARM_TEST_LOCATION_ALT2
+`)
 	}
 }
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -766,6 +766,7 @@ func buildClientCertificateCredential(model providerData, options azidentity.Def
 	var certData []byte
 	if certPath := model.ClientCertificatePath.ValueString(); certPath != "" {
 		log.Printf("[DEBUG] reading certificate from file %s", certPath)
+		// #nosec G304
 		certData, err = os.ReadFile(certPath)
 		if err != nil {
 			return nil, fmt.Errorf(`failed to read certificate file "%s": %v`, certPath, err)

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -724,7 +724,7 @@ func buildChainedTokenCredential(model providerData, options azidentity.DefaultA
 
 	if model.UseCLI.ValueBool() {
 		log.Printf("[DEBUG] cli credential enabled")
-		if cred, err := buildAzureCLICredential(model, options); err == nil {
+		if cred, err := buildAzureCLICredential(options); err == nil {
 			creds = append(creds, cred)
 		} else {
 			log.Printf("[DEBUG] failed to initialize cli credential: %v", err)
@@ -829,7 +829,7 @@ func buildManagedIdentityCredential(model providerData, options azidentity.Defau
 	return NewManagedIdentityCredential(o)
 }
 
-func buildAzureCLICredential(model providerData, options azidentity.DefaultAzureCredentialOptions) (azcore.TokenCredential, error) {
+func buildAzureCLICredential(options azidentity.DefaultAzureCredentialOptions) (azcore.TokenCredential, error) {
 	log.Printf("[DEBUG] building azure cli credential")
 	o := &azidentity.AzureCLICredentialOptions{
 		AdditionallyAllowedTenants: options.AdditionallyAllowedTenants,

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"log"
 	"os"
@@ -45,6 +46,7 @@ type providerData struct {
 	AuxiliaryTenantIDs           types.List   `tfsdk:"auxiliary_tenant_ids"`
 	Endpoint                     types.List   `tfsdk:"endpoint"`
 	Environment                  types.String `tfsdk:"environment"`
+	ClientCertificate            types.String `tfsdk:"client_certificate"`
 	ClientCertificatePath        types.String `tfsdk:"client_certificate_path"`
 	ClientCertificatePassword    types.String `tfsdk:"client_certificate_password"`
 	ClientSecret                 types.String `tfsdk:"client_secret"`
@@ -199,6 +201,11 @@ func (p Provider) Schema(ctx context.Context, request provider.SchemaRequest, re
 			"client_certificate_path": schema.StringAttribute{
 				Optional:    true,
 				Description: "The path to the Client Certificate associated with the Service Principal for use when authenticating as a Service Principal using a Client Certificate.",
+			},
+
+			"client_certificate": schema.StringAttribute{
+				Optional:    true,
+				Description: "A base64-encoded PKCS#12 bundle to be used as the client certificate for authentication.",
 			},
 
 			"client_certificate_password": schema.StringAttribute{
@@ -402,6 +409,12 @@ func (p Provider) Configure(ctx context.Context, request provider.ConfigureReque
 		}
 	}
 
+	if model.ClientCertificate.IsNull() {
+		if v := os.Getenv("ARM_CLIENT_CERTIFICATE"); v != "" {
+			model.ClientCertificate = types.StringValue(v)
+		}
+	}
+
 	if model.ClientCertificatePath.IsNull() {
 		if v := os.Getenv("ARM_CLIENT_CERTIFICATE_PATH"); v != "" {
 			model.ClientCertificatePath = types.StringValue(v)
@@ -559,37 +572,14 @@ func (p Provider) Configure(ctx context.Context, request provider.ConfigureReque
 		}
 	}
 
-	// Maps the auth related environment variables used in the provider to what azidentity honors.
-	if v := model.TenantID.ValueString(); v != "" {
-		_ = os.Setenv("AZURE_TENANT_ID", v)
-	}
-	if v, err := model.GetClientId(); err != nil {
-		response.Diagnostics.AddError("Failed to obtain a Client ID.", err.Error())
-		return
-	} else if v != nil && *v != "" {
-		_ = os.Setenv("AZURE_CLIENT_ID", *v)
-	}
-	if v, err := model.GetClientSecret(); err != nil {
-		response.Diagnostics.AddError("Failed to obtain a Client Secret.", err.Error())
-		return
-	} else if v != nil && *v != "" {
-		_ = os.Setenv("AZURE_CLIENT_SECRET", *v)
-	}
-	if v := model.ClientCertificatePath.ValueString(); v != "" {
-		_ = os.Setenv("AZURE_CLIENT_CERTIFICATE_PATH", v)
-	}
-	if v := model.ClientCertificatePassword.ValueString(); v != "" {
-		_ = os.Setenv("AZURE_CLIENT_CERTIFICATE_PASSWORD", v)
-	}
 	var auxTenants []string
 	if elements := model.AuxiliaryTenantIDs.Elements(); len(elements) != 0 {
 		for _, element := range elements {
 			auxTenants = append(auxTenants, element.(basetypes.StringValue).ValueString())
 		}
-		_ = os.Setenv("AZURE_ADDITIONALLY_ALLOWED_TENANTS", strings.Join(auxTenants, ";"))
 	}
 
-	option := &azidentity.DefaultAzureCredentialOptions{
+	option := azidentity.DefaultAzureCredentialOptions{
 		AdditionallyAllowedTenants: auxTenants,
 		ClientOptions: azcore.ClientOptions{
 			Cloud: cloudConfig,
@@ -597,7 +587,7 @@ func (p Provider) Configure(ctx context.Context, request provider.ConfigureReque
 		TenantID: model.TenantID.ValueString(),
 	}
 
-	cred, err := newDefaultAzureCredential(model, option)
+	cred, err := buildChainedTokenCredential(model, option)
 	if err != nil {
 		response.Diagnostics.AddError("Failed to obtain a credential.", err.Error())
 		return
@@ -698,70 +688,46 @@ func buildUserAgent(terraformVersion string, partnerID string, disableTerraformP
 	return userAgent
 }
 
-func newDefaultAzureCredential(model providerData, options *azidentity.DefaultAzureCredentialOptions) (*azidentity.ChainedTokenCredential, error) {
+func buildChainedTokenCredential(model providerData, options azidentity.DefaultAzureCredentialOptions) (*azidentity.ChainedTokenCredential, error) {
+	log.Printf("[DEBUG] building chained token credential")
 	var creds []azcore.TokenCredential
 
-	if options == nil {
-		options = &azidentity.DefaultAzureCredentialOptions{}
-	}
-
-	clientId, err := model.GetClientId()
-	if err != nil {
-		return nil, err
-	}
-
 	if model.UseOIDC.ValueBool() {
-		oidcCred, err := NewOidcCredential(&OidcCredentialOptions{
-			ClientOptions: azcore.ClientOptions{
-				Cloud: options.Cloud,
-			},
-			AdditionallyAllowedTenants: options.AdditionallyAllowedTenants,
-			TenantID:                   model.TenantID.ValueString(),
-			ClientID:                   *clientId,
-			RequestToken:               model.OIDCRequestToken.ValueString(),
-			RequestUrl:                 model.OIDCRequestURL.ValueString(),
-			Token:                      model.OIDCToken.ValueString(),
-			TokenFilePath:              model.OIDCTokenFilePath.ValueString(),
-		})
-
-		if err == nil {
-			creds = append(creds, oidcCred)
+		log.Printf("[DEBUG] oidc credential enabled")
+		if cred, err := buildOidcCredential(model, options); err == nil {
+			creds = append(creds, cred)
 		} else {
-			log.Printf("newDefaultAzureCredential failed to initialize oidc credential:\n\t%s", err.Error())
+			log.Printf("[DEBUG] failed to initialize oidc credential: %v", err)
 		}
 	}
 
-	envCred, err := azidentity.NewEnvironmentCredential(&azidentity.EnvironmentCredentialOptions{
-		ClientOptions:            options.ClientOptions,
-		DisableInstanceDiscovery: options.DisableInstanceDiscovery,
-	})
-	if err == nil {
-		creds = append(creds, envCred)
+	if cred, err := buildClientSecretCredential(model, options); err == nil {
+		creds = append(creds, cred)
 	} else {
-		log.Printf("newDefaultAzureCredential failed to initialize environment credential:\n\t%s", err.Error())
+		log.Printf("[DEBUG] failed to initialize client secret credential: %v", err)
+	}
+
+	if cred, err := buildClientCertificateCredential(model, options); err == nil {
+		creds = append(creds, cred)
+	} else {
+		log.Printf("[DEBUG] failed to initialize client certificate credential: %v", err)
 	}
 
 	if model.UseMSI.ValueBool() {
-		o := &azidentity.ManagedIdentityCredentialOptions{ClientOptions: options.ClientOptions}
-		if ID, ok := os.LookupEnv("AZURE_CLIENT_ID"); ok {
-			o.ID = azidentity.ClientID(ID)
-		}
-		miCred, err := NewManagedIdentityCredential(o)
-		if err == nil {
-			creds = append(creds, miCred)
+		log.Printf("[DEBUG] msi credential enabled")
+		if cred, err := buildManagedIdentityCredential(model, options); err == nil {
+			creds = append(creds, cred)
 		} else {
-			log.Printf("newDefaultAzureCredential failed to initialize msi credential:\n\t%s", err.Error())
+			log.Printf("[DEBUG] failed to initialize msi credential: %v", err)
 		}
 	}
 
 	if model.UseCLI.ValueBool() {
-		cliCred, err := azidentity.NewAzureCLICredential(&azidentity.AzureCLICredentialOptions{
-			AdditionallyAllowedTenants: options.AdditionallyAllowedTenants,
-			TenantID:                   options.TenantID})
-		if err == nil {
-			creds = append(creds, cliCred)
+		log.Printf("[DEBUG] cli credential enabled")
+		if cred, err := buildAzureCLICredential(model, options); err == nil {
+			creds = append(creds, cred)
 		} else {
-			log.Printf("newDefaultAzureCredential failed to initialize cli credential:\n\t%s", err.Error())
+			log.Printf("[DEBUG] failed to initialize cli credential: %v", err)
 		}
 	}
 
@@ -769,10 +735,118 @@ func newDefaultAzureCredential(model providerData, options *azidentity.DefaultAz
 		return nil, fmt.Errorf("no credentials were successfully initialized")
 	}
 
-	chain, err := azidentity.NewChainedTokenCredential(creds, nil)
+	return azidentity.NewChainedTokenCredential(creds, nil)
+}
+
+func buildClientSecretCredential(model providerData, options azidentity.DefaultAzureCredentialOptions) (azcore.TokenCredential, error) {
+	log.Printf("[DEBUG] building client secret credential")
+	clientID, err := model.GetClientId()
+	if err != nil {
+		return nil, err
+	}
+	clientSecret, err := model.GetClientSecret()
+	if err != nil {
+		return nil, err
+	}
+	o := &azidentity.ClientSecretCredentialOptions{
+		AdditionallyAllowedTenants: options.AdditionallyAllowedTenants,
+		ClientOptions:              options.ClientOptions,
+		DisableInstanceDiscovery:   options.DisableInstanceDiscovery,
+	}
+	return azidentity.NewClientSecretCredential(options.TenantID, *clientID, *clientSecret, o)
+}
+
+func buildClientCertificateCredential(model providerData, options azidentity.DefaultAzureCredentialOptions) (azcore.TokenCredential, error) {
+	log.Printf("[DEBUG] building client certificate credential")
+	clientID, err := model.GetClientId()
 	if err != nil {
 		return nil, err
 	}
 
-	return chain, nil
+	var certData []byte
+	if certPath := model.ClientCertificatePath.ValueString(); certPath != "" {
+		log.Printf("[DEBUG] reading certificate from file %s", certPath)
+		certData, err = os.ReadFile(certPath)
+		if err != nil {
+			return nil, fmt.Errorf(`failed to read certificate file "%s": %v`, certPath, err)
+		}
+	}
+	if certBase64 := model.ClientCertificate.ValueString(); certBase64 != "" {
+		log.Printf("[DEBUG] decoding certificate from base64")
+		certData, err = decodeCertificate(certBase64)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	var password []byte
+	if v := model.ClientCertificatePassword.ValueString(); v != "" {
+		password = []byte(v)
+	}
+	certs, key, err := azidentity.ParseCertificates(certData, password)
+	if err != nil {
+		return nil, fmt.Errorf(`failed to load certificate": %v`, err)
+	}
+	o := &azidentity.ClientCertificateCredentialOptions{
+		AdditionallyAllowedTenants: options.AdditionallyAllowedTenants,
+		ClientOptions:              options.ClientOptions,
+		DisableInstanceDiscovery:   options.DisableInstanceDiscovery,
+	}
+	return azidentity.NewClientCertificateCredential(options.TenantID, *clientID, certs, key, o)
+}
+
+func buildOidcCredential(model providerData, options azidentity.DefaultAzureCredentialOptions) (azcore.TokenCredential, error) {
+	log.Printf("[DEBUG] building oidc credential")
+	clientId, err := model.GetClientId()
+	if err != nil {
+		return nil, err
+	}
+	o := &OidcCredentialOptions{
+		ClientOptions: azcore.ClientOptions{
+			Cloud: options.Cloud,
+		},
+		AdditionallyAllowedTenants: options.AdditionallyAllowedTenants,
+		TenantID:                   options.TenantID,
+		ClientID:                   *clientId,
+		RequestToken:               model.OIDCRequestToken.ValueString(),
+		RequestUrl:                 model.OIDCRequestURL.ValueString(),
+		Token:                      model.OIDCToken.ValueString(),
+		TokenFilePath:              model.OIDCTokenFilePath.ValueString(),
+	}
+	return NewOidcCredential(o)
+}
+
+func buildManagedIdentityCredential(model providerData, options azidentity.DefaultAzureCredentialOptions) (azcore.TokenCredential, error) {
+	log.Printf("[DEBUG] building managed identity credential")
+	clientId, err := model.GetClientId()
+	if err != nil {
+		return nil, err
+	}
+	o := &azidentity.ManagedIdentityCredentialOptions{
+		ClientOptions: options.ClientOptions,
+		ID:            azidentity.ClientID(*clientId),
+	}
+	return NewManagedIdentityCredential(o)
+}
+
+func buildAzureCLICredential(model providerData, options azidentity.DefaultAzureCredentialOptions) (azcore.TokenCredential, error) {
+	log.Printf("[DEBUG] building azure cli credential")
+	o := &azidentity.AzureCLICredentialOptions{
+		AdditionallyAllowedTenants: options.AdditionallyAllowedTenants,
+		TenantID:                   options.TenantID,
+	}
+	return azidentity.NewAzureCLICredential(o)
+}
+
+func decodeCertificate(clientCertificate string) ([]byte, error) {
+	var pfx []byte
+	if clientCertificate != "" {
+		out := make([]byte, base64.StdEncoding.DecodedLen(len(clientCertificate)))
+		n, err := base64.StdEncoding.Decode(out, []byte(clientCertificate))
+		if err != nil {
+			return pfx, fmt.Errorf("could not decode client certificate data: %v", err)
+		}
+		pfx = out[:n]
+	}
+	return pfx, nil
 }

--- a/internal/services/azapi_auth_test.go
+++ b/internal/services/azapi_auth_test.go
@@ -55,3 +55,19 @@ func TestAccAuth_oidc(t *testing.T) {
 		},
 	})
 }
+
+func TestAccAuth_azcli(t *testing.T) {
+	if ok := os.Getenv("ARM_USE_CLI"); ok == "" {
+		t.Skip("Skipping as `ARM_USE_CLI` is not specified")
+	}
+
+	data := acceptance.BuildTestData(t, "data.azapi_resource_action", "test")
+	r := ActionDataSource{}
+
+	data.DataSourceTest(t, []resource.TestStep{
+		{
+			Config: r.providerAction(),
+			Check:  resource.ComposeTestCheckFunc(),
+		},
+	})
+}

--- a/internal/services/azapi_auth_test.go
+++ b/internal/services/azapi_auth_test.go
@@ -1,0 +1,57 @@
+package services_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/Azure/terraform-provider-azapi/internal/acceptance"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccAuth_clientCertificatePath(t *testing.T) {
+	if ok := os.Getenv("ARM_CLIENT_CERTIFICATE_PATH"); ok == "" {
+		t.Skip("Skipping as `ARM_CLIENT_CERTIFICATE_PATH` is not specified")
+	}
+
+	data := acceptance.BuildTestData(t, "data.azapi_resource_action", "test")
+	r := ActionDataSource{}
+
+	data.DataSourceTest(t, []resource.TestStep{
+		{
+			Config: r.providerAction(),
+			Check:  resource.ComposeTestCheckFunc(),
+		},
+	})
+}
+
+func TestAccAuth_clientCertificate(t *testing.T) {
+	if ok := os.Getenv("ARM_CLIENT_CERTIFICATE"); ok == "" {
+		t.Skip("Skipping as `ARM_CLIENT_CERTIFICATE` is not specified")
+	}
+
+	data := acceptance.BuildTestData(t, "data.azapi_resource_action", "test")
+	r := ActionDataSource{}
+
+	data.DataSourceTest(t, []resource.TestStep{
+		{
+			Config: r.providerAction(),
+			Check:  resource.ComposeTestCheckFunc(),
+		},
+	})
+}
+
+func TestAccAuth_oidc(t *testing.T) {
+	if ok := os.Getenv("ARM_USE_OIDC"); ok == "" {
+		t.Skip("Skipping as `ARM_USE_OIDC` is not specified")
+	}
+
+	data := acceptance.BuildTestData(t, "data.azapi_resource_action", "test")
+	r := ActionDataSource{}
+
+	data.DataSourceTest(t, []resource.TestStep{
+		{
+			Config: r.providerAction(),
+			Check:  resource.ComposeTestCheckFunc(),
+		},
+	})
+}

--- a/internal/services/azapi_resource_test.go
+++ b/internal/services/azapi_resource_test.go
@@ -351,7 +351,6 @@ func TestAccGenericResource_extensionScope(t *testing.T) {
 			Config: r.extensionScope(data),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("location").HasValue(location.Normalize(data.LocationPrimary)),
 			),
 		},
 		data.ImportStep(defaultIgnores()...),
@@ -415,25 +414,6 @@ func TestAccGenericResource_locks(t *testing.T) {
 			),
 		},
 		data.ImportStepWithImportStateIdFunc(r.ImportIdFunc, defaultIgnores()...),
-	})
-}
-
-func TestAccGenericResource_oidc(t *testing.T) {
-	if ok := os.Getenv("ARM_USE_OIDC"); ok == "" {
-		t.Skip("Skipping as `ARM_USE_OIDC` is not specified")
-	}
-
-	data := acceptance.BuildTestData(t, "azapi_resource", "test")
-	r := GenericResource{}
-
-	data.ResourceTest(t, r, []resource.TestStep{
-		{
-			Config: r.basic(data),
-			Check: resource.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(defaultIgnores()...),
 	})
 }
 

--- a/internal/services/azapi_resource_test.go
+++ b/internal/services/azapi_resource_test.go
@@ -353,7 +353,7 @@ func TestAccGenericResource_extensionScope(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep(defaultIgnores()...),
+		data.ImportStepWithImportStateIdFunc(r.ImportIdFunc, defaultIgnores()...),
 	})
 }
 


### PR DESCRIPTION
related issue: https://github.com/Azure/terraform-provider-azapi/issues/488

This PR also refactors the logics that build credentials and adds test cases for different authentication methods.

Test results:

1. az cli
```
=== RUN   TestAccAuth_azcli
=== PAUSE TestAccAuth_azcli
=== CONT  TestAccAuth_azcli
--- PASS: TestAccAuth_azcli (39.17s)
PASS
```

2. sp client secret
running test....


3. sp client certificate path
```
=== RUN   TestAccAuth_clientCertificatePath
=== PAUSE TestAccAuth_clientCertificatePath
=== CONT  TestAccAuth_clientCertificatePath
--- PASS: TestAccAuth_clientCertificatePath (38.29s)
PASS
```
4. sp client certificate
```
=== RUN   TestAccAuth_clientCertificate
=== PAUSE TestAccAuth_clientCertificate
=== CONT  TestAccAuth_clientCertificate
--- PASS: TestAccAuth_clientCertificate (38.17s)
PASS

```
5. oidc
<img width="1069" alt="image" src="https://github.com/Azure/terraform-provider-azapi/assets/79895375/2d91fdaa-6cf0-477d-93e5-971d80d8fba4">


6. msi
```
adminuser@henglu-vm:~/terraform-provider-azapi$ TF_ACC=1 /snap/bin/go test -v ./internal/services -run TestAccActionDataSource_providerAction -timeout 10m -ldflags="-X=github.com/Azure/terraform-provider-azapi/version.ProviderVersion=acc"

=== RUN   TestAccActionDataSource_providerAction
=== PAUSE TestAccActionDataSource_providerAction
=== CONT  TestAccActionDataSource_providerAction
--- PASS: TestAccActionDataSource_providerAction (32.21s)
PASS
ok  	github.com/Azure/terraform-provider-azapi/internal/services	32.218s
```