### PR TITLE
new data source: `azapi_client_config`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## v1.14.0 (unreleased)
+FEATURES:
+- **New Data Source**: azapi_client_config
 
 ENHANCEMENTS:
 - `azapi` provider: Support `client_certificate` field, which specifies base64-encoded PKCS#12 bundle to be used as the client certificate for authentication.

--- a/docs/data-sources/azapi_client_config.md
+++ b/docs/data-sources/azapi_client_config.md
@@ -1,0 +1,53 @@
+---
+subcategory: ""
+layout: "azapi"
+page_title: "Client Config Data Source: azapi_client_config"
+description: |-
+  Gets information about the configuration of the azapi provider.
+---
+
+# azapi_client_config
+
+Use this data source to access the configuration of the azapi provider.
+
+## Example Usage
+
+```hcl
+terraform {
+  required_providers {
+    azapi = {
+      source = "Azure/azapi"
+    }
+  }
+}
+
+provider "azapi" {
+}
+
+data "azapi_client_config" "current" {
+}
+
+output "subscription_id" {
+  value = data.azapi_client_config.current.subscription_id
+}
+
+output "tenant_id" {
+  value = data.azapi_client_config.current.tenant_id
+}
+```
+
+## Arguments Reference
+
+There are no arguments available for this data source.
+
+## Attributes Reference
+
+* `tenant_id` is set to the Azure Tenant ID.
+
+* `subscription_id` is set to the Azure Subscription ID.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `read` - (Defaults to 30 minutes) Used when retrieving the azure resource.

--- a/internal/acceptance/testclient.go
+++ b/internal/acceptance/testclient.go
@@ -53,6 +53,8 @@ func BuildTestClient() (*clients.Client, error) {
 			CloudCfg:                 cloudConfig,
 			Features:                 features.Default(),
 			SkipProviderRegistration: true,
+			TenantId:                 os.Getenv("ARM_TENANT_ID"),
+			SubscriptionId:           os.Getenv("ARM_SUBSCRIPTION_ID"),
 		}
 
 		client := &clients.Client{}

--- a/internal/clients/account.go
+++ b/internal/clients/account.go
@@ -11,50 +11,67 @@ import (
 )
 
 type ResourceManagerAccount struct {
+	tenantId       *string
 	subscriptionId *string
 	mutex          *sync.Mutex
 }
 
-func NewResourceManagerAccount(subscriptionId string) ResourceManagerAccount {
-	if subscriptionId == "" {
-		return ResourceManagerAccount{
-			mutex: &sync.Mutex{},
-		}
+func NewResourceManagerAccount(tenantId, subscriptionId string) ResourceManagerAccount {
+	out := ResourceManagerAccount{
+		mutex: &sync.Mutex{},
 	}
-	return ResourceManagerAccount{
-		subscriptionId: &subscriptionId,
-		mutex:          &sync.Mutex{},
+	if tenantId != "" {
+		out.tenantId = &tenantId
 	}
+	if subscriptionId != "" {
+		out.subscriptionId = &subscriptionId
+	}
+	return out
 }
 
-func (account ResourceManagerAccount) GetSubscriptionId() string {
+func (account *ResourceManagerAccount) GetTenantId() string {
+	account.mutex.Lock()
+	defer account.mutex.Unlock()
+	if account.tenantId != nil {
+		return *account.tenantId
+	}
+
+	err := account.loadDefaultsFromAzCmd()
+	if err != nil {
+		log.Printf("[DEBUG] Error getting default tenant ID: %s", err)
+	}
+
+	return *account.tenantId
+}
+
+func (account *ResourceManagerAccount) GetSubscriptionId() string {
 	account.mutex.Lock()
 	defer account.mutex.Unlock()
 	if account.subscriptionId != nil {
 		return *account.subscriptionId
 	}
 
-	subscriptionId, err := getDefaultSubscriptionID()
+	err := account.loadDefaultsFromAzCmd()
 	if err != nil {
 		log.Printf("[DEBUG] Error getting default subscription ID: %s", err)
 	}
 
-	account.subscriptionId = &subscriptionId
-
 	return *account.subscriptionId
 }
 
-// getDefaultSubscriptionID tries to determine the default subscription
-func getDefaultSubscriptionID() (string, error) {
-	var account struct {
+func (account *ResourceManagerAccount) loadDefaultsFromAzCmd() error {
+	var accountModel struct {
 		SubscriptionID string `json:"id"`
+		TenantId       string `json:"tenantId"`
 	}
-	err := jsonUnmarshalAzCmd(&account, "account", "show")
+	err := jsonUnmarshalAzCmd(&accountModel, "account", "show")
 	if err != nil {
-		return "", fmt.Errorf("obtaining subscription ID: %s", err)
+		return fmt.Errorf("obtaining defaults from az cmd: %s", err)
 	}
 
-	return account.SubscriptionID, nil
+	account.tenantId = &accountModel.TenantId
+	account.subscriptionId = &accountModel.SubscriptionID
+	return nil
 }
 
 // jsonUnmarshalAzCmd executes an Azure CLI command and unmarshalls the JSON output.

--- a/internal/clients/client.go
+++ b/internal/clients/client.go
@@ -34,6 +34,7 @@ type Option struct {
 	CloudCfg                    cloud.Configuration
 	CustomCorrelationRequestID  string
 	SubscriptionId              string
+	TenantId                    string
 }
 
 // NOTE: it should be possible for this method to become Private once the top level Client's removed
@@ -130,7 +131,7 @@ func (client *Client) Build(ctx context.Context, o *Option) error {
 	}
 	client.DataPlaneClient = dataPlaneClient
 
-	client.Account = NewResourceManagerAccount(o.SubscriptionId)
+	client.Account = NewResourceManagerAccount(o.TenantId, o.SubscriptionId)
 
 	return nil
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -609,6 +609,7 @@ func (p Provider) Configure(ctx context.Context, request provider.ConfigureReque
 		DisableCorrelationRequestID: model.DisableCorrelationRequestID.ValueBool(),
 		CustomCorrelationRequestID:  model.CustomCorrelationRequestID.ValueString(),
 		SubscriptionId:              model.SubscriptionID.ValueString(),
+		TenantId:                    model.TenantID.ValueString(),
 	}
 
 	client := &clients.Client{}
@@ -637,6 +638,9 @@ func (p Provider) DataSources(ctx context.Context) []func() datasource.DataSourc
 		},
 		func() datasource.DataSource {
 			return &services.AzapiResourceDataSource{}
+		},
+		func() datasource.DataSource {
+			return &services.ClientConfigDataSource{}
 		},
 	}
 

--- a/internal/services/azapi_client_config_data_source.go
+++ b/internal/services/azapi_client_config_data_source.go
@@ -1,0 +1,85 @@
+package services
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/Azure/terraform-provider-azapi/internal/clients"
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type ClientConfigDataSourceModel struct {
+	ID             types.String   `tfsdk:"id"`
+	TenantID       types.String   `tfsdk:"tenant_id"`
+	SubscriptionID types.String   `tfsdk:"subscription_id"`
+	Timeouts       timeouts.Value `tfsdk:"timeouts"`
+}
+
+type ClientConfigDataSource struct {
+	ProviderData *clients.Client
+}
+
+var _ datasource.DataSource = &ClientConfigDataSource{}
+var _ datasource.DataSourceWithConfigure = &ClientConfigDataSource{}
+
+func (r *ClientConfigDataSource) Configure(ctx context.Context, request datasource.ConfigureRequest, response *datasource.ConfigureResponse) {
+	if v, ok := request.ProviderData.(*clients.Client); ok {
+		r.ProviderData = v
+	}
+}
+
+func (r *ClientConfigDataSource) Metadata(ctx context.Context, request datasource.MetadataRequest, response *datasource.MetadataResponse) {
+	response.TypeName = request.ProviderTypeName + "_client_config"
+}
+
+func (r *ClientConfigDataSource) Schema(ctx context.Context, request datasource.SchemaRequest, response *datasource.SchemaResponse) {
+	response.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed: true,
+			},
+
+			"tenant_id": schema.StringAttribute{
+				Computed: true,
+			},
+
+			"subscription_id": schema.StringAttribute{
+				Computed: true,
+			},
+		},
+
+		Blocks: map[string]schema.Block{
+			"timeouts": timeouts.Block(ctx, timeouts.Opts{
+				Read: true,
+			}),
+		},
+	}
+}
+
+func (r *ClientConfigDataSource) Read(ctx context.Context, request datasource.ReadRequest, response *datasource.ReadResponse) {
+	var model ClientConfigDataSourceModel
+	if response.Diagnostics.Append(request.Config.Get(ctx, &model)...); response.Diagnostics.HasError() {
+		return
+	}
+
+	readTimeout, diags := model.Timeouts.Read(ctx, 5*time.Minute)
+	response.Diagnostics.Append(diags...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, readTimeout)
+	defer cancel()
+
+	subscriptionId := r.ProviderData.Account.GetSubscriptionId()
+	tenantId := r.ProviderData.Account.GetTenantId()
+
+	model.ID = types.StringValue(fmt.Sprintf("clientConfigs/subscriptionId=%s;tenantId=%s", subscriptionId, tenantId))
+	model.SubscriptionID = types.StringValue(subscriptionId)
+	model.TenantID = types.StringValue(tenantId)
+	response.Diagnostics.Append(response.State.Set(ctx, &model)...)
+}

--- a/internal/services/azapi_client_config_data_source_test.go
+++ b/internal/services/azapi_client_config_data_source_test.go
@@ -1,0 +1,58 @@
+package services_test
+
+import (
+	"os"
+	"regexp"
+	"testing"
+
+	"github.com/Azure/terraform-provider-azapi/internal/acceptance"
+	"github.com/Azure/terraform-provider-azapi/internal/acceptance/check"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+type ClientConfigDataSource struct{}
+
+func TestAccClientConfigDataSource_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azapi_client_config", "test")
+	r := ClientConfigDataSource{}
+
+	tenantId := os.Getenv("ARM_TENANT_ID")
+	subscriptionId := os.Getenv("ARM_SUBSCRIPTION_ID")
+
+	data.DataSourceTest(t, []resource.TestStep{
+		{
+			Config: r.basic(),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("tenant_id").HasValue(tenantId),
+				check.That(data.ResourceName).Key("subscription_id").HasValue(subscriptionId),
+			),
+		},
+	})
+}
+
+func TestAccClientConfigDataSource_azcli(t *testing.T) {
+	if ok := os.Getenv("ARM_USE_CLI"); ok == "" {
+		t.Skip("Skipping as `ARM_USE_CLI` is not specified")
+	}
+
+	data := acceptance.BuildTestData(t, "data.azapi_client_config", "test")
+	r := ClientConfigDataSource{}
+
+	idRegex := regexp.MustCompile("^[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}$")
+
+	data.DataSourceTest(t, []resource.TestStep{
+		{
+			Config: r.basic(),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("tenant_id").MatchesRegex(idRegex),
+				check.That(data.ResourceName).Key("subscription_id").MatchesRegex(idRegex),
+			),
+		},
+	})
+}
+
+func (r ClientConfigDataSource) basic() string {
+	return `
+data "azapi_client_config" "test" {}
+`
+}


### PR DESCRIPTION
fixes https://github.com/Azure/terraform-provider-azapi/issues/504

This PR adds an `azapi_client_config` data source which is used to get information about the configuration of azapi provider. For the first iteration, it only supports `subscription_id` and `tenant_id`.

This data source will try to retrieve these information from provider's block directly, if not specified, it will try to load from az cli command.