### PR TITLE
fix: `utils.UpdateObject` duplication of array members

### DIFF
--- a/utils/json.go
+++ b/utils/json.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"regexp"
 	"strings"
 )
@@ -65,6 +66,9 @@ type UpdateJsonOption struct {
 
 // UpdateObject is used to get an updated object which has same schema as old, but with new value
 func UpdateObject(old interface{}, new interface{}, option UpdateJsonOption) interface{} {
+	if reflect.DeepEqual(old, new) {
+		return old
+	}
 	switch oldValue := old.(type) {
 	case map[string]interface{}:
 		if newMap, ok := new.(map[string]interface{}); ok {

--- a/utils/json.go
+++ b/utils/json.go
@@ -106,7 +106,7 @@ func UpdateObject(old interface{}, new interface{}, option UpdateJsonOption) int
 
 			for _, oldItem := range oldValue {
 				for index, newItem := range newArr {
-					if reflect.DeepEqual(oldItem, newItem) && !used[index] {
+					if areSameArrayItems(oldItem, newItem) {
 						res = append(res, UpdateObject(oldItem, newItem, option))
 						used[index] = true
 						break

--- a/utils/json.go
+++ b/utils/json.go
@@ -106,7 +106,7 @@ func UpdateObject(old interface{}, new interface{}, option UpdateJsonOption) int
 
 			for _, oldItem := range oldValue {
 				for index, newItem := range newArr {
-					if areSameArrayItems(oldItem, newItem) {
+					if reflect.DeepEqual(oldItem, newItem) && !used[index] {
 						res = append(res, UpdateObject(oldItem, newItem, option))
 						used[index] = true
 						break

--- a/utils/json.go
+++ b/utils/json.go
@@ -105,8 +105,20 @@ func UpdateObject(old interface{}, new interface{}, option UpdateJsonOption) int
 			used := make([]bool, len(newArr))
 
 			for _, oldItem := range oldValue {
+				found := false
 				for index, newItem := range newArr {
-					if areSameArrayItems(oldItem, newItem) {
+					if reflect.DeepEqual(oldItem, newItem) && !used[index] {
+						res = append(res, UpdateObject(oldItem, newItem, option))
+						used[index] = true
+						found = true
+						break
+					}
+				}
+				if found {
+					continue
+				}
+				for index, newItem := range newArr {
+					if areSameArrayItems(oldItem, newItem) && !used[index] {
 						res = append(res, UpdateObject(oldItem, newItem, option))
 						used[index] = true
 						break

--- a/utils/json.go
+++ b/utils/json.go
@@ -134,15 +134,6 @@ func UpdateObject(old interface{}, new interface{}, option UpdateJsonOption) int
 	return new
 }
 
-func areSameArrayItems(a, b interface{}) bool {
-	aId := identifierOfArrayItem(a)
-	bId := identifierOfArrayItem(b)
-	if aId == "" || bId == "" {
-		return false
-	}
-	return aId == bId
-}
-
 func identifierOfArrayItem(input interface{}) string {
 	inputMap, ok := input.(map[string]interface{})
 	if !ok {

--- a/utils/json.go
+++ b/utils/json.go
@@ -134,6 +134,15 @@ func UpdateObject(old interface{}, new interface{}, option UpdateJsonOption) int
 	return new
 }
 
+func areSameArrayItems(a, b interface{}) bool {
+	aId := identifierOfArrayItem(a)
+	bId := identifierOfArrayItem(b)
+	if aId == "" || bId == "" {
+		return false
+	}
+	return aId == bId
+}
+
 func identifierOfArrayItem(input interface{}) string {
 	inputMap, ok := input.(map[string]interface{})
 	if !ok {

--- a/utils/json_test.go
+++ b/utils/json_test.go
@@ -659,3 +659,60 @@ func Test_UpdateObjectDuplicateIdentifiers(t *testing.T) {
 		t.Fatalf("Expected:\n%s\n\n but got\n%s", expectedJson, gotJson)
 	}
 }
+
+func Test_UpdateObjectDuplicateIdentifiersWithInconsistentOrdering(t *testing.T) {
+	OldJson := `
+{
+	"contentFilters": [
+		{
+			"name": "Hate",
+			"allowedContentLevel": "Medium",
+			"blocking": true,
+			"enabled": true,
+			"source": "Prompt"
+		},
+		{
+			"name": "Hate",
+			"allowedContentLevel": "Medium",
+			"blocking": true,
+			"enabled": true,
+			"source": "Completion"
+		}
+  ]
+}
+`
+	NewJson := `
+{
+	"contentFilters": [
+		{
+			"name": "Hate",
+			"allowedContentLevel": "Medium",
+			"blocking": true,
+			"enabled": true,
+			"source": "Completion"
+			},
+			{
+				"name": "Hate",
+				"allowedContentLevel": "Medium",
+				"blocking": true,
+				"enabled": true,
+				"source": "Prompt"
+			}
+  ]
+}
+`
+	var old, new, expected any
+	_ = json.Unmarshal([]byte(OldJson), &old)
+	_ = json.Unmarshal([]byte(NewJson), &new)
+	_ = json.Unmarshal([]byte(OldJson), &expected)
+
+	got := utils.UpdateObject(old, new, utils.UpdateJsonOption{
+		IgnoreCasing:          false,
+		IgnoreMissingProperty: true,
+	})
+	if !reflect.DeepEqual(got, expected) {
+		expectedJson, _ := json.MarshalIndent(expected, "", "  ")
+		gotJson, _ := json.MarshalIndent(got, "", "  ")
+		t.Fatalf("Expected:\n%s\n\n but got\n%s", expectedJson, gotJson)
+	}
+}

--- a/utils/json_test.go
+++ b/utils/json_test.go
@@ -3,7 +3,6 @@ package utils_test
 import (
 	"encoding/json"
 	"reflect"
-	"strconv"
 	"testing"
 
 	"github.com/Azure/terraform-provider-azapi/utils"
@@ -108,28 +107,18 @@ func Test_UpdateObject(t *testing.T) {
       "dnsServers": []
     },
     "subnets": [
-			{
-				"etag": "W/\"5633f421-aaa4-4cf3-b9a6-40625807bd75\"",
-				"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/henglu422/providers/Microsoft.Network/virtualNetworks/henglu422/subnets/henglu422",
-				"name": "henglu422",
-				"properties": {
-					"addressPrefix": "10.0.2.0/24",
-					"delegations": [],
-					"networkSecurityGroup": {
-						"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/henglu422/providers/Microsoft.Network/networkSecurityGroups/NRMS-zpedr2ai6dglmhenglu422"
-					},
-					"privateEndpointNetworkPolicies": "Disabled",
-					"privateLinkServiceNetworkPolicies": "Enabled",
-					"provisioningState": "Succeeded"
-				},
-				"type": "Microsoft.Network/virtualNetworks/subnets"
-			},
       {
-        "etag": "W/\"5633f421-aaa4-4cf3-b9a6-40625807bd75\"",
-        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/henglu422/providers/Microsoft.Network/virtualNetworks/henglu422/subnets/default",
         "name": "default",
         "properties": {
-          "addressPrefix": "10.0.3.0/24",
+          "addressPrefix": "10.0.3.0/24"
+        }
+      },
+      {
+        "etag": "W/\"5633f421-aaa4-4cf3-b9a6-40625807bd75\"",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/henglu422/providers/Microsoft.Network/virtualNetworks/henglu422/subnets/henglu422",
+        "name": "henglu422",
+        "properties": {
+          "addressPrefix": "10.0.2.0/24",
           "delegations": [],
           "networkSecurityGroup": {
             "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/henglu422/providers/Microsoft.Network/networkSecurityGroups/NRMS-zpedr2ai6dglmhenglu422"
@@ -227,20 +216,18 @@ func Test_UpdateObject(t *testing.T) {
 		},
 	}
 
-	for i, testcase := range testcases {
-		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			var new, old, expected interface{}
-			_ = json.Unmarshal([]byte(testcase.OldJson), &old)
-			_ = json.Unmarshal([]byte(testcase.NewJson), &new)
-			_ = json.Unmarshal([]byte(testcase.ExpectJson), &expected)
+	for _, testcase := range testcases {
+		var new, old, expected interface{}
+		_ = json.Unmarshal([]byte(testcase.OldJson), &old)
+		_ = json.Unmarshal([]byte(testcase.NewJson), &new)
+		_ = json.Unmarshal([]byte(testcase.ExpectJson), &expected)
 
-			result := utils.UpdateObject(old, new, testcase.Option)
-			if !reflect.DeepEqual(result, expected) {
-				expectedJson, _ := json.MarshalIndent(expected, "", "  ")
-				resultJson, _ := json.MarshalIndent(result, "", "  ")
-				t.Fatalf("Expected \n\n%s\n\nbut got\n\n%s", expectedJson, resultJson)
-			}
-		})
+		result := utils.UpdateObject(old, new, testcase.Option)
+		if !reflect.DeepEqual(result, expected) {
+			expectedJson, _ := json.Marshal(expected)
+			resultJson, _ := json.Marshal(result)
+			t.Fatalf("Expected %s but got %s", expectedJson, resultJson)
+		}
 	}
 }
 
@@ -660,63 +647,6 @@ func Test_UpdateObjectDuplicateIdentifiers(t *testing.T) {
 	var old, new, expected any
 	_ = json.Unmarshal([]byte(OldJson), &old)
 	_ = json.Unmarshal([]byte(OldJson), &new)
-	_ = json.Unmarshal([]byte(OldJson), &expected)
-
-	got := utils.UpdateObject(old, new, utils.UpdateJsonOption{
-		IgnoreCasing:          false,
-		IgnoreMissingProperty: true,
-	})
-	if !reflect.DeepEqual(got, expected) {
-		expectedJson, _ := json.MarshalIndent(expected, "", "  ")
-		gotJson, _ := json.MarshalIndent(got, "", "  ")
-		t.Fatalf("Expected:\n%s\n\n but got\n%s", expectedJson, gotJson)
-	}
-}
-
-func Test_UpdateObjectDuplicateIdentifiersUnordered(t *testing.T) {
-	OldJson := `
-{
-	"contentFilters": [
-		{
-			"name": "Hate",
-			"allowedContentLevel": "Medium",
-			"blocking": true,
-			"enabled": true,
-			"source": "Prompt"
-		},
-		{
-			"name": "Hate",
-			"allowedContentLevel": "Medium",
-			"blocking": true,
-			"enabled": true,
-			"source": "Completion"
-		}
-	]
-}
-`
-	NewJson := `
-{
-	"contentFilters": [
-		{
-				"name": "Hate",
-				"allowedContentLevel": "Medium",
-				"blocking": true,
-				"enabled": true,
-				"source": "Completion"
-		},
-		{
-				"name": "Hate",
-				"allowedContentLevel": "Medium",
-				"blocking": true,
-				"enabled": true,
-				"source": "Prompt"
-		}
-	]
-}
-`
-	var old, new, expected any
-	_ = json.Unmarshal([]byte(OldJson), &old)
-	_ = json.Unmarshal([]byte(NewJson), &new)
 	_ = json.Unmarshal([]byte(OldJson), &expected)
 
 	got := utils.UpdateObject(old, new, utils.UpdateJsonOption{

--- a/utils/json_test.go
+++ b/utils/json_test.go
@@ -574,3 +574,259 @@ func Test_OverrideWithPaths(t *testing.T) {
 		}
 	}
 }
+
+func Test_UpdateObjectPolicyDefinition(t *testing.T) {
+	OldJson := `
+{
+	"properties": {
+    "description": "Deploys the diagnostic settings for Database for PostgreSQL to stream to a Log Analytics workspace when any Database for PostgreSQL which is missing this diagnostic settings is created or updated. This policy is superseded by built-in initiative https://www.azadvertizer.net/azpolicyinitiativesadvertizer/0884adba-2312-4468-abeb-5422caed1038.html.",
+    "displayName": "[Deprecated]: Deploy Diagnostic Settings for Database for PostgreSQL to Log Analytics workspace",
+    "metadata": {
+      "alzCloudEnvironments": [
+        "AzureCloud",
+        "AzureChinaCloud",
+        "AzureUSGovernment"
+      ],
+      "category": "Monitoring",
+      "deprecated": true,
+      "source": "https://github.com/Azure/Enterprise-Scale/",
+      "version": "2.0.0-deprecated"
+    },
+    "mode": "Indexed",
+    "parameters": {
+      "effect": {
+        "allowedValues": [
+          "DeployIfNotExists",
+          "Disabled"
+        ],
+        "defaultValue": "DeployIfNotExists",
+        "metadata": {
+          "description": "Enable or disable the execution of the policy",
+          "displayName": "Effect"
+        },
+        "type": "String"
+      },
+      "logAnalytics": {
+        "metadata": {
+          "description": "Select Log Analytics workspace from dropdown list. If this workspace is outside of the scope of the assignment you must manually grant 'Log Analytics Contributor' permissions (or similar) to the policy assignment's principal ID.",
+          "displayName": "Log Analytics workspace",
+          "strongType": "omsWorkspace"
+        },
+        "type": "String"
+      },
+      "logsEnabled": {
+        "allowedValues": [
+          "True",
+          "False"
+        ],
+        "defaultValue": "True",
+        "metadata": {
+          "description": "Whether to enable logs stream to the Log Analytics workspace - True or False",
+          "displayName": "Enable logs"
+        },
+        "type": "String"
+      },
+      "metricsEnabled": {
+        "allowedValues": [
+          "True",
+          "False"
+        ],
+        "defaultValue": "True",
+        "metadata": {
+          "description": "Whether to enable metrics stream to the Log Analytics workspace - True or False",
+          "displayName": "Enable metrics"
+        },
+        "type": "String"
+      },
+      "profileName": {
+        "defaultValue": "setbypolicy",
+        "metadata": {
+          "description": "The diagnostic settings profile name",
+          "displayName": "Profile name"
+        },
+        "type": "String"
+      }
+    },
+    "policyRule": {
+      "if": {
+        "anyOf": [
+          {
+            "equals": "Microsoft.DBforPostgreSQL/flexibleServers",
+            "field": "type"
+          },
+          {
+            "equals": "Microsoft.DBforPostgreSQL/servers",
+            "field": "type"
+          }
+        ]
+      },
+      "then": {
+        "details": {
+          "deployment": {
+            "properties": {
+              "mode": "Incremental",
+              "parameters": {
+                "location": {
+                  "value": "[field('location')]"
+                },
+                "logAnalytics": {
+                  "value": "[parameters('logAnalytics')]"
+                },
+                "logsEnabled": {
+                  "value": "[parameters('logsEnabled')]"
+                },
+                "metricsEnabled": {
+                  "value": "[parameters('metricsEnabled')]"
+                },
+                "profileName": {
+                  "value": "[parameters('profileName')]"
+                },
+                "resourceName": {
+                  "value": "[field('name')]"
+                },
+                "resourceType": {
+                  "value": "[field('type')]"
+                }
+              },
+              "template": {
+                "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                "contentVersion": "1.0.0.0",
+                "outputs": {},
+                "parameters": {
+                  "location": {
+                    "type": "String"
+                  },
+                  "logAnalytics": {
+                    "type": "String"
+                  },
+                  "logsEnabled": {
+                    "type": "String"
+                  },
+                  "metricsEnabled": {
+                    "type": "String"
+                  },
+                  "profileName": {
+                    "type": "String"
+                  },
+                  "resourceName": {
+                    "type": "String"
+                  },
+                  "resourceType": {
+                    "type": "String"
+                  }
+                },
+                "resources": [
+                  {
+                    "apiVersion": "2021-05-01-preview",
+                    "condition": "[startsWith(parameters('resourceType'),'Microsoft.DBforPostgreSQL/flexibleServers')]",
+                    "dependsOn": [],
+                    "location": "[parameters('location')]",
+                    "name": "[concat(parameters('resourceName'), '/', 'Microsoft.Insights/', parameters('profileName'))]",
+                    "properties": {
+                      "logs": [
+                        {
+                          "category": "PostgreSQLLogs",
+                          "enabled": "[parameters('logsEnabled')]"
+                        }
+                      ],
+                      "metrics": [
+                        {
+                          "category": "AllMetrics",
+                          "enabled": "[parameters('metricsEnabled')]",
+                          "retentionPolicy": {
+                            "days": 0,
+                            "enabled": false
+                          },
+                          "timeGrain": null
+                        }
+                      ],
+                      "workspaceId": "[parameters('logAnalytics')]"
+                    },
+                    "type": "Microsoft.DBforPostgreSQL/flexibleServers/providers/diagnosticSettings"
+                  },
+                  {
+                    "apiVersion": "2021-05-01-preview",
+                    "condition": "[startsWith(parameters('resourceType'),'Microsoft.DBforPostgreSQL/servers')]",
+                    "dependsOn": [],
+                    "location": "[parameters('location')]",
+                    "name": "[concat(parameters('resourceName'), '/', 'Microsoft.Insights/', parameters('profileName'))]",
+                    "properties": {
+                      "logs": [
+                        {
+                          "category": "PostgreSQLLogs",
+                          "enabled": "[parameters('logsEnabled')]"
+                        },
+                        {
+                          "category": "QueryStoreRuntimeStatistics",
+                          "enabled": "[parameters('logsEnabled')]"
+                        },
+                        {
+                          "category": "QueryStoreWaitStatistics",
+                          "enabled": "[parameters('logsEnabled')]"
+                        }
+                      ],
+                      "metrics": [
+                        {
+                          "category": "AllMetrics",
+                          "enabled": "[parameters('metricsEnabled')]",
+                          "retentionPolicy": {
+                            "days": 0,
+                            "enabled": false
+                          },
+                          "timeGrain": null
+                        }
+                      ],
+                      "workspaceId": "[parameters('logAnalytics')]"
+                    },
+                    "type": "Microsoft.DBforPostgreSQL/servers/providers/diagnosticSettings"
+                  }
+                ],
+                "variables": {}
+              }
+            }
+          },
+          "existenceCondition": {
+            "allOf": [
+              {
+                "equals": "true",
+                "field": "Microsoft.Insights/diagnosticSettings/logs.enabled"
+              },
+              {
+                "equals": "true",
+                "field": "Microsoft.Insights/diagnosticSettings/metrics.enabled"
+              },
+              {
+                "equals": "[parameters('logAnalytics')]",
+                "field": "Microsoft.Insights/diagnosticSettings/workspaceId"
+              }
+            ]
+          },
+          "name": "[parameters('profileName')]",
+          "roleDefinitionIds": [
+            "/providers/microsoft.authorization/roleDefinitions/749f88d5-cbae-40b8-bcfc-e573ddc772fa",
+            "/providers/microsoft.authorization/roleDefinitions/92aaf0da-9dab-42b6-94a3-d43ce8d16293"
+          ],
+          "type": "Microsoft.Insights/diagnosticSettings"
+        },
+        "effect": "[parameters('effect')]"
+      }
+    },
+    "policyType": "Custom"
+  }
+}
+`
+	var old, new, expected any
+	_ = json.Unmarshal([]byte(OldJson), &old)
+	_ = json.Unmarshal([]byte(OldJson), &new)
+	_ = json.Unmarshal([]byte(OldJson), &expected)
+
+	got := utils.UpdateObject(old, new, utils.UpdateJsonOption{
+		IgnoreCasing:          false,
+		IgnoreMissingProperty: true,
+	})
+	if !reflect.DeepEqual(got, expected) {
+		expectedJson, _ := json.MarshalIndent(expected, "", "  ")
+		gotJson, _ := json.MarshalIndent(got, "", "  ")
+		t.Fatalf("Expected:\n%s\n\n but got\n%s", expectedJson, gotJson)
+	}
+}

--- a/utils/json_test.go
+++ b/utils/json_test.go
@@ -575,245 +575,74 @@ func Test_OverrideWithPaths(t *testing.T) {
 	}
 }
 
-func Test_UpdateObjectPolicyDefinition(t *testing.T) {
+func Test_UpdateObjectDuplicateIdentifiers(t *testing.T) {
 	OldJson := `
-{
-	"properties": {
-    "description": "Deploys the diagnostic settings for Database for PostgreSQL to stream to a Log Analytics workspace when any Database for PostgreSQL which is missing this diagnostic settings is created or updated. This policy is superseded by built-in initiative https://www.azadvertizer.net/azpolicyinitiativesadvertizer/0884adba-2312-4468-abeb-5422caed1038.html.",
-    "displayName": "[Deprecated]: Deploy Diagnostic Settings for Database for PostgreSQL to Log Analytics workspace",
-    "metadata": {
-      "alzCloudEnvironments": [
-        "AzureCloud",
-        "AzureChinaCloud",
-        "AzureUSGovernment"
-      ],
-      "category": "Monitoring",
-      "deprecated": true,
-      "source": "https://github.com/Azure/Enterprise-Scale/",
-      "version": "2.0.0-deprecated"
-    },
-    "mode": "Indexed",
-    "parameters": {
-      "effect": {
-        "allowedValues": [
-          "DeployIfNotExists",
-          "Disabled"
-        ],
-        "defaultValue": "DeployIfNotExists",
-        "metadata": {
-          "description": "Enable or disable the execution of the policy",
-          "displayName": "Effect"
-        },
-        "type": "String"
-      },
-      "logAnalytics": {
-        "metadata": {
-          "description": "Select Log Analytics workspace from dropdown list. If this workspace is outside of the scope of the assignment you must manually grant 'Log Analytics Contributor' permissions (or similar) to the policy assignment's principal ID.",
-          "displayName": "Log Analytics workspace",
-          "strongType": "omsWorkspace"
-        },
-        "type": "String"
-      },
-      "logsEnabled": {
-        "allowedValues": [
-          "True",
-          "False"
-        ],
-        "defaultValue": "True",
-        "metadata": {
-          "description": "Whether to enable logs stream to the Log Analytics workspace - True or False",
-          "displayName": "Enable logs"
-        },
-        "type": "String"
-      },
-      "metricsEnabled": {
-        "allowedValues": [
-          "True",
-          "False"
-        ],
-        "defaultValue": "True",
-        "metadata": {
-          "description": "Whether to enable metrics stream to the Log Analytics workspace - True or False",
-          "displayName": "Enable metrics"
-        },
-        "type": "String"
-      },
-      "profileName": {
-        "defaultValue": "setbypolicy",
-        "metadata": {
-          "description": "The diagnostic settings profile name",
-          "displayName": "Profile name"
-        },
-        "type": "String"
-      }
-    },
-    "policyRule": {
-      "if": {
-        "anyOf": [
-          {
-            "equals": "Microsoft.DBforPostgreSQL/flexibleServers",
-            "field": "type"
-          },
-          {
-            "equals": "Microsoft.DBforPostgreSQL/servers",
-            "field": "type"
-          }
-        ]
-      },
-      "then": {
-        "details": {
-          "deployment": {
-            "properties": {
-              "mode": "Incremental",
-              "parameters": {
-                "location": {
-                  "value": "[field('location')]"
-                },
-                "logAnalytics": {
-                  "value": "[parameters('logAnalytics')]"
-                },
-                "logsEnabled": {
-                  "value": "[parameters('logsEnabled')]"
-                },
-                "metricsEnabled": {
-                  "value": "[parameters('metricsEnabled')]"
-                },
-                "profileName": {
-                  "value": "[parameters('profileName')]"
-                },
-                "resourceName": {
-                  "value": "[field('name')]"
-                },
-                "resourceType": {
-                  "value": "[field('type')]"
-                }
-              },
-              "template": {
-                "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-                "contentVersion": "1.0.0.0",
-                "outputs": {},
-                "parameters": {
-                  "location": {
-                    "type": "String"
-                  },
-                  "logAnalytics": {
-                    "type": "String"
-                  },
-                  "logsEnabled": {
-                    "type": "String"
-                  },
-                  "metricsEnabled": {
-                    "type": "String"
-                  },
-                  "profileName": {
-                    "type": "String"
-                  },
-                  "resourceName": {
-                    "type": "String"
-                  },
-                  "resourceType": {
-                    "type": "String"
-                  }
-                },
-                "resources": [
-                  {
-                    "apiVersion": "2021-05-01-preview",
-                    "condition": "[startsWith(parameters('resourceType'),'Microsoft.DBforPostgreSQL/flexibleServers')]",
-                    "dependsOn": [],
-                    "location": "[parameters('location')]",
-                    "name": "[concat(parameters('resourceName'), '/', 'Microsoft.Insights/', parameters('profileName'))]",
-                    "properties": {
-                      "logs": [
-                        {
-                          "category": "PostgreSQLLogs",
-                          "enabled": "[parameters('logsEnabled')]"
-                        }
-                      ],
-                      "metrics": [
-                        {
-                          "category": "AllMetrics",
-                          "enabled": "[parameters('metricsEnabled')]",
-                          "retentionPolicy": {
-                            "days": 0,
-                            "enabled": false
-                          },
-                          "timeGrain": null
-                        }
-                      ],
-                      "workspaceId": "[parameters('logAnalytics')]"
-                    },
-                    "type": "Microsoft.DBforPostgreSQL/flexibleServers/providers/diagnosticSettings"
-                  },
-                  {
-                    "apiVersion": "2021-05-01-preview",
-                    "condition": "[startsWith(parameters('resourceType'),'Microsoft.DBforPostgreSQL/servers')]",
-                    "dependsOn": [],
-                    "location": "[parameters('location')]",
-                    "name": "[concat(parameters('resourceName'), '/', 'Microsoft.Insights/', parameters('profileName'))]",
-                    "properties": {
-                      "logs": [
-                        {
-                          "category": "PostgreSQLLogs",
-                          "enabled": "[parameters('logsEnabled')]"
-                        },
-                        {
-                          "category": "QueryStoreRuntimeStatistics",
-                          "enabled": "[parameters('logsEnabled')]"
-                        },
-                        {
-                          "category": "QueryStoreWaitStatistics",
-                          "enabled": "[parameters('logsEnabled')]"
-                        }
-                      ],
-                      "metrics": [
-                        {
-                          "category": "AllMetrics",
-                          "enabled": "[parameters('metricsEnabled')]",
-                          "retentionPolicy": {
-                            "days": 0,
-                            "enabled": false
-                          },
-                          "timeGrain": null
-                        }
-                      ],
-                      "workspaceId": "[parameters('logAnalytics')]"
-                    },
-                    "type": "Microsoft.DBforPostgreSQL/servers/providers/diagnosticSettings"
-                  }
-                ],
-                "variables": {}
-              }
-            }
-          },
-          "existenceCondition": {
-            "allOf": [
-              {
-                "equals": "true",
-                "field": "Microsoft.Insights/diagnosticSettings/logs.enabled"
-              },
-              {
-                "equals": "true",
-                "field": "Microsoft.Insights/diagnosticSettings/metrics.enabled"
-              },
-              {
-                "equals": "[parameters('logAnalytics')]",
-                "field": "Microsoft.Insights/diagnosticSettings/workspaceId"
-              }
-            ]
-          },
-          "name": "[parameters('profileName')]",
-          "roleDefinitionIds": [
-            "/providers/microsoft.authorization/roleDefinitions/749f88d5-cbae-40b8-bcfc-e573ddc772fa",
-            "/providers/microsoft.authorization/roleDefinitions/92aaf0da-9dab-42b6-94a3-d43ce8d16293"
-          ],
-          "type": "Microsoft.Insights/diagnosticSettings"
-        },
-        "effect": "[parameters('effect')]"
-      }
-    },
-    "policyType": "Custom"
-  }
-}
+[
+	{
+		"apiVersion": "2021-05-01-preview",
+		"condition": "[startsWith(parameters('resourceType'),'Microsoft.DBforPostgreSQL/flexibleServers')]",
+		"dependsOn": [],
+		"location": "[parameters('location')]",
+		"name": "[concat(parameters('resourceName'), '/', 'Microsoft.Insights/', parameters('profileName'))]",
+		"properties": {
+			"logs": [
+				{
+					"category": "PostgreSQLLogs",
+					"enabled": "[parameters('logsEnabled')]"
+				}
+			],
+			"metrics": [
+				{
+					"category": "AllMetrics",
+					"enabled": "[parameters('metricsEnabled')]",
+					"retentionPolicy": {
+						"days": 0,
+						"enabled": false
+					},
+					"timeGrain": null
+				}
+			],
+			"workspaceId": "[parameters('logAnalytics')]"
+		},
+		"type": "Microsoft.DBforPostgreSQL/flexibleServers/providers/diagnosticSettings"
+	},
+	{
+		"apiVersion": "2021-05-01-preview",
+		"condition": "[startsWith(parameters('resourceType'),'Microsoft.DBforPostgreSQL/servers')]",
+		"dependsOn": [],
+		"location": "[parameters('location')]",
+		"name": "[concat(parameters('resourceName'), '/', 'Microsoft.Insights/', parameters('profileName'))]",
+		"properties": {
+			"logs": [
+				{
+					"category": "PostgreSQLLogs",
+					"enabled": "[parameters('logsEnabled')]"
+				},
+				{
+					"category": "QueryStoreRuntimeStatistics",
+					"enabled": "[parameters('logsEnabled')]"
+				},
+				{
+					"category": "QueryStoreWaitStatistics",
+					"enabled": "[parameters('logsEnabled')]"
+				}
+			],
+			"metrics": [
+				{
+					"category": "AllMetrics",
+					"enabled": "[parameters('metricsEnabled')]",
+					"retentionPolicy": {
+						"days": 0,
+						"enabled": false
+					},
+					"timeGrain": null
+				}
+			],
+			"workspaceId": "[parameters('logAnalytics')]"
+		},
+		"type": "Microsoft.DBforPostgreSQL/servers/providers/diagnosticSettings"
+	}
+]
 `
 	var old, new, expected any
 	_ = json.Unmarshal([]byte(OldJson), &old)

--- a/utils/json_test.go
+++ b/utils/json_test.go
@@ -3,6 +3,7 @@ package utils_test
 import (
 	"encoding/json"
 	"reflect"
+	"strconv"
 	"testing"
 
 	"github.com/Azure/terraform-provider-azapi/utils"
@@ -107,18 +108,28 @@ func Test_UpdateObject(t *testing.T) {
       "dnsServers": []
     },
     "subnets": [
-      {
-        "name": "default",
-        "properties": {
-          "addressPrefix": "10.0.3.0/24"
-        }
-      },
+			{
+				"etag": "W/\"5633f421-aaa4-4cf3-b9a6-40625807bd75\"",
+				"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/henglu422/providers/Microsoft.Network/virtualNetworks/henglu422/subnets/henglu422",
+				"name": "henglu422",
+				"properties": {
+					"addressPrefix": "10.0.2.0/24",
+					"delegations": [],
+					"networkSecurityGroup": {
+						"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/henglu422/providers/Microsoft.Network/networkSecurityGroups/NRMS-zpedr2ai6dglmhenglu422"
+					},
+					"privateEndpointNetworkPolicies": "Disabled",
+					"privateLinkServiceNetworkPolicies": "Enabled",
+					"provisioningState": "Succeeded"
+				},
+				"type": "Microsoft.Network/virtualNetworks/subnets"
+			},
       {
         "etag": "W/\"5633f421-aaa4-4cf3-b9a6-40625807bd75\"",
-        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/henglu422/providers/Microsoft.Network/virtualNetworks/henglu422/subnets/henglu422",
-        "name": "henglu422",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/henglu422/providers/Microsoft.Network/virtualNetworks/henglu422/subnets/default",
+        "name": "default",
         "properties": {
-          "addressPrefix": "10.0.2.0/24",
+          "addressPrefix": "10.0.3.0/24",
           "delegations": [],
           "networkSecurityGroup": {
             "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/henglu422/providers/Microsoft.Network/networkSecurityGroups/NRMS-zpedr2ai6dglmhenglu422"
@@ -216,18 +227,20 @@ func Test_UpdateObject(t *testing.T) {
 		},
 	}
 
-	for _, testcase := range testcases {
-		var new, old, expected interface{}
-		_ = json.Unmarshal([]byte(testcase.OldJson), &old)
-		_ = json.Unmarshal([]byte(testcase.NewJson), &new)
-		_ = json.Unmarshal([]byte(testcase.ExpectJson), &expected)
+	for i, testcase := range testcases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			var new, old, expected interface{}
+			_ = json.Unmarshal([]byte(testcase.OldJson), &old)
+			_ = json.Unmarshal([]byte(testcase.NewJson), &new)
+			_ = json.Unmarshal([]byte(testcase.ExpectJson), &expected)
 
-		result := utils.UpdateObject(old, new, testcase.Option)
-		if !reflect.DeepEqual(result, expected) {
-			expectedJson, _ := json.Marshal(expected)
-			resultJson, _ := json.Marshal(result)
-			t.Fatalf("Expected %s but got %s", expectedJson, resultJson)
-		}
+			result := utils.UpdateObject(old, new, testcase.Option)
+			if !reflect.DeepEqual(result, expected) {
+				expectedJson, _ := json.MarshalIndent(expected, "", "  ")
+				resultJson, _ := json.MarshalIndent(result, "", "  ")
+				t.Fatalf("Expected \n\n%s\n\nbut got\n\n%s", expectedJson, resultJson)
+			}
+		})
 	}
 }
 
@@ -647,6 +660,63 @@ func Test_UpdateObjectDuplicateIdentifiers(t *testing.T) {
 	var old, new, expected any
 	_ = json.Unmarshal([]byte(OldJson), &old)
 	_ = json.Unmarshal([]byte(OldJson), &new)
+	_ = json.Unmarshal([]byte(OldJson), &expected)
+
+	got := utils.UpdateObject(old, new, utils.UpdateJsonOption{
+		IgnoreCasing:          false,
+		IgnoreMissingProperty: true,
+	})
+	if !reflect.DeepEqual(got, expected) {
+		expectedJson, _ := json.MarshalIndent(expected, "", "  ")
+		gotJson, _ := json.MarshalIndent(got, "", "  ")
+		t.Fatalf("Expected:\n%s\n\n but got\n%s", expectedJson, gotJson)
+	}
+}
+
+func Test_UpdateObjectDuplicateIdentifiersUnordered(t *testing.T) {
+	OldJson := `
+{
+	"contentFilters": [
+		{
+			"name": "Hate",
+			"allowedContentLevel": "Medium",
+			"blocking": true,
+			"enabled": true,
+			"source": "Prompt"
+		},
+		{
+			"name": "Hate",
+			"allowedContentLevel": "Medium",
+			"blocking": true,
+			"enabled": true,
+			"source": "Completion"
+		}
+	]
+}
+`
+	NewJson := `
+{
+	"contentFilters": [
+		{
+				"name": "Hate",
+				"allowedContentLevel": "Medium",
+				"blocking": true,
+				"enabled": true,
+				"source": "Completion"
+		},
+		{
+				"name": "Hate",
+				"allowedContentLevel": "Medium",
+				"blocking": true,
+				"enabled": true,
+				"source": "Prompt"
+		}
+	]
+}
+`
+	var old, new, expected any
+	_ = json.Unmarshal([]byte(OldJson), &old)
+	_ = json.Unmarshal([]byte(NewJson), &new)
 	_ = json.Unmarshal([]byte(OldJson), &expected)
 
 	got := utils.UpdateObject(old, new, utils.UpdateJsonOption{


### PR DESCRIPTION
fixes #545

`utils.UpdateObject` would duplicate array members under certain conditions.

Adds `reflect.DeepEqual()` check to start of `utils.UpdateObject` to return early if old is the same as new. This could be masking the original bug but it's still probably a worthy thing to do.

This PR adds a test, which used to fail but now passes.

Pinging @ms-henglu 