### PR TITLE
bugfix: inconsistent results when the case of `resource_id` and `type` are different

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 BUG FIXES:
 - Fix a bug that differences in a list of objects are not detected correctly.
+- Fix a bug that azapi_update_resource produced inconsistent results when the case of the `resource_id` and `type` fields are different.
 
 ## v1.14.0
 FEATURES:


### PR DESCRIPTION
fixes https://github.com/Azure/terraform-provider-azapi/issues/554