### PR TITLE
Branch 240807 deprecate features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v2.0.0-beta
+BREAKING CHANGES:
+- Provider field `default_naming_prefix` and `default_naming_suffix` are removed. Please specify the naming prefix and suffix in the resource's `name` field instead.
+- Provider field `enable_hcl_output_for_data_source` is removed. The `output` field in the data source is always in HCL format.
+- The `azapi_resource`'s `removing_special_chars` field is removed. Please specify the `name` field and remove the special characters in the `name` field instead.
+
+
 ## v1.15.0
 
 ENHANCEMENTS:
@@ -31,8 +38,8 @@ BUG FIXES:
 ENHANCEMENTS:
 - `azapi` provider: Support `enable_hcl_output_for_data_source` field, which is used to enable the HCL output for the data source, the default value is `false`.
   This could resolve the following breaking changes in the previous release:
-  - `azapi_resource` data source: The `output` field changes from JSON string to HCL object. Users can use access the fields in the output as an HCL object. Please remove the `jsondecode` function when using the `output` field.
-  - `azapi_resource_list` data source: The `output` field changes from JSON string to HCL object. Users can use access the fields in the output as an HCL object. Please remove the `jsondecode` function when using the `output` field.
+- `azapi_resource` data source: The `output` field changes from JSON string to HCL object. Users can use access the fields in the output as an HCL object. Please remove the `jsondecode` function when using the `output` field.
+- `azapi_resource_list` data source: The `output` field changes from JSON string to HCL object. Users can use access the fields in the output as an HCL object. Please remove the `jsondecode` function when using the `output` field.
 
 BUG FIXES:
 - Fix a bug when upgrading from previous provider `azapi_resource` resource will set `tags` for resources that don't have `tags` in the configuration.

--- a/docs/data-sources/azapi_resource.md
+++ b/docs/data-sources/azapi_resource.md
@@ -22,7 +22,6 @@ terraform {
 }
 
 provider "azapi" {
-  enable_hcl_output_for_data_source = true
 }
 
 provider "azurerm" {
@@ -111,8 +110,7 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `location` - The Azure Region where the azure resource should exist.
 
-* `output` - The output containing the properties specified in `response_export_values`. It supports both JSON and HCL object. By default, it will be in JSON format.
-  If specifying `enable_hcl_output_for_data_source` to `true` in the provider block, it will be in HCL format.
+* `output` - The output containing the properties specified in `response_export_values`. It is stored in HCL format.
 
 
   *Examples to use the values in HCL format:*
@@ -125,18 +123,6 @@ output "login_server" {
 // it will output "disabled"
 output "quarantine_policy" {
   value = data.azapi_resource.example.output.properties.policies.quarantinePolicy.status
-}
-```
-*Examples to use the values in JSON format:*
-```hcl
-// it will output "registry1.azurecr.io"
-output "login_server" {
-  value = jsondecode(data.azapi_resource.example.output).properties.loginServer
-}
-
-// it will output "disabled"
-output "quarantine_policy" {
-  value = jsondecode(data.azapi_resource.example.output).properties.policies.quarantinePolicy.status
 }
 ```
 

--- a/docs/data-sources/azapi_resource_action.md
+++ b/docs/data-sources/azapi_resource_action.md
@@ -24,7 +24,6 @@ terraform {
 }
 
 provider "azapi" {
-  enable_hcl_output_for_data_source = true
 }
 
 provider "azurerm" {
@@ -67,7 +66,6 @@ provider "azurerm" {
 }
 
 provider "azapi" {
-  enable_hcl_output_for_data_source = true
 }
 
 data "azurerm_client_config" "current" {}
@@ -92,7 +90,6 @@ terraform {
 }
 
 provider "azapi" {
-  enable_hcl_output_for_data_source = true
 }
 
 resource "azapi_resource_action" "test" {
@@ -148,8 +145,7 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `id` - The ID of the azure resource action.
 
-* `output` - The output containing the properties specified in `response_export_values`. It supports both JSON and HCL object. By default, it will be in JSON format.
-  If specifying `enable_hcl_output_for_data_source` to `true` in the provider block, it will be in HCL format.
+* `output` - The output containing the properties specified in `response_export_values`. It is stored in HCL format.
 
 
 *Examples to use the values in HCL format:*
@@ -162,18 +158,6 @@ output "primary_key" {
 // it will output "6yoCad******SLzKzg=="
 output "secondary_key" {
   value = data.azapi_resource_action.example.output.keys.1.Value
-}
-```
-*Examples to use the values in JSON format:*
-```hcl
-// it will output "nHGYNd******i4wdug=="
-output "primary_key" {
-  value = jsondecode(data.azapi_resource.example.output).keys.0.Value
-}
-
-// it will output "6yoCad******SLzKzg=="
-output "secondary_key" {
-  value = jsondecode(data.azapi_resource.example.output).keys.1.Value
 }
 ```
 

--- a/docs/data-sources/azapi_resource_list.md
+++ b/docs/data-sources/azapi_resource_list.md
@@ -22,7 +22,6 @@ terraform {
 }
 
 provider "azapi" {
-  enable_hcl_output_for_data_source = true
 }
 
 data "azapi_resource_list" "listBySubscription" {
@@ -80,20 +79,13 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `id` - The ID of the azure resource list.
 
-* `output` - The output containing the properties specified in `response_export_values`. It supports both JSON and HCL object. By default, it will be in JSON format.
-  If specifying `enable_hcl_output_for_data_source` to `true` in the provider block, it will be in HCL format.
+* `output` - The output containing the properties specified in `response_export_values`. It is stored in HCL format.
 
 
 *Examples to use the values in HCL format:*
 ```hcl
 output "value" {
   value = data.azapi_resource_list.example.output.value
-}
-```
-*Examples to use the values in JSON format:*
-```hcl
-output "value" {
-  value = jsondecode(data.azapi_resource_list.example.output).value
 }
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -76,10 +76,6 @@ It's possible to configure the behaviour of certain resources using the followin
 
 * `default_name` - (Optional) The default name to create the azure resource. `name` in each resource block can override the `default_name`. Conflicts with `default_name_prefix`, `default_naming_suffix`. Changing this forces new resources to be created.
 
-* `default_naming_prefix` - (Optional) The default name prefix to create the azure resource. Used together with `name` in each resource block. Conflicts with `default_name`. Changing this forces new resources to be created.
-
-* `default_naming_suffix` - (Optional) The default name suffix to create the azure resource. Used together with `name` in each resource block. Conflicts with `default_name`. Changing this forces new resources to be created.
-
 * `endpoint` - (Optional) A `endpoint` block as defined below.
 
 ---

--- a/docs/index.md
+++ b/docs/index.md
@@ -165,5 +165,3 @@ For some advanced scenarios, such as where more granular permissions are necessa
 * `skip_provider_registration` - (Optional) Should the Provider skip registering the Resource Providers it supports? This can also be sourced from the `ARM_SKIP_PROVIDER_REGISTRATION` Environment Variable. Defaults to `false`.
 
 -> By default, Terraform will attempt to register the Resource Providers that the provisioning resources belong to. If you're running in an environment with restricted permissions, or wish to manage Resource Provider Registration outside of Terraform you may wish to disable this flag; however, please note that the error messages returned from Azure may be confusing as a result (example: `API version 2019-01-01 was not found for Microsoft.Foo`).
-
-* `enable_hcl_output_for_data_source` - (Optional) Should the provider return the output in HCL format for data sources? Defaults to `false`. When set to `true`, the provider will return HCL output for data sources. When set to `false`, the provider will return JSON output for data sources.

--- a/docs/resources/azapi_resource.md
+++ b/docs/resources/azapi_resource.md
@@ -96,9 +96,7 @@ The following arguments are supported:
 * `type` - (Required) It is in a format like `<resource-type>@<api-version>`. `<resource-type>` is the Azure resource type, for example, `Microsoft.Storage/storageAccounts`.
   `<api-version>` is version of the API used to manage this azure resource.
 
-* `body` - (Required) A dynamic attribute that contains the request body used to create and update azure resource. 
-
-* `removing_special_chars` - (Optional) Whether to remove special characters in resource name. Defaults to `false`.
+* `body` - (Required) A dynamic attribute that contains the request body used to create and update azure resource.
 
 ---
   

--- a/internal/features/user_flags.go
+++ b/internal/features/user_flags.go
@@ -1,19 +1,15 @@
 package features
 
 type UserFeatures struct {
-	DefaultTags                  map[string]string
-	DefaultLocation              string
-	DefaultNaming                string
-	CafEnabled                   bool
-	EnableHCLOutputForDataSource bool
+	DefaultTags     map[string]string
+	DefaultLocation string
+	DefaultNaming   string
 }
 
 func Default() UserFeatures {
 	return UserFeatures{
-		DefaultTags:                  nil,
-		DefaultLocation:              "",
-		DefaultNaming:                "",
-		CafEnabled:                   false,
-		EnableHCLOutputForDataSource: false,
+		DefaultTags:     nil,
+		DefaultLocation: "",
+		DefaultNaming:   "",
 	}
 }

--- a/internal/features/user_flags.go
+++ b/internal/features/user_flags.go
@@ -4,8 +4,6 @@ type UserFeatures struct {
 	DefaultTags                  map[string]string
 	DefaultLocation              string
 	DefaultNaming                string
-	DefaultNamingPrefix          string
-	DefaultNamingSuffix          string
 	CafEnabled                   bool
 	EnableHCLOutputForDataSource bool
 }
@@ -15,8 +13,6 @@ func Default() UserFeatures {
 		DefaultTags:                  nil,
 		DefaultLocation:              "",
 		DefaultNaming:                "",
-		DefaultNamingPrefix:          "",
-		DefaultNamingSuffix:          "",
 		CafEnabled:                   false,
 		EnableHCLOutputForDataSource: false,
 	}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -65,8 +65,6 @@ type providerData struct {
 	DisableCorrelationRequestID  types.Bool   `tfsdk:"disable_correlation_request_id"`
 	DisableTerraformPartnerID    types.Bool   `tfsdk:"disable_terraform_partner_id"`
 	DefaultName                  types.String `tfsdk:"default_name"`
-	DefaultNamingPrefix          types.String `tfsdk:"default_naming_prefix"`
-	DefaultNamingSuffix          types.String `tfsdk:"default_naming_suffix"`
 	DefaultLocation              types.String `tfsdk:"default_location"`
 	DefaultTags                  types.Map    `tfsdk:"default_tags"`
 	EnableHCLOutputForDataSource types.Bool   `tfsdk:"enable_hcl_output_for_data_source"`
@@ -322,18 +320,6 @@ func (p Provider) Schema(ctx context.Context, request provider.SchemaRequest, re
 				Description: "The default name which should be used for resources.",
 			},
 
-			"default_naming_prefix": schema.StringAttribute{
-				DeprecationMessage: "This field is deprecated and will be removed in a major release. Please specify the naming prefix and suffix in the resource's `name` field instead.",
-				Optional:           true,
-				Description:        "The default prefix which should be used for resources.",
-			},
-
-			"default_naming_suffix": schema.StringAttribute{
-				DeprecationMessage: "This field is deprecated and will be removed in a major release. Please specify the naming prefix and suffix in the resource's `name` field instead.",
-				Optional:           true,
-				Description:        "The default suffix which should be used for resources.",
-			},
-
 			"default_location": schema.StringAttribute{
 				Optional:    true,
 				Description: "The default location which should be used for resources.",
@@ -359,11 +345,6 @@ func (p Provider) Schema(ctx context.Context, request provider.SchemaRequest, re
 func (p Provider) Configure(ctx context.Context, request provider.ConfigureRequest, response *provider.ConfigureResponse) {
 	var model providerData
 	if response.Diagnostics.Append(request.Config.Get(ctx, &model)...); response.Diagnostics.HasError() {
-		return
-	}
-
-	if !model.DefaultName.IsNull() && (!model.DefaultNamingPrefix.IsNull() || !model.DefaultNamingSuffix.IsNull()) {
-		response.Diagnostics.AddError("Invalid `default_name` value.", "The `default_name` value cannot be used with `default_naming_prefix` or `default_naming_suffix`.")
 		return
 	}
 
@@ -627,8 +608,6 @@ func (p Provider) Configure(ctx context.Context, request provider.ConfigureReque
 			DefaultTags:                  tags.ExpandTags(model.DefaultTags),
 			DefaultLocation:              location.Normalize(model.DefaultLocation.ValueString()),
 			DefaultNaming:                model.DefaultName.ValueString(),
-			DefaultNamingPrefix:          model.DefaultNamingPrefix.ValueString(),
-			DefaultNamingSuffix:          model.DefaultNamingSuffix.ValueString(),
 			EnableHCLOutputForDataSource: model.EnableHCLOutputForDataSource.ValueBool(),
 		},
 		SkipProviderRegistration:    model.SkipProviderRegistration.ValueBool(),

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -39,35 +39,34 @@ type Provider struct {
 }
 
 type providerData struct {
-	SubscriptionID               types.String `tfsdk:"subscription_id"`
-	ClientID                     types.String `tfsdk:"client_id"`
-	ClientIDFilePath             types.String `tfsdk:"client_id_file_path"`
-	TenantID                     types.String `tfsdk:"tenant_id"`
-	AuxiliaryTenantIDs           types.List   `tfsdk:"auxiliary_tenant_ids"`
-	Endpoint                     types.List   `tfsdk:"endpoint"`
-	Environment                  types.String `tfsdk:"environment"`
-	ClientCertificate            types.String `tfsdk:"client_certificate"`
-	ClientCertificatePath        types.String `tfsdk:"client_certificate_path"`
-	ClientCertificatePassword    types.String `tfsdk:"client_certificate_password"`
-	ClientSecret                 types.String `tfsdk:"client_secret"`
-	ClientSecretFilePath         types.String `tfsdk:"client_secret_file_path"`
-	SkipProviderRegistration     types.Bool   `tfsdk:"skip_provider_registration"`
-	OIDCRequestToken             types.String `tfsdk:"oidc_request_token"`
-	OIDCRequestURL               types.String `tfsdk:"oidc_request_url"`
-	OIDCToken                    types.String `tfsdk:"oidc_token"`
-	OIDCTokenFilePath            types.String `tfsdk:"oidc_token_file_path"`
-	UseOIDC                      types.Bool   `tfsdk:"use_oidc"`
-	UseCLI                       types.Bool   `tfsdk:"use_cli"`
-	UseMSI                       types.Bool   `tfsdk:"use_msi"`
-	UseAKSWorkloadIdentity       types.Bool   `tfsdk:"use_aks_workload_identity"`
-	PartnerID                    types.String `tfsdk:"partner_id"`
-	CustomCorrelationRequestID   types.String `tfsdk:"custom_correlation_request_id"`
-	DisableCorrelationRequestID  types.Bool   `tfsdk:"disable_correlation_request_id"`
-	DisableTerraformPartnerID    types.Bool   `tfsdk:"disable_terraform_partner_id"`
-	DefaultName                  types.String `tfsdk:"default_name"`
-	DefaultLocation              types.String `tfsdk:"default_location"`
-	DefaultTags                  types.Map    `tfsdk:"default_tags"`
-	EnableHCLOutputForDataSource types.Bool   `tfsdk:"enable_hcl_output_for_data_source"`
+	SubscriptionID              types.String `tfsdk:"subscription_id"`
+	ClientID                    types.String `tfsdk:"client_id"`
+	ClientIDFilePath            types.String `tfsdk:"client_id_file_path"`
+	TenantID                    types.String `tfsdk:"tenant_id"`
+	AuxiliaryTenantIDs          types.List   `tfsdk:"auxiliary_tenant_ids"`
+	Endpoint                    types.List   `tfsdk:"endpoint"`
+	Environment                 types.String `tfsdk:"environment"`
+	ClientCertificate           types.String `tfsdk:"client_certificate"`
+	ClientCertificatePath       types.String `tfsdk:"client_certificate_path"`
+	ClientCertificatePassword   types.String `tfsdk:"client_certificate_password"`
+	ClientSecret                types.String `tfsdk:"client_secret"`
+	ClientSecretFilePath        types.String `tfsdk:"client_secret_file_path"`
+	SkipProviderRegistration    types.Bool   `tfsdk:"skip_provider_registration"`
+	OIDCRequestToken            types.String `tfsdk:"oidc_request_token"`
+	OIDCRequestURL              types.String `tfsdk:"oidc_request_url"`
+	OIDCToken                   types.String `tfsdk:"oidc_token"`
+	OIDCTokenFilePath           types.String `tfsdk:"oidc_token_file_path"`
+	UseOIDC                     types.Bool   `tfsdk:"use_oidc"`
+	UseCLI                      types.Bool   `tfsdk:"use_cli"`
+	UseMSI                      types.Bool   `tfsdk:"use_msi"`
+	UseAKSWorkloadIdentity      types.Bool   `tfsdk:"use_aks_workload_identity"`
+	PartnerID                   types.String `tfsdk:"partner_id"`
+	CustomCorrelationRequestID  types.String `tfsdk:"custom_correlation_request_id"`
+	DisableCorrelationRequestID types.Bool   `tfsdk:"disable_correlation_request_id"`
+	DisableTerraformPartnerID   types.Bool   `tfsdk:"disable_terraform_partner_id"`
+	DefaultName                 types.String `tfsdk:"default_name"`
+	DefaultLocation             types.String `tfsdk:"default_location"`
+	DefaultTags                 types.Map    `tfsdk:"default_tags"`
 }
 
 func (model providerData) GetClientId() (*string, error) {
@@ -333,11 +332,6 @@ func (p Provider) Schema(ctx context.Context, request provider.SchemaRequest, re
 				},
 				Description: "The default tags which should be used for resources.",
 			},
-
-			"enable_hcl_output_for_data_source": schema.BoolAttribute{
-				Optional:    true,
-				Description: "Enable HCL output for data sources. The default is false. When set to true, the provider will return HCL output for data sources. When set to false, the provider will return JSON output for data sources.",
-			},
 		},
 	}
 }
@@ -534,10 +528,6 @@ func (p Provider) Configure(ctx context.Context, request provider.ConfigureReque
 		}
 	}
 
-	if model.EnableHCLOutputForDataSource.IsNull() {
-		model.EnableHCLOutputForDataSource = types.BoolValue(false)
-	}
-
 	var cloudConfig cloud.Configuration
 	env := model.Environment.ValueString()
 	switch strings.ToLower(env) {
@@ -605,10 +595,9 @@ func (p Provider) Configure(ctx context.Context, request provider.ConfigureReque
 		CloudCfg:             cloudConfig,
 		ApplicationUserAgent: buildUserAgent(request.TerraformVersion, model.PartnerID.ValueString(), model.DisableTerraformPartnerID.ValueBool()),
 		Features: features.UserFeatures{
-			DefaultTags:                  tags.ExpandTags(model.DefaultTags),
-			DefaultLocation:              location.Normalize(model.DefaultLocation.ValueString()),
-			DefaultNaming:                model.DefaultName.ValueString(),
-			EnableHCLOutputForDataSource: model.EnableHCLOutputForDataSource.ValueBool(),
+			DefaultTags:     tags.ExpandTags(model.DefaultTags),
+			DefaultLocation: location.Normalize(model.DefaultLocation.ValueString()),
+			DefaultNaming:   model.DefaultName.ValueString(),
 		},
 		SkipProviderRegistration:    model.SkipProviderRegistration.ValueBool(),
 		DisableCorrelationRequestID: model.DisableCorrelationRequestID.ValueBool(),

--- a/internal/services/azapi_resource.go
+++ b/internal/services/azapi_resource.go
@@ -51,7 +51,6 @@ type AzapiResourceModel struct {
 	Identity                types.List     `tfsdk:"identity"`
 	Body                    types.Dynamic  `tfsdk:"body"`
 	Locks                   types.List     `tfsdk:"locks"`
-	RemovingSpecialChars    types.Bool     `tfsdk:"removing_special_chars"`
 	SchemaValidationEnabled types.Bool     `tfsdk:"schema_validation_enabled"`
 	IgnoreBodyChanges       types.List     `tfsdk:"ignore_body_changes"`
 	IgnoreCasing            types.Bool     `tfsdk:"ignore_casing"`
@@ -105,13 +104,6 @@ func (r *AzapiResource) Schema(ctx context.Context, _ resource.SchemaRequest, re
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
-			},
-
-			"removing_special_chars": schema.BoolAttribute{
-				DeprecationMessage: "This feature is deprecated and will be removed in a major release. Please use the `name` argument to specify the name of the resource.",
-				Optional:           true,
-				Computed:           true,
-				Default:            defaults.BoolDefault(false),
 			},
 
 			"parent_id": schema.StringAttribute{
@@ -775,7 +767,6 @@ func (r *AzapiResource) ImportState(ctx context.Context, request resource.Import
 		Locks:                   types.ListNull(types.StringType),
 		Identity:                types.ListNull(identity.Model{}.ModelType()),
 		Body:                    types.DynamicNull(),
-		RemovingSpecialChars:    types.BoolValue(false),
 		SchemaValidationEnabled: types.BoolValue(true),
 		IgnoreBodyChanges:       types.ListNull(types.StringType),
 		IgnoreCasing:            types.BoolValue(false),

--- a/internal/services/azapi_resource_action_data_source.go
+++ b/internal/services/azapi_resource_action_data_source.go
@@ -151,11 +151,7 @@ func (r *ResourceActionDataSource) Read(ctx context.Context, request datasource.
 	}
 
 	model.ID = basetypes.NewStringValue(id.ID())
-	if dynamicIsString(model.Body) || !r.ProviderData.Features.EnableHCLOutputForDataSource {
-		model.Output = types.DynamicValue(basetypes.NewStringValue(flattenOutput(responseBody, AsStringList(model.ResponseExportValues))))
-	} else {
-		model.Output = types.DynamicValue(flattenOutputPayload(responseBody, AsStringList(model.ResponseExportValues)))
-	}
+	model.Output = types.DynamicValue(flattenOutputPayload(responseBody, AsStringList(model.ResponseExportValues)))
 
 	response.Diagnostics.Append(response.State.Set(ctx, &model)...)
 }

--- a/internal/services/azapi_resource_action_data_source_test.go
+++ b/internal/services/azapi_resource_action_data_source_test.go
@@ -142,7 +142,6 @@ data "azapi_resource_action" "test" {
 func (r ActionDataSource) dynamicSchemaHclOutput() string {
 	return `
 provider "azapi" {
-  enable_hcl_output_for_data_source = true
 }
 
 data "azapi_resource_action" "test" {

--- a/internal/services/azapi_resource_data_source.go
+++ b/internal/services/azapi_resource_data_source.go
@@ -214,10 +214,6 @@ func (r *AzapiResourceDataSource) Read(ctx context.Context, request datasource.R
 			model.Identity = identity.ToList(*v)
 		}
 	}
-	if r.ProviderData.Features.EnableHCLOutputForDataSource {
-		model.Output = types.DynamicValue(flattenOutputPayload(responseBody, AsStringList(model.ResponseExportValues)))
-	} else {
-		model.Output = types.DynamicValue(types.StringValue(flattenOutput(responseBody, AsStringList(model.ResponseExportValues))))
-	}
+	model.Output = types.DynamicValue(types.StringValue(flattenOutput(responseBody, AsStringList(model.ResponseExportValues))))
 	response.Diagnostics.Append(response.State.Set(ctx, &model)...)
 }

--- a/internal/services/azapi_resource_data_source_test.go
+++ b/internal/services/azapi_resource_data_source_test.go
@@ -127,7 +127,6 @@ func (r GenericDataSource) hclOutput(data acceptance.TestData) string {
 %s
 
 provider "azapi" {
-  enable_hcl_output_for_data_source = true
 }
 
 data "azapi_resource" "test" {

--- a/internal/services/azapi_resource_list_data_source.go
+++ b/internal/services/azapi_resource_list_data_source.go
@@ -117,10 +117,6 @@ func (r *ResourceListDataSource) Read(ctx context.Context, request datasource.Re
 	}
 
 	model.ID = basetypes.NewStringValue(listUrl)
-	if r.ProviderData.Features.EnableHCLOutputForDataSource {
-		model.Output = types.DynamicValue(flattenOutputPayload(responseBody, AsStringList(model.ResponseExportValues)))
-	} else {
-		model.Output = types.DynamicValue(types.StringValue(flattenOutput(responseBody, AsStringList(model.ResponseExportValues))))
-	}
+	model.Output = types.DynamicValue(types.StringValue(flattenOutput(responseBody, AsStringList(model.ResponseExportValues))))
 	response.Diagnostics.Append(response.State.Set(ctx, &model)...)
 }

--- a/internal/services/azapi_resource_list_data_source_test.go
+++ b/internal/services/azapi_resource_list_data_source_test.go
@@ -73,7 +73,6 @@ provider "azurerm" {
 }
 
 provider "azapi" {
-  enable_hcl_output_for_data_source = true
 }
 
 data "azurerm_client_config" "current" {}

--- a/internal/services/azapi_resource_test.go
+++ b/internal/services/azapi_resource_test.go
@@ -22,7 +22,7 @@ import (
 type GenericResource struct{}
 
 func defaultIgnores() []string {
-	return []string{"ignore_casing", "ignore_missing_property", "schema_validation_enabled", "body", "locks", "removing_special_chars", "output"}
+	return []string{"ignore_casing", "ignore_missing_property", "schema_validation_enabled", "body", "locks", "output"}
 }
 
 var testCertRaw, _ = os.ReadFile(filepath.Join("testdata", "automation_certificate_test.pfx"))

--- a/internal/services/azapi_resource_test.go
+++ b/internal/services/azapi_resource_test.go
@@ -310,22 +310,6 @@ func TestAccGenericResource_defaultsNaming(t *testing.T) {
 	})
 }
 
-func TestAccGenericResource_defaultsNamingPrefixAndSuffix(t *testing.T) {
-	t.Skip(`The default naming prefix and suffix are not compatible with the framework, because the computed name is not the same as the config name, the framework will fail as it's an invalid plan'`)
-	data := acceptance.BuildTestData(t, "azapi_resource", "test")
-	r := GenericResource{}
-
-	data.ResourceTest(t, r, []resource.TestStep{
-		{
-			Config: r.defaultNamingWithPrefixAndSuffix(data),
-			Check: resource.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(defaultIgnores()...),
-	})
-}
-
 func TestAccGenericResource_subscriptionScope(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azapi_resource", "test")
 	r := GenericResource{}
@@ -1032,31 +1016,6 @@ resource "azapi_resource" "test" {
   })
 }
 `, r.template(data))
-}
-
-func (r GenericResource) defaultNamingWithPrefixAndSuffix(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-%s
-provider "azapi" {
-  default_naming_prefix = "p%[2]s-"
-  default_naming_suffix = "-s%[2]s"
-}
-
-resource "azapi_resource" "test" {
-  type      = "Microsoft.Automation/automationAccounts@2023-11-01"
-  name      = "acc"
-  parent_id = azurerm_resource_group.test.id
-
-  location = azurerm_resource_group.test.location
-  body = jsonencode({
-    properties = {
-      sku = {
-        name = "Basic"
-      }
-    }
-  })
-}
-`, r.template(data), data.RandomString)
 }
 
 func (r GenericResource) defaultsNotApplicable(data acceptance.TestData) string {


### PR DESCRIPTION
This PR adds the following breaking changes in 2.0 beta:
- Provider field `default_naming_prefix` and `default_naming_suffix` are removed. Please specify the naming prefix and suffix in the resource's `name` field instead.
- Provider field `enable_hcl_output_for_data_source` is removed. The `output` field in the data source is always in HCL format.
- The `azapi_resource`'s `removing_special_chars` field is removed. Please specify the `name` field and remove the special characters in the `name` field instead.