### PR TITLE
bugfix: state migration should target the latest schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ BREAKING CHANGES:
 - The `body` field now only accepts an HCL object. Please remove the `jsondecode` function when using the `body` field.
 - The `output` field now only exports an HCL object. Please remove the `jsondecode` function when using the `output` field.
 
+ENHANCEMENTS:
+- `azapi_resource` resource: Support `replace_triggers_external_values` field which is used to trigger a replacement of the resource.
+- `azapi` resources and data sources: Support `retry` field, which is used to specify the retry configuration.
+- 
+
 ## v1.15.0
 
 ENHANCEMENTS:

--- a/internal/services/azapi_data_plane_resource.go
+++ b/internal/services/azapi_data_plane_resource.go
@@ -66,7 +66,7 @@ func (r *DataPlaneResource) Metadata(ctx context.Context, request resource.Metad
 
 func (r *DataPlaneResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
 	return map[int64]resource.StateUpgrader{
-		0: migration.AzapiDataPlaneResourceMigrationV0ToV1(ctx),
+		0: migration.AzapiDataPlaneResourceMigrationV0ToV2(ctx),
 		1: migration.AzapiDataPlaneResourceMigrationV1ToV2(ctx),
 	}
 }

--- a/internal/services/azapi_data_plane_resource_test.go
+++ b/internal/services/azapi_data_plane_resource_test.go
@@ -401,3 +401,36 @@ resource "azapi_data_plane_resource" "test" {
 }
 `, data.LocationPrimary, data.RandomString)
 }
+
+func (r DataPlaneResource) oldConfig(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "example" {
+  name     = "acctest%[2]s"
+  location = "%[1]s"
+}
+
+resource "azurerm_purview_account" "example" {
+  name                = "acctest%[2]s"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+
+resource "azapi_data_plane_resource" "test" {
+  type      = "Microsoft.Purview/accounts/Account/collections@2019-11-01-preview"
+  parent_id = "${azurerm_purview_account.example.name}.purview.azure.com"
+  name      = "defaultResourceSetRuleConfig"
+  body = jsonencode({
+    friendlyName = "Finance"
+  })
+  response_export_values = ["*"]
+}
+`, data.LocationPrimary, data.RandomString)
+}

--- a/internal/services/azapi_data_plane_resource_upgrade_test.go
+++ b/internal/services/azapi_data_plane_resource_upgrade_test.go
@@ -136,7 +136,7 @@ func TestAccAzapiDataPlaneResourceUpgrade_basic_from_schema_v0(t *testing.T) {
 	r := DataPlaneResource{}
 
 	updatedConfig := r.oldConfig(data)
-	updatedConfig = strings.ReplaceAll(r.oldConfig(data), "jsonencode({", "{")
+	updatedConfig = strings.ReplaceAll(updatedConfig, "jsonencode({", "{")
 	updatedConfig = strings.ReplaceAll(updatedConfig, "})", "}")
 
 	data.UpgradeTest(t, r, []resource.TestStep{

--- a/internal/services/azapi_data_plane_resource_upgrade_test.go
+++ b/internal/services/azapi_data_plane_resource_upgrade_test.go
@@ -130,3 +130,24 @@ func TestAccAzapiDataPlaneResourceUpgrade_timeouts_from_v1_13_1(t *testing.T) {
 		}),
 	})
 }
+
+func TestAccAzapiDataPlaneResourceUpgrade_basic_from_schema_v0(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azapi_data_plane_resource", "test")
+	r := DataPlaneResource{}
+
+	updatedConfig := r.oldConfig(data)
+	updatedConfig = strings.ReplaceAll(r.oldConfig(data), "jsonencode({", "{")
+	updatedConfig = strings.ReplaceAll(updatedConfig, "})", "}")
+
+	data.UpgradeTest(t, r, []resource.TestStep{
+		data.UpgradeTestDeployStep(resource.TestStep{
+			Config: r.oldConfig(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		}, "1.12.1"),
+		data.UpgradeTestPlanStep(resource.TestStep{
+			Config: updatedConfig,
+		}),
+	})
+}

--- a/internal/services/azapi_resource.go
+++ b/internal/services/azapi_resource.go
@@ -88,7 +88,7 @@ func (r *AzapiResource) Metadata(_ context.Context, request resource.MetadataReq
 
 func (r *AzapiResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
 	return map[int64]resource.StateUpgrader{
-		0: migration.AzapiResourceMigrationV0ToV1(ctx),
+		0: migration.AzapiResourceMigrationV0ToV2(ctx),
 		1: migration.AzapiResourceMigrationV1ToV2(ctx),
 	}
 }

--- a/internal/services/azapi_resource_action_resource.go
+++ b/internal/services/azapi_resource_action_resource.go
@@ -65,7 +65,7 @@ func (r *ActionResource) Metadata(ctx context.Context, request resource.Metadata
 
 func (r *ActionResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
 	return map[int64]resource.StateUpgrader{
-		0: migration.AzapiResourceActionMigrationV0ToV1(ctx),
+		0: migration.AzapiResourceActionMigrationV0ToV2(ctx),
 		1: migration.AzapiResourceActionMigrationV1ToV2(ctx),
 	}
 }

--- a/internal/services/azapi_resource_action_resource_test.go
+++ b/internal/services/azapi_resource_action_resource_test.go
@@ -156,10 +156,10 @@ provider "azurerm" {
 data "azurerm_client_config" "current" {}
 
 resource "azapi_resource_action" "test" {
-  type        = "Microsoft.Resources/providers@2021-04-01"
-  resource_id = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/providers/Microsoft.Compute"
-  action      = "register"
-  method      = "POST"
+  type                   = "Microsoft.Resources/providers@2021-04-01"
+  resource_id            = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/providers/Microsoft.Compute"
+  action                 = "register"
+  method                 = "POST"
   response_export_values = ["*"]
 }
 `

--- a/internal/services/azapi_resource_action_resource_test.go
+++ b/internal/services/azapi_resource_action_resource_test.go
@@ -160,6 +160,7 @@ resource "azapi_resource_action" "test" {
   resource_id = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/providers/Microsoft.Compute"
   action      = "register"
   method      = "POST"
+  response_export_values = ["*"]
 }
 `
 }
@@ -282,4 +283,25 @@ resource "azapi_resource_action" "test" {
   }
 }
 `, GenericResource{}.identityNone(data))
+}
+
+func (r ActionResource) oldConfig(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+data "azurerm_client_config" "current" {}
+
+resource "azapi_resource_action" "test" {
+  type        = "Microsoft.Cache@2023-04-01"
+  resource_id = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/providers/Microsoft.Cache"
+  action      = "CheckNameAvailability"
+  body = jsonencode({
+    type = "Microsoft.Cache/Redis"
+    name = "%s"
+  })
+  response_export_values = ["*"]
+}
+`, data.RandomString)
 }

--- a/internal/services/azapi_resource_action_resource_upgrade_test.go
+++ b/internal/services/azapi_resource_action_resource_upgrade_test.go
@@ -137,7 +137,7 @@ func TestAccAzapiActionResourceUpgrade_basic_from_schema_v0(t *testing.T) {
 	r := ActionResource{}
 
 	updatedConfig := r.oldConfig(data)
-	updatedConfig = strings.ReplaceAll(r.oldConfig(data), "jsonencode({", "{")
+	updatedConfig = strings.ReplaceAll(updatedConfig, "jsonencode({", "{")
 	updatedConfig = strings.ReplaceAll(updatedConfig, "})", "}")
 
 	data.UpgradeTest(t, r, []resource.TestStep{

--- a/internal/services/azapi_resource_action_resource_upgrade_test.go
+++ b/internal/services/azapi_resource_action_resource_upgrade_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/Azure/terraform-provider-azapi/internal/acceptance"
+	"github.com/Azure/terraform-provider-azapi/internal/acceptance/check"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
@@ -127,6 +128,27 @@ func TestAccAzapiActionResourceUpgrade_timeouts_from_v1_13_1(t *testing.T) {
 		}),
 		data.UpgradeTestPlanStep(resource.TestStep{
 			Config: r.timeouts(data),
+		}),
+	})
+}
+
+func TestAccAzapiActionResourceUpgrade_basic_from_schema_v0(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azapi_resource_action", "test")
+	r := ActionResource{}
+
+	updatedConfig := r.oldConfig(data)
+	updatedConfig = strings.ReplaceAll(r.oldConfig(data), "jsonencode({", "{")
+	updatedConfig = strings.ReplaceAll(updatedConfig, "})", "}")
+
+	data.UpgradeTest(t, r, []resource.TestStep{
+		data.UpgradeTestDeployStep(resource.TestStep{
+			Config: r.oldConfig(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		}, "1.12.1"),
+		data.UpgradeTestPlanStep(resource.TestStep{
+			Config: updatedConfig,
 		}),
 	})
 }

--- a/internal/services/azapi_resource_action_resource_upgrade_test.go
+++ b/internal/services/azapi_resource_action_resource_upgrade_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/Azure/terraform-provider-azapi/internal/acceptance"
-	"github.com/Azure/terraform-provider-azapi/internal/acceptance/check"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
@@ -143,9 +142,7 @@ func TestAccAzapiActionResourceUpgrade_basic_from_schema_v0(t *testing.T) {
 	data.UpgradeTest(t, r, []resource.TestStep{
 		data.UpgradeTestDeployStep(resource.TestStep{
 			Config: r.oldConfig(data),
-			Check: resource.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
+			Check:  resource.ComposeTestCheckFunc(),
 		}, "1.12.1"),
 		data.UpgradeTestPlanStep(resource.TestStep{
 			Config: updatedConfig,

--- a/internal/services/azapi_resource_test.go
+++ b/internal/services/azapi_resource_test.go
@@ -1603,3 +1603,27 @@ resource "azapi_resource" "test" {
 }
 `, r.template(data), data.RandomString)
 }
+
+func (r GenericResource) oldConfig(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azapi_resource" "test" {
+  type      = "Microsoft.Automation/automationAccounts@2023-11-01"
+  name      = "acctest%[2]s"
+  parent_id = azurerm_resource_group.test.id
+  location  = azurerm_resource_group.test.location
+  body = jsonencode({
+    properties = {
+      sku = {
+        name = "Basic"
+      }
+    }
+  })
+  tags = {
+    env = "prod"
+  }
+  response_export_values = ["properties"]
+}
+`, r.template(data), data.RandomString)
+}

--- a/internal/services/azapi_resource_upgrade_test.go
+++ b/internal/services/azapi_resource_upgrade_test.go
@@ -476,3 +476,49 @@ func TestAccAzapiResourceUpgrade_timeouts_from_v1_13_1(t *testing.T) {
 		}),
 	})
 }
+
+func TestAccAzapiResourceUpgrade_completeBody_from_schema_v0(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azapi_resource", "test")
+	r := GenericResource{}
+
+	data.UpgradeTest(t, r, []resource.TestStep{
+		data.UpgradeTestDeployStep(resource.TestStep{
+			Config: r.completeJsonBody(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		}, "1.12.1"),
+		data.UpgradeTestPlanStep(resource.TestStep{
+			Config: r.completeBody(data),
+			// It's a known breaking change that identity in the body will not be synced to the top-level identity block
+			ExpectNonEmptyPlan: true,
+		}),
+		data.UpgradeTestApplyStep(resource.TestStep{
+			Config: r.completeBody(data),
+		}),
+		data.UpgradeTestPlanStep(resource.TestStep{
+			Config: r.completeBody(data),
+		}),
+	})
+}
+
+func TestAccAzapiResourceUpgrade_basic_from_schema_v0(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azapi_resource", "test")
+	r := GenericResource{}
+
+	updatedConfig := r.oldConfig(data)
+	updatedConfig = strings.ReplaceAll(r.oldConfig(data), "jsonencode({", "{")
+	updatedConfig = strings.ReplaceAll(updatedConfig, "})", "}")
+
+	data.UpgradeTest(t, r, []resource.TestStep{
+		data.UpgradeTestDeployStep(resource.TestStep{
+			Config: r.oldConfig(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		}, "1.12.1"),
+		data.UpgradeTestPlanStep(resource.TestStep{
+			Config: updatedConfig,
+		}),
+	})
+}

--- a/internal/services/azapi_resource_upgrade_test.go
+++ b/internal/services/azapi_resource_upgrade_test.go
@@ -507,7 +507,7 @@ func TestAccAzapiResourceUpgrade_basic_from_schema_v0(t *testing.T) {
 	r := GenericResource{}
 
 	updatedConfig := r.oldConfig(data)
-	updatedConfig = strings.ReplaceAll(r.oldConfig(data), "jsonencode({", "{")
+	updatedConfig = strings.ReplaceAll(updatedConfig, "jsonencode({", "{")
 	updatedConfig = strings.ReplaceAll(updatedConfig, "})", "}")
 
 	data.UpgradeTest(t, r, []resource.TestStep{

--- a/internal/services/azapi_update_resource.go
+++ b/internal/services/azapi_update_resource.go
@@ -69,7 +69,7 @@ func (r *AzapiUpdateResource) Metadata(ctx context.Context, request resource.Met
 
 func (r *AzapiUpdateResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
 	return map[int64]resource.StateUpgrader{
-		0: migration.AzapiUpdateResourceMigrationV0ToV1(ctx),
+		0: migration.AzapiUpdateResourceMigrationV0ToV2(ctx),
 		1: migration.AzapiUpdateResourceMigrationV1ToV2(ctx),
 	}
 }

--- a/internal/services/azapi_update_resource_test.go
+++ b/internal/services/azapi_update_resource_test.go
@@ -468,3 +468,27 @@ resource "azapi_update_resource" "test" {
 }
 `, r.template(data), data.RandomString)
 }
+
+func (r GenericUpdateResource) oldConfig(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_automation_account" "test" {
+  name                = "acctest-%[2]s"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku_name            = "Basic"
+}
+
+resource "azapi_update_resource" "test" {
+  type        = "Microsoft.Automation/automationAccounts@2023-11-01"
+  resource_id = azurerm_automation_account.test.id
+  body = jsonencode({
+    properties = {
+      publicNetworkAccess = true
+    }
+  })
+  response_export_values = ["properties"]
+}
+`, r.template(data), data.RandomString)
+}

--- a/internal/services/azapi_update_resource_upgrade_test.go
+++ b/internal/services/azapi_update_resource_upgrade_test.go
@@ -119,7 +119,7 @@ func TestAccAzapiUpdateResourceUpgrade_basic_from_schema_v0(t *testing.T) {
 	r := GenericUpdateResource{}
 
 	updatedConfig := r.oldConfig(data)
-	updatedConfig = strings.ReplaceAll(r.oldConfig(data), "jsonencode({", "{")
+	updatedConfig = strings.ReplaceAll(updatedConfig, "jsonencode({", "{")
 	updatedConfig = strings.ReplaceAll(updatedConfig, "})", "}")
 
 	data.UpgradeTest(t, r, []resource.TestStep{

--- a/internal/services/azapi_update_resource_upgrade_test.go
+++ b/internal/services/azapi_update_resource_upgrade_test.go
@@ -113,3 +113,24 @@ func TestAccAzapiUpdateResourceUpgrade_timeouts_from_v1_13_1(t *testing.T) {
 		}),
 	})
 }
+
+func TestAccAzapiUpdateResourceUpgrade_basic_from_schema_v0(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azapi_update_resource", "test")
+	r := GenericUpdateResource{}
+
+	updatedConfig := r.oldConfig(data)
+	updatedConfig = strings.ReplaceAll(r.oldConfig(data), "jsonencode({", "{")
+	updatedConfig = strings.ReplaceAll(updatedConfig, "})", "}")
+
+	data.UpgradeTest(t, r, []resource.TestStep{
+		data.UpgradeTestDeployStep(resource.TestStep{
+			Config: r.oldConfig(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		}, "1.12.1"),
+		data.UpgradeTestPlanStep(resource.TestStep{
+			Config: updatedConfig,
+		}),
+	})
+}

--- a/internal/services/migration/azapi_resource_migration_v0_to_v2.go
+++ b/internal/services/migration/azapi_resource_migration_v0_to_v2.go
@@ -3,13 +3,14 @@ package migration
 import (
 	"context"
 
+	"github.com/Azure/terraform-provider-azapi/internal/retry"
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-func AzapiResourceMigrationV0ToV1(ctx context.Context) resource.StateUpgrader {
+func AzapiResourceMigrationV0ToV2(ctx context.Context) resource.StateUpgrader {
 	return resource.StateUpgrader{
 		PriorSchema: &schema.Schema{
 			Attributes: map[string]schema.Attribute{
@@ -139,23 +140,23 @@ func AzapiResourceMigrationV0ToV1(ctx context.Context) resource.StateUpgrader {
 				Timeouts                timeouts.Value `tfsdk:"timeouts"`
 			}
 			type newModel struct {
-				ID                      types.String   `tfsdk:"id"`
-				Name                    types.String   `tfsdk:"name"`
-				ParentID                types.String   `tfsdk:"parent_id"`
-				Type                    types.String   `tfsdk:"type"`
-				Location                types.String   `tfsdk:"location"`
-				Identity                types.List     `tfsdk:"identity"`
-				Body                    types.Dynamic  `tfsdk:"body"`
-				Locks                   types.List     `tfsdk:"locks"`
-				RemovingSpecialChars    types.Bool     `tfsdk:"removing_special_chars"`
-				SchemaValidationEnabled types.Bool     `tfsdk:"schema_validation_enabled"`
-				IgnoreBodyChanges       types.List     `tfsdk:"ignore_body_changes"`
-				IgnoreCasing            types.Bool     `tfsdk:"ignore_casing"`
-				IgnoreMissingProperty   types.Bool     `tfsdk:"ignore_missing_property"`
-				ResponseExportValues    types.List     `tfsdk:"response_export_values"`
-				Output                  types.Dynamic  `tfsdk:"output"`
-				Tags                    types.Map      `tfsdk:"tags"`
-				Timeouts                timeouts.Value `tfsdk:"timeouts"`
+				ID                            types.String     `tfsdk:"id"`
+				Name                          types.String     `tfsdk:"name"`
+				ParentID                      types.String     `tfsdk:"parent_id"`
+				Type                          types.String     `tfsdk:"type"`
+				Location                      types.String     `tfsdk:"location"`
+				Identity                      types.List       `tfsdk:"identity"`
+				Body                          types.Dynamic    `tfsdk:"body"`
+				Locks                         types.List       `tfsdk:"locks"`
+				SchemaValidationEnabled       types.Bool       `tfsdk:"schema_validation_enabled"`
+				IgnoreCasing                  types.Bool       `tfsdk:"ignore_casing"`
+				IgnoreMissingProperty         types.Bool       `tfsdk:"ignore_missing_property"`
+				ReplaceTriggersExternalValues types.Dynamic    `tfsdk:"replace_triggers_external_values"`
+				ResponseExportValues          types.List       `tfsdk:"response_export_values"`
+				Retry                         retry.RetryValue `tfsdk:"retry"`
+				Output                        types.Dynamic    `tfsdk:"output"`
+				Tags                          types.Map        `tfsdk:"tags"`
+				Timeouts                      timeouts.Value   `tfsdk:"timeouts"`
 			}
 
 			var oldState OldModel
@@ -163,24 +164,38 @@ func AzapiResourceMigrationV0ToV1(ctx context.Context) resource.StateUpgrader {
 				return
 			}
 
+			oldBody := types.DynamicValue(types.StringValue(oldState.Body.ValueString()))
+			bodyVal, err := migrateToDynamicValue(oldBody)
+			if err != nil {
+				response.Diagnostics.AddError("failed to migrate body to dynamic value", err.Error())
+				return
+			}
+
+			oldOutput := types.DynamicValue(types.StringValue(oldState.Output.ValueString()))
+			outputVal, err := migrateToDynamicValue(oldOutput)
+			if err != nil {
+				response.Diagnostics.AddError("failed to migrate output to dynamic value", err.Error())
+				return
+			}
+
 			newState := newModel{
-				ID:                      oldState.ID,
-				Name:                    oldState.Name,
-				ParentID:                oldState.ParentID,
-				Type:                    oldState.Type,
-				Location:                oldState.Location,
-				Identity:                oldState.Identity,
-				Body:                    types.DynamicValue(types.StringValue(oldState.Body.ValueString())),
-				Locks:                   oldState.Locks,
-				RemovingSpecialChars:    oldState.RemovingSpecialChars,
-				SchemaValidationEnabled: oldState.SchemaValidationEnabled,
-				IgnoreBodyChanges:       oldState.IgnoreBodyChanges,
-				IgnoreCasing:            oldState.IgnoreCasing,
-				IgnoreMissingProperty:   oldState.IgnoreMissingProperty,
-				ResponseExportValues:    oldState.ResponseExportValues,
-				Output:                  types.DynamicValue(types.StringValue(oldState.Output.ValueString())),
-				Tags:                    oldState.Tags,
-				Timeouts:                oldState.Timeouts,
+				ID:                            oldState.ID,
+				Name:                          oldState.Name,
+				ParentID:                      oldState.ParentID,
+				Type:                          oldState.Type,
+				Location:                      oldState.Location,
+				Identity:                      oldState.Identity,
+				Body:                          bodyVal,
+				Locks:                         oldState.Locks,
+				SchemaValidationEnabled:       oldState.SchemaValidationEnabled,
+				IgnoreCasing:                  oldState.IgnoreCasing,
+				IgnoreMissingProperty:         oldState.IgnoreMissingProperty,
+				ReplaceTriggersExternalValues: types.DynamicNull(),
+				ResponseExportValues:          oldState.ResponseExportValues,
+				Retry:                         retry.NewRetryValueNull(),
+				Output:                        outputVal,
+				Tags:                          oldState.Tags,
+				Timeouts:                      oldState.Timeouts,
 			}
 
 			response.Diagnostics.Append(response.State.Set(ctx, newState)...)


### PR DESCRIPTION
This PR updates the state migration for the v0 schema, and adds tests.