### PR TITLE
`azapi_data_plane_resource`: support `retry` field

### DIFF
--- a/docs/resources/data_plane_resource.md
+++ b/docs/resources/data_plane_resource.md
@@ -94,6 +94,7 @@ resource "azapi_data_plane_resource" "dataset" {
 		}
 	}
 	```
+- `retry` (Attributes) The retry block supports the following arguments: (see [below for nested schema](#nestedatt--retry))
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only
@@ -112,6 +113,21 @@ resource "azapi_data_plane_resource" "dataset" {
 		value = azapi_data_plane_resource.example.output.properties.policies.quarantinePolicy.status
 	}
 	```
+
+<a id="nestedatt--retry"></a>
+### Nested Schema for `retry`
+
+Required:
+
+- `error_message_regex` (List of String) A list of regular expressions to match against error messages. If any of the regular expressions match, the error is considered retryable.
+
+Optional:
+
+- `interval_seconds` (Number) The base number of seconds to wait between retries. Default is `10`.
+- `max_interval_seconds` (Number) The maximum number of seconds to wait between retries. Default is `180`.
+- `multiplier` (Number) The multiplier to apply to the interval between retries. Default is `1.5`.
+- `randomization_factor` (Number) The randomization factor to apply to the interval between retries. The formula for the randomized interval is: `RetryInterval * (random value in range [1 - RandomizationFactor, 1 + RandomizationFactor])`. Therefore set to zero `0.0` for no randomization. Default is `0.5`.
+
 
 <a id="nestedblock--timeouts"></a>
 ### Nested Schema for `timeouts`

--- a/internal/clients/data_plane_client_mock_test.go
+++ b/internal/clients/data_plane_client_mock_test.go
@@ -1,0 +1,85 @@
+package clients_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Azure/terraform-provider-azapi/internal/clients"
+	"github.com/Azure/terraform-provider-azapi/internal/services/parse"
+)
+
+// check that MockDataPlaneClient implements the clients.DataPlaneRequester interface
+var _ clients.DataPlaneRequester = &MockDataPlaneClient{}
+
+// MockDataPlaneClient is a mock implementation of the clients.DataPlaneRequester interface
+type MockDataPlaneClient struct {
+	t            *testing.T
+	response     interface{}
+	err          error
+	retries      int
+	requestCount int
+	retryErr     error
+	mu           sync.Mutex
+	requestTimes []time.Time
+}
+
+func NewMockDataPlaneClient(t *testing.T, resp interface{}, err error, retries int, retryErr error) *MockDataPlaneClient {
+	return &MockDataPlaneClient{
+		t:            t,
+		response:     resp,
+		err:          err,
+		retryErr:     retryErr,
+		retries:      retries,
+		requestCount: 0,
+		mu:           sync.Mutex{},
+		requestTimes: make([]time.Time, 0, 10),
+	}
+}
+
+func (m *MockDataPlaneClient) CreateOrUpdateThenPoll(ctx context.Context, id parse.DataPlaneResourceId, body interface{}) (interface{}, error) {
+	return m.respond(ctx)
+}
+
+func (m *MockDataPlaneClient) Get(ctx context.Context, id parse.DataPlaneResourceId) (interface{}, error) {
+	return m.respond(ctx)
+}
+
+func (m *MockDataPlaneClient) DeleteThenPoll(ctx context.Context, id parse.DataPlaneResourceId) (interface{}, error) {
+	return m.respond(ctx)
+}
+
+func (m *MockDataPlaneClient) Action(ctx context.Context, resourceID string, action string, apiVersion string, method string, body interface{}) (interface{}, error) {
+	return m.respond(ctx)
+}
+
+func (m *MockDataPlaneClient) respond(ctx context.Context) (interface{}, error) {
+	select {
+	case <-ctx.Done():
+		m.t.Logf("context cancelled")
+		return nil, ctx.Err()
+	default:
+		m.mu.Lock()
+		defer m.mu.Unlock()
+		timeSinceLastRequest := time.Duration(0)
+		if len(m.requestTimes) != 0 {
+			timeSinceLastRequest = time.Since(m.requestTimes[len(m.requestTimes)-1])
+		}
+		m.t.Logf("request: %d, time since last: %s", m.requestCount, timeSinceLastRequest)
+		m.requestTimes = append(m.requestTimes, time.Now())
+		if m.requestCount < m.retries && m.retryErr != nil {
+			m.requestCount++
+			return nil, m.retryErr
+		}
+		return m.response, m.err
+	}
+}
+
+func (m *MockDataPlaneClient) RequestCount() int {
+	return m.requestCount
+}
+
+func (m *MockDataPlaneClient) RequestTimes() []time.Time {
+	return m.requestTimes
+}

--- a/internal/clients/data_plane_client_test.go
+++ b/internal/clients/data_plane_client_test.go
@@ -1,0 +1,90 @@
+package clients_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/Azure/terraform-provider-azapi/internal/clients"
+	"github.com/Azure/terraform-provider-azapi/internal/services/parse"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestRetryClient tests the retry client with a mock client that returns an error.
+// This test should retry 3 times (4 requests in total) and retirn a nil error.
+// The ransomized interval is calculated by the backoff package as follows:
+//
+//	randomized interval =
+//	  RetryInterval * (random value in range [1 - RandomizationFactor, 1 + RandomizationFactor])
+//
+// Therefore a configuration of interval = 1s, multiplier = 2 and randomization = 0.0 should result in
+// the following intervals:
+// 1. 0s (the 1st request is made immediately)
+// 2. 1s (iniital interval)
+// 3. 2s (last interval 1s * 2 multiplier)
+// 4. 4s (last interval 2s * 2 multiplier)
+//
+// We check these timings are expected using the assert.InDeltaSlice function.
+func TestRetryDataPlaneClient(t *testing.T) {
+	mock := NewMockDataPlaneClient(t, nil, nil, 3, errors.New("retry error"))
+	bkof, errRegExps := clients.NewRetryableErrors(1, 30, 2, 0.0, []string{"retry error"})
+	retryClient := clients.NewDataPlaneClientRetryableErrors(mock, bkof, errRegExps)
+	_, err := retryClient.Get(context.Background(), parse.DataPlaneResourceId{})
+	assert.NoError(t, err)
+	assert.Equal(t, 3, mock.requestCount)
+	assert.Len(t, mock.requestTimes, 4)
+	requestBackoffDiractionNanos := make([]int, len(mock.requestTimes))
+	for i, v := range mock.requestTimes {
+		if i == 0 {
+			requestBackoffDiractionNanos[i] = 0
+			continue
+		}
+		requestBackoffDiractionNanos[i] = int(v.Sub(mock.requestTimes[i-1]).Nanoseconds())
+	}
+	// We assert that the intervals are within 0.01 seconds of the expected values
+	assert.InDeltaSlice(t, []int{0, 1e+09, 2e+09, 4e+09}, requestBackoffDiractionNanos, 1e+07)
+}
+
+func TestRetryDataPlaneClientRegexp(t *testing.T) {
+	mock := NewMockDataPlaneClient(t, nil, nil, 3, errors.New("retry error"))
+	bkof, errRegExps := clients.NewRetryableErrors(1, 5, 1.5, 0.0, []string{"^retry"})
+	retryClient := clients.NewDataPlaneClientRetryableErrors(mock, bkof, errRegExps)
+	_, err := retryClient.Get(context.Background(), parse.DataPlaneResourceId{})
+	assert.NoError(t, err)
+	assert.Equal(t, 3, mock.RequestCount())
+}
+
+func TestRetryDataPlaneClientMultiRegexp(t *testing.T) {
+	mock := NewMockDataPlaneClient(t, nil, nil, 3, errors.New("retry error"))
+	bkof, errRegExps := clients.NewRetryableErrors(1, 5, 1.5, 0.0, []string{"nomatch", "^retry"})
+	retryClient := clients.NewDataPlaneClientRetryableErrors(mock, bkof, errRegExps)
+	_, err := retryClient.Get(context.Background(), parse.DataPlaneResourceId{})
+	assert.NoError(t, err)
+	assert.Equal(t, 3, mock.RequestCount())
+}
+
+func TestRetryDataPlaneClientMultiRegexpNoMatchWithPermError(t *testing.T) {
+	mock := NewMockDataPlaneClient(t, nil, errors.New("perm error"), 3, errors.New("retry error"))
+	bkof, errRegExps := clients.NewRetryableErrors(1, 5, 1.5, 0.0, []string{"retry"})
+	retryClient := clients.NewDataPlaneClientRetryableErrors(mock, bkof, errRegExps)
+	_, err := retryClient.Get(context.Background(), parse.DataPlaneResourceId{})
+	assert.ErrorContains(t, err, "perm error")
+	assert.Equal(t, 3, mock.RequestCount())
+}
+
+func TestRetryDataPlaneClientContextDeadline(t *testing.T) {
+	mock := NewMockDataPlaneClient(t, nil, nil, 3, errors.New("retry error"))
+	bkof, errRegExps := clients.NewRetryableErrors(60, 60, 1.5, 0.0, []string{"^retry"})
+	retryClient := clients.NewDataPlaneClientRetryableErrors(mock, bkof, errRegExps)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	start := time.Now()
+	_, err := retryClient.Get(ctx, parse.DataPlaneResourceId{})
+	elapsed := time.Since(start)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.True(t, elapsed < 15*time.Second)
+	// Test that the context was cancelled
+	_, ok := <-ctx.Done()
+	assert.False(t, ok)
+}

--- a/internal/services/migration/azapi_data_plane_resource_migration_v0_to_v2.go
+++ b/internal/services/migration/azapi_data_plane_resource_migration_v0_to_v2.go
@@ -3,6 +3,7 @@ package migration
 import (
 	"context"
 
+	"github.com/Azure/terraform-provider-azapi/internal/retry"
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -84,17 +85,18 @@ func AzapiDataPlaneResourceMigrationV0ToV2(ctx context.Context) resource.StateUp
 				Timeouts              timeouts.Value `tfsdk:"timeouts"`
 			}
 			type newModel struct {
-				ID                    types.String   `tfsdk:"id"`
-				Name                  types.String   `tfsdk:"name"`
-				ParentID              types.String   `tfsdk:"parent_id"`
-				Type                  types.String   `tfsdk:"type"`
-				Body                  types.Dynamic  `tfsdk:"body"`
-				IgnoreCasing          types.Bool     `tfsdk:"ignore_casing"`
-				IgnoreMissingProperty types.Bool     `tfsdk:"ignore_missing_property"`
-				ResponseExportValues  types.List     `tfsdk:"response_export_values"`
-				Locks                 types.List     `tfsdk:"locks"`
-				Output                types.Dynamic  `tfsdk:"output"`
-				Timeouts              timeouts.Value `tfsdk:"timeouts"`
+				ID                    types.String     `tfsdk:"id"`
+				Name                  types.String     `tfsdk:"name"`
+				ParentID              types.String     `tfsdk:"parent_id"`
+				Type                  types.String     `tfsdk:"type"`
+				Body                  types.Dynamic    `tfsdk:"body"`
+				IgnoreCasing          types.Bool       `tfsdk:"ignore_casing"`
+				IgnoreMissingProperty types.Bool       `tfsdk:"ignore_missing_property"`
+				ResponseExportValues  types.List       `tfsdk:"response_export_values"`
+				Retry                 retry.RetryValue `tfsdk:"retry"`
+				Locks                 types.List       `tfsdk:"locks"`
+				Output                types.Dynamic    `tfsdk:"output"`
+				Timeouts              timeouts.Value   `tfsdk:"timeouts"`
 			}
 
 			var oldState OldModel
@@ -126,6 +128,7 @@ func AzapiDataPlaneResourceMigrationV0ToV2(ctx context.Context) resource.StateUp
 				IgnoreCasing:          oldState.IgnoreCasing,
 				IgnoreMissingProperty: oldState.IgnoreMissingProperty,
 				ResponseExportValues:  oldState.ResponseExportValues,
+				Retry:                 retry.NewRetryValueNull(),
 				Output:                outputVal,
 				Timeouts:              oldState.Timeouts,
 			}

--- a/internal/services/migration/azapi_data_plane_resource_migration_v1_to_v2.go
+++ b/internal/services/migration/azapi_data_plane_resource_migration_v1_to_v2.go
@@ -3,6 +3,7 @@ package migration
 import (
 	"context"
 
+	"github.com/Azure/terraform-provider-azapi/internal/retry"
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -84,17 +85,18 @@ func AzapiDataPlaneResourceMigrationV1ToV2(ctx context.Context) resource.StateUp
 				Timeouts              timeouts.Value `tfsdk:"timeouts"`
 			}
 			type newModel struct {
-				ID                    types.String   `tfsdk:"id"`
-				Name                  types.String   `tfsdk:"name"`
-				ParentID              types.String   `tfsdk:"parent_id"`
-				Type                  types.String   `tfsdk:"type"`
-				Body                  types.Dynamic  `tfsdk:"body"`
-				IgnoreCasing          types.Bool     `tfsdk:"ignore_casing"`
-				IgnoreMissingProperty types.Bool     `tfsdk:"ignore_missing_property"`
-				ResponseExportValues  types.List     `tfsdk:"response_export_values"`
-				Locks                 types.List     `tfsdk:"locks"`
-				Output                types.Dynamic  `tfsdk:"output"`
-				Timeouts              timeouts.Value `tfsdk:"timeouts"`
+				ID                    types.String     `tfsdk:"id"`
+				Name                  types.String     `tfsdk:"name"`
+				ParentID              types.String     `tfsdk:"parent_id"`
+				Type                  types.String     `tfsdk:"type"`
+				Body                  types.Dynamic    `tfsdk:"body"`
+				IgnoreCasing          types.Bool       `tfsdk:"ignore_casing"`
+				IgnoreMissingProperty types.Bool       `tfsdk:"ignore_missing_property"`
+				ResponseExportValues  types.List       `tfsdk:"response_export_values"`
+				Retry                 retry.RetryValue `tfsdk:"retry"`
+				Locks                 types.List       `tfsdk:"locks"`
+				Output                types.Dynamic    `tfsdk:"output"`
+				Timeouts              timeouts.Value   `tfsdk:"timeouts"`
 			}
 
 			var oldState OldModel
@@ -123,6 +125,7 @@ func AzapiDataPlaneResourceMigrationV1ToV2(ctx context.Context) resource.StateUp
 				IgnoreCasing:          oldState.IgnoreCasing,
 				IgnoreMissingProperty: oldState.IgnoreMissingProperty,
 				ResponseExportValues:  oldState.ResponseExportValues,
+				Retry:                 retry.NewRetryValueNull(),
 				Output:                outputVal,
 				Timeouts:              oldState.Timeouts,
 			}


### PR DESCRIPTION
This PR adds retry function to the data plane resource.

```
=== RUN   TestAccAzapiDataPlaneResourceUpgrade_appConfigKeyValues
=== PAUSE TestAccAzapiDataPlaneResourceUpgrade_appConfigKeyValues
=== CONT  TestAccAzapiDataPlaneResourceUpgrade_appConfigKeyValues
=== RUN   TestAccAzapiDataPlaneResourceUpgrade_purviewClassification
=== PAUSE TestAccAzapiDataPlaneResourceUpgrade_purviewClassification
=== CONT  TestAccAzapiDataPlaneResourceUpgrade_purviewClassification
=== RUN   TestAccAzapiDataPlaneResourceUpgrade_purviewCollection
=== PAUSE TestAccAzapiDataPlaneResourceUpgrade_purviewCollection
=== CONT  TestAccAzapiDataPlaneResourceUpgrade_purviewCollection
=== RUN   TestAccAzapiDataPlaneResourceUpgrade_keyVaultIssuer
=== PAUSE TestAccAzapiDataPlaneResourceUpgrade_keyVaultIssuer
=== CONT  TestAccAzapiDataPlaneResourceUpgrade_keyVaultIssuer
=== RUN   TestAccAzapiDataPlaneResourceUpgrade_iotAppsUser
=== PAUSE TestAccAzapiDataPlaneResourceUpgrade_iotAppsUser
=== CONT  TestAccAzapiDataPlaneResourceUpgrade_iotAppsUser
=== RUN   TestAccAzapiDataPlaneResourceUpgrade_timeouts
=== PAUSE TestAccAzapiDataPlaneResourceUpgrade_timeouts
=== CONT  TestAccAzapiDataPlaneResourceUpgrade_timeouts
=== RUN   TestAccAzapiDataPlaneResourceUpgrade_timeouts_from_v1_13_1
=== PAUSE TestAccAzapiDataPlaneResourceUpgrade_timeouts_from_v1_13_1
=== CONT  TestAccAzapiDataPlaneResourceUpgrade_timeouts_from_v1_13_1
=== RUN   TestAccAzapiDataPlaneResourceUpgrade_basic_from_schema_v0
=== PAUSE TestAccAzapiDataPlaneResourceUpgrade_basic_from_schema_v0
=== CONT  TestAccAzapiDataPlaneResourceUpgrade_basic_from_schema_v0
--- PASS: TestAccAzapiDataPlaneResourceUpgrade_iotAppsUser (511.24s)
--- PASS: TestAccAzapiDataPlaneResourceUpgrade_appConfigKeyValues (563.83s)
--- PASS: TestAccAzapiDataPlaneResourceUpgrade_keyVaultIssuer (577.16s)
--- PASS: TestAccAzapiDataPlaneResourceUpgrade_timeouts (609.47s)
--- PASS: TestAccAzapiDataPlaneResourceUpgrade_timeouts_from_v1_13_1 (614.17s)
--- PASS: TestAccAzapiDataPlaneResourceUpgrade_basic_from_schema_v0 (766.41s)
--- PASS: TestAccAzapiDataPlaneResourceUpgrade_purviewCollection (817.72s)
--- PASS: TestAccAzapiDataPlaneResourceUpgrade_purviewClassification (855.58s)
PASS

Process finished with the exit code 0

```