### PR TITLE
fix: always use non-retry client to check new resource does not exist

### DIFF
--- a/internal/services/azapi_resource.go
+++ b/internal/services/azapi_resource.go
@@ -492,7 +492,8 @@ func (r *AzapiResource) CreateUpdate(ctx context.Context, requestPlan tfsdk.Plan
 	defer cancel()
 
 	if isNewResource {
-		// check if the resource already exists
+		// check if the resource already exists using the non-retry client to avoid issue where user specifies
+		// a FooResourceNotFound error as a retryable error
 		_, err = r.ProviderData.ResourceClient.Get(ctx, id.AzureResourceId, id.ApiVersion)
 		if err == nil {
 			diagnostics.AddError("Resource already exists", tf.ImportAsExistsError("azapi_resource", id.ID()).Error())

--- a/internal/services/azapi_resource.go
+++ b/internal/services/azapi_resource.go
@@ -493,7 +493,7 @@ func (r *AzapiResource) CreateUpdate(ctx context.Context, requestPlan tfsdk.Plan
 
 	if isNewResource {
 		// check if the resource already exists
-		_, err = client.Get(ctx, id.AzureResourceId, id.ApiVersion)
+		_, err = r.ProviderData.ResourceClient.Get(ctx, id.AzureResourceId, id.ApiVersion)
 		if err == nil {
 			diagnostics.AddError("Resource already exists", tf.ImportAsExistsError("azapi_resource", id.ID()).Error())
 			return


### PR DESCRIPTION
Hi @ms-henglu 

In testing I found a scenario where we want to add a retryable error for a ResourceNotFound situation. For new resources, there is a check to ensure the resource does not already exist. If we use the retry client then the provider will infinite loop until the context deadline.

This fix ensures we use the non-retry client to check that the resource does not already exist!