### PR TITLE
remove azurerm provider from testcases

### DIFF
--- a/internal/acceptance/testcase.go
+++ b/internal/acceptance/testcase.go
@@ -165,16 +165,7 @@ func (td TestData) providers() map[string]func() (tfprotov6.ProviderServer, erro
 }
 
 func (td TestData) externalProviders() map[string]resource.ExternalProvider {
-	return map[string]resource.ExternalProvider{
-		"azurerm": {
-			Source:            "registry.terraform.io/hashicorp/azurerm",
-			VersionConstraint: "= 3.100.0",
-		},
-		"random": {
-			Source:            "registry.terraform.io/hashicorp/random",
-			VersionConstraint: "= 3.6.1",
-		},
-	}
+	return map[string]resource.ExternalProvider{}
 }
 
 func PreCheck(t *testing.T) {

--- a/internal/acceptance/testcase.go
+++ b/internal/acceptance/testcase.go
@@ -74,7 +74,9 @@ func (td *TestData) RandomStringOfLength(len int) string {
 
 // UpgradeTestDeployStep returns a test step used to deploy the configuration with previous version
 func (td TestData) UpgradeTestDeployStep(step resource.TestStep, upgradeFrom string) resource.TestStep {
-	step.ExternalProviders = td.externalProviders()
+	if step.ExternalProviders == nil {
+		step.ExternalProviders = td.externalProviders()
+	}
 	step.ExternalProviders["azapi"] = resource.ExternalProvider{
 		Source:            "registry.terraform.io/azure/azapi",
 		VersionConstraint: fmt.Sprintf("= %s", upgradeFrom),
@@ -85,7 +87,9 @@ func (td TestData) UpgradeTestDeployStep(step resource.TestStep, upgradeFrom str
 
 // UpgradeTestApplyStep returns a test step used to run terraform apply with the development version
 func (td TestData) UpgradeTestApplyStep(applyStep resource.TestStep) resource.TestStep {
-	applyStep.ExternalProviders = td.externalProviders()
+	if applyStep.ExternalProviders == nil {
+		applyStep.ExternalProviders = td.externalProviders()
+	}
 	applyStep.ProtoV6ProviderFactories = td.providers()
 	return applyStep
 }
@@ -93,7 +97,9 @@ func (td TestData) UpgradeTestApplyStep(applyStep resource.TestStep) resource.Te
 // UpgradeTestPlanStep returns a test step used to run terraform plan with the development version to check if there's any changes
 func (td TestData) UpgradeTestPlanStep(planStep resource.TestStep) resource.TestStep {
 	planStep.PlanOnly = true
-	planStep.ExternalProviders = td.externalProviders()
+	if planStep.ExternalProviders == nil {
+		planStep.ExternalProviders = td.externalProviders()
+	}
 	planStep.ProtoV6ProviderFactories = td.providers()
 	return planStep
 }

--- a/internal/services/azapi_data_plane_resource.go
+++ b/internal/services/azapi_data_plane_resource.go
@@ -20,6 +20,7 @@ import (
 	"github.com/Azure/terraform-provider-azapi/utils"
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -115,6 +116,9 @@ func (r *DataPlaneResource) Schema(ctx context.Context, request resource.SchemaR
 			// The body attribute is a dynamic attribute that only allows users to specify the resource body as an HCL object
 			"body": schema.DynamicAttribute{
 				Optional: true,
+				Computed: true,
+				// in the previous version, the default value is string "{}", now it's a dynamic value {}
+				Default: defaults.DynamicDefault(types.ObjectValueMust(map[string]attr.Type{}, map[string]attr.Value{})),
 				PlanModifiers: []planmodifier.Dynamic{
 					myplanmodifier.DynamicUseStateWhen(dynamic.SemanticallyEqual),
 				},

--- a/internal/services/azapi_data_plane_resource_upgrade_test.go
+++ b/internal/services/azapi_data_plane_resource_upgrade_test.go
@@ -9,19 +9,30 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
+func externalProvidersAzurerm() map[string]resource.ExternalProvider {
+	return map[string]resource.ExternalProvider{
+		"azurerm": {
+			VersionConstraint: "3.106.0",
+			Source:            "hashicorp/azurerm",
+		},
+	}
+}
+
 func TestAccAzapiDataPlaneResourceUpgrade_appConfigKeyValues(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azapi_data_plane_resource", "test")
 	r := DataPlaneResource{}
 
 	data.UpgradeTest(t, r, []resource.TestStep{
 		data.UpgradeTestDeployStep(resource.TestStep{
-			Config: r.appConfigKeyValues(data),
+			Config:            r.appConfigKeyValues(data),
+			ExternalProviders: externalProvidersAzurerm(),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		}, PreviousVersion),
 		data.UpgradeTestPlanStep(resource.TestStep{
-			Config: r.appConfigKeyValues(data),
+			Config:            r.appConfigKeyValues(data),
+			ExternalProviders: externalProvidersAzurerm(),
 		}),
 	})
 }
@@ -66,13 +77,15 @@ func TestAccAzapiDataPlaneResourceUpgrade_keyVaultIssuer(t *testing.T) {
 
 	data.UpgradeTest(t, r, []resource.TestStep{
 		data.UpgradeTestDeployStep(resource.TestStep{
-			Config: r.keyVaultIssuer(data),
+			Config:            r.keyVaultIssuer(data),
+			ExternalProviders: externalProvidersAzurerm(),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		}, PreviousVersion),
 		data.UpgradeTestPlanStep(resource.TestStep{
-			Config: r.keyVaultIssuer(data),
+			Config:            r.keyVaultIssuer(data),
+			ExternalProviders: externalProvidersAzurerm(),
 		}),
 	})
 }
@@ -83,13 +96,15 @@ func TestAccAzapiDataPlaneResourceUpgrade_iotAppsUser(t *testing.T) {
 
 	data.UpgradeTest(t, r, []resource.TestStep{
 		data.UpgradeTestDeployStep(resource.TestStep{
-			Config: r.iotAppsUser(data),
+			Config:            r.iotAppsUser(data),
+			ExternalProviders: externalProvidersAzurerm(),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		}, PreviousVersion),
 		data.UpgradeTestPlanStep(resource.TestStep{
-			Config: r.iotAppsUser(data),
+			Config:            r.iotAppsUser(data),
+			ExternalProviders: externalProvidersAzurerm(),
 		}),
 	})
 }
@@ -100,13 +115,15 @@ func TestAccAzapiDataPlaneResourceUpgrade_timeouts(t *testing.T) {
 
 	data.UpgradeTest(t, r, []resource.TestStep{
 		data.UpgradeTestDeployStep(resource.TestStep{
-			Config: r.timeouts(data),
+			Config:            r.timeouts(data),
+			ExternalProviders: externalProvidersAzurerm(),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		}, PreviousVersion),
 		data.UpgradeTestPlanStep(resource.TestStep{
-			Config: r.timeouts(data),
+			Config:            r.timeouts(data),
+			ExternalProviders: externalProvidersAzurerm(),
 		}),
 	})
 }
@@ -117,16 +134,19 @@ func TestAccAzapiDataPlaneResourceUpgrade_timeouts_from_v1_13_1(t *testing.T) {
 
 	data.UpgradeTest(t, r, []resource.TestStep{
 		data.UpgradeTestDeployStep(resource.TestStep{
-			Config: strings.ReplaceAll(r.timeouts(data), `update = "10m"`, ""),
+			Config:            strings.ReplaceAll(r.timeouts(data), `update = "10m"`, ""),
+			ExternalProviders: externalProvidersAzurerm(),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		}, "1.13.1"),
 		data.UpgradeTestApplyStep(resource.TestStep{
-			Config: r.timeouts(data),
+			ExternalProviders: externalProvidersAzurerm(),
+			Config:            r.timeouts(data),
 		}),
 		data.UpgradeTestPlanStep(resource.TestStep{
-			Config: r.timeouts(data),
+			ExternalProviders: externalProvidersAzurerm(),
+			Config:            r.timeouts(data),
 		}),
 	})
 }

--- a/internal/services/azapi_resource.go
+++ b/internal/services/azapi_resource.go
@@ -148,6 +148,9 @@ func (r *AzapiResource) Schema(ctx context.Context, _ resource.SchemaRequest, re
 			// The body attribute is a dynamic attribute that only allows users to specify the resource body as an HCL object
 			"body": schema.DynamicAttribute{
 				Optional: true,
+				Computed: true,
+				// in the previous version, the default value is string "{}", now it's a dynamic value {}
+				Default: defaults.DynamicDefault(types.ObjectValueMust(map[string]attr.Type{}, map[string]attr.Value{})),
 				PlanModifiers: []planmodifier.Dynamic{
 					myplanmodifier.DynamicUseStateWhen(dynamic.SemanticallyEqual),
 				},

--- a/internal/services/azapi_resource_action_data_source_test.go
+++ b/internal/services/azapi_resource_action_data_source_test.go
@@ -61,15 +61,12 @@ data "azapi_resource_action" "test" {
 
 func (r ActionDataSource) providerPermissions() string {
 	return `
-provider "azurerm" {
-  features {}
-}
 
-data "azurerm_client_config" "current" {}
+data "azapi_client_config" "current" {}
 
 data "azapi_resource_action" "test" {
   type        = "Microsoft.Resources/providers@2021-04-01"
-  resource_id = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/providers/Microsoft.Network"
+  resource_id = "/subscriptions/${data.azapi_client_config.current.subscription_id}/providers/Microsoft.Network"
   action      = "providerPermissions"
   method      = "GET"
 }

--- a/internal/services/azapi_resource_action_resource_test.go
+++ b/internal/services/azapi_resource_action_resource_test.go
@@ -3,6 +3,7 @@ package services_test
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/Azure/terraform-provider-azapi/internal/acceptance"
@@ -53,7 +54,7 @@ func TestAccActionResource_registerResourceProvider(t *testing.T) {
 
 	data.DataSourceTest(t, []resource.TestStep{
 		{
-			Config: r.registerResourceProvider(),
+			Config: r.registerResourceProvider(os.Getenv("ARM_SUBSCRIPTION_ID")),
 			Check:  resource.ComposeTestCheckFunc(),
 		},
 	})
@@ -77,8 +78,9 @@ func TestAccActionResource_nonstandardLRO(t *testing.T) {
 
 	data.DataSourceTest(t, []resource.TestStep{
 		{
-			Config: r.nonstandardLRO(data),
-			Check:  resource.ComposeTestCheckFunc(),
+			Config:            r.nonstandardLRO(data),
+			ExternalProviders: externalProvidersAzurerm(),
+			Check:             resource.ComposeTestCheckFunc(),
 		},
 	})
 }
@@ -147,35 +149,26 @@ resource "azapi_resource_action" "test" {
 `, GenericResource{}.identityNone(data))
 }
 
-func (r ActionResource) registerResourceProvider() string {
-	return `
-provider "azurerm" {
-  features {}
-}
-
-data "azurerm_client_config" "current" {}
-
+func (r ActionResource) registerResourceProvider(subscriptionId string) string {
+	return fmt.Sprintf(`
 resource "azapi_resource_action" "test" {
   type                   = "Microsoft.Resources/providers@2021-04-01"
-  resource_id            = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/providers/Microsoft.Compute"
+  resource_id            = "/subscriptions/%s/providers/Microsoft.Compute"
   action                 = "register"
   method                 = "POST"
   response_export_values = ["*"]
 }
-`
+`, subscriptionId)
 }
 
 func (r ActionResource) providerAction(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
 
-data "azurerm_client_config" "current" {}
+data "azapi_client_config" "current" {}
 
 resource "azapi_resource_action" "test" {
   type        = "Microsoft.Cache@2023-04-01"
-  resource_id = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/providers/Microsoft.Cache"
+  resource_id = "/subscriptions/${data.azapi_client_config.current.subscription_id}/providers/Microsoft.Cache"
   action      = "CheckNameAvailability"
   body = {
     type = "Microsoft.Cache/Redis"
@@ -187,9 +180,6 @@ resource "azapi_resource_action" "test" {
 
 func (r ActionResource) nonstandardLRO(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
 
 resource "azurerm_resource_group" "test" {
   name     = "acctestrg-%[2]s"
@@ -285,17 +275,12 @@ resource "azapi_resource_action" "test" {
 `, GenericResource{}.identityNone(data))
 }
 
-func (r ActionResource) oldConfig(data acceptance.TestData) string {
+func (r ActionResource) oldConfig(data acceptance.TestData, subscriptionId string) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
-data "azurerm_client_config" "current" {}
 
 resource "azapi_resource_action" "test" {
   type        = "Microsoft.Cache@2023-04-01"
-  resource_id = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/providers/Microsoft.Cache"
+  resource_id = "/subscriptions/%s/providers/Microsoft.Cache"
   action      = "CheckNameAvailability"
   body = jsonencode({
     type = "Microsoft.Cache/Redis"
@@ -303,5 +288,5 @@ resource "azapi_resource_action" "test" {
   })
   response_export_values = ["*"]
 }
-`, data.RandomString)
+`, subscriptionId, data.RandomString)
 }

--- a/internal/services/azapi_resource_action_resource_test.go
+++ b/internal/services/azapi_resource_action_resource_test.go
@@ -180,6 +180,9 @@ resource "azapi_resource_action" "test" {
 
 func (r ActionResource) nonstandardLRO(data acceptance.TestData) string {
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
 
 resource "azurerm_resource_group" "test" {
   name     = "acctestrg-%[2]s"

--- a/internal/services/azapi_resource_action_resource_upgrade_test.go
+++ b/internal/services/azapi_resource_action_resource_upgrade_test.go
@@ -1,6 +1,7 @@
 package services_test
 
 import (
+	"os"
 	"strings"
 	"testing"
 
@@ -42,13 +43,14 @@ func TestAccAzapiActionResourceUpgrade_registerResourceProvider(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azapi_resource_action", "test")
 	r := ActionResource{}
 
+	subscriptionId := os.Getenv("ARM_SUBSCRIPTION_ID")
 	data.UpgradeTest(t, r, []resource.TestStep{
 		data.UpgradeTestDeployStep(resource.TestStep{
-			Config: r.registerResourceProvider(),
+			Config: r.registerResourceProvider(subscriptionId),
 			Check:  resource.ComposeTestCheckFunc(),
 		}, PreviousVersion),
 		data.UpgradeTestPlanStep(resource.TestStep{
-			Config: r.registerResourceProvider(),
+			Config: r.registerResourceProvider(subscriptionId),
 		}),
 	})
 }
@@ -57,13 +59,14 @@ func TestAccAzapiActionResourceUpgrade_upgradeFromVeryOldVersion(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azapi_resource_action", "test")
 	r := ActionResource{}
 
+	subscriptionId := os.Getenv("ARM_SUBSCRIPTION_ID")
 	data.UpgradeTest(t, r, []resource.TestStep{
 		data.UpgradeTestDeployStep(resource.TestStep{
-			Config: r.registerResourceProvider(),
+			Config: r.registerResourceProvider(subscriptionId),
 			Check:  resource.ComposeTestCheckFunc(),
 		}, "1.8.0"),
 		data.UpgradeTestPlanStep(resource.TestStep{
-			Config: r.registerResourceProvider(),
+			Config: r.registerResourceProvider(subscriptionId),
 		}),
 	})
 }
@@ -135,13 +138,14 @@ func TestAccAzapiActionResourceUpgrade_basic_from_schema_v0(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azapi_resource_action", "test")
 	r := ActionResource{}
 
-	updatedConfig := r.oldConfig(data)
+	subscriptionId := os.Getenv("ARM_SUBSCRIPTION_ID")
+	updatedConfig := r.oldConfig(data, subscriptionId)
 	updatedConfig = strings.ReplaceAll(updatedConfig, "jsonencode({", "{")
 	updatedConfig = strings.ReplaceAll(updatedConfig, "})", "}")
 
 	data.UpgradeTest(t, r, []resource.TestStep{
 		data.UpgradeTestDeployStep(resource.TestStep{
-			Config: r.oldConfig(data),
+			Config: r.oldConfig(data, subscriptionId),
 			Check:  resource.ComposeTestCheckFunc(),
 		}, "1.12.1"),
 		data.UpgradeTestPlanStep(resource.TestStep{

--- a/internal/services/azapi_resource_action_resource_upgrade_test.go
+++ b/internal/services/azapi_resource_action_resource_upgrade_test.go
@@ -92,11 +92,13 @@ func TestAccAzapiActionResourceUpgrade_nonstandardLRO(t *testing.T) {
 
 	data.UpgradeTest(t, r, []resource.TestStep{
 		data.UpgradeTestDeployStep(resource.TestStep{
-			Config: r.nonstandardLRO(data),
-			Check:  resource.ComposeTestCheckFunc(),
+			Config:            r.nonstandardLRO(data),
+			ExternalProviders: externalProvidersAzurerm(),
+			Check:             resource.ComposeTestCheckFunc(),
 		}, PreviousVersion),
 		data.UpgradeTestPlanStep(resource.TestStep{
-			Config: r.nonstandardLRO(data),
+			ExternalProviders: externalProvidersAzurerm(),
+			Config:            r.nonstandardLRO(data),
 		}),
 	})
 }

--- a/internal/services/azapi_resource_list_data_source_test.go
+++ b/internal/services/azapi_resource_list_data_source_test.go
@@ -38,15 +38,11 @@ func TestAccListDataSource_paging(t *testing.T) {
 
 func (r ListDataSource) basic() string {
 	return `
-provider "azurerm" {
-  features {}
-}
-
-data "azurerm_client_config" "current" {}
+data "azapi_client_config" "current" {}
 
 data "azapi_resource_list" "test" {
   type                   = "Microsoft.Resources/resourceGroups@2024-03-01"
-  parent_id              = "/subscriptions/${data.azurerm_client_config.current.subscription_id}"
+  parent_id              = "/subscriptions/${data.azapi_client_config.current.subscription_id}"
   response_export_values = ["*"]
 }
 `
@@ -54,15 +50,11 @@ data "azapi_resource_list" "test" {
 
 func (r ListDataSource) paging() string {
 	return `
-provider "azurerm" {
-  features {}
-}
-
-data "azurerm_client_config" "current" {}
+data "azapi_client_config" "current" {}
 
 data "azapi_resource_list" "test" {
   type                   = "Microsoft.Authorization/policyDefinitions@2021-06-01"
-  parent_id              = "/subscriptions/${data.azurerm_client_config.current.subscription_id}"
+  parent_id              = "/subscriptions/${data.azapi_client_config.current.subscription_id}"
   response_export_values = ["*"]
 }
 `

--- a/internal/services/azapi_resource_test.go
+++ b/internal/services/azapi_resource_test.go
@@ -1328,7 +1328,7 @@ resource "azapi_resource" "test" {
 
   body = {
     properties = {
-      accountKey  = data.azapi_resource_action.listKeys.output.keys[0].value
+      accountKey  = try(data.azapi_resource_action.listKeys.output.keys[0].value, jsondecode(data.azapi_resource_action.listKeys.output).keys[0].value)
       accountName = azapi_resource.storageAccount.name
       storageType = "storageaccount"
     }

--- a/internal/services/azapi_resource_upgrade_test.go
+++ b/internal/services/azapi_resource_upgrade_test.go
@@ -289,10 +289,6 @@ func TestAccAzapiResourceUpgrade_subscriptionScope(t *testing.T) {
 	subscriptionId := os.Getenv("ARM_SUBSCRIPTION_ID")
 
 	updatedConfig := fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
 resource "azapi_resource" "test" {
   type      = "Microsoft.Resources/resourceGroups@2023-07-01"
   name      = "acctestRG-%[1]d"


### PR DESCRIPTION
This PR removes azurerm usage from the test cases to speed up the end to end tests. Because downloading external providers in each test case takes too long.

This reduces the time from 200 mins to 90 mins.