### PR TITLE
bugfix: fix state migration for `response_export_values`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ ENHANCEMENTS:
 - `azapi_resource` resource: Support `replace_triggers_external_values` field which is used to trigger a replacement of the resource.
 - `azapi` resources and data sources: Support `retry` field, which is used to specify the retry configuration.
 - `azapi` resources and data sources: Support `headers` and `query_parameters` fields, which are used to specify the headers and query parameters.
+- `azapi` resources and data sources: The `response_export_values` field supports JMESPath expressions.
 
 ## v1.15.0
 

--- a/internal/services/common.go
+++ b/internal/services/common.go
@@ -7,6 +7,7 @@ import (
 	"github.com/Azure/terraform-provider-azapi/internal/docstrings"
 	"github.com/Azure/terraform-provider-azapi/internal/services/dynamic"
 	"github.com/Azure/terraform-provider-azapi/internal/services/myplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -24,11 +25,7 @@ func CommonAttributeResponseExportValues() schema.DynamicAttribute {
 
 func buildOutputFromBody(responseBody interface{}, modelResponseExportValues types.Dynamic) (types.Dynamic, error) {
 	if modelResponseExportValues.IsNull() {
-		return types.DynamicNull(), nil
-	}
-
-	if modelResponseExportValues.IsUnknown() {
-		return types.DynamicUnknown(), nil
+		return types.DynamicValue(types.ObjectValueMust(map[string]attr.Type{}, map[string]attr.Value{})), nil
 	}
 
 	data, err := dynamic.ToJSON(modelResponseExportValues)

--- a/internal/services/migration/azapi_data_plane_resource_migration_v0_to_v2.go
+++ b/internal/services/migration/azapi_data_plane_resource_migration_v0_to_v2.go
@@ -126,6 +126,11 @@ func AzapiDataPlaneResourceMigrationV0ToV2(ctx context.Context) resource.StateUp
 				return
 			}
 
+			responseExportValues := types.DynamicNull()
+			if !oldState.ResponseExportValues.IsNull() {
+				responseExportValues = types.DynamicValue(oldState.ResponseExportValues)
+			}
+
 			newState := newModel{
 				ID:                    oldState.ID,
 				Name:                  oldState.Name,
@@ -135,7 +140,7 @@ func AzapiDataPlaneResourceMigrationV0ToV2(ctx context.Context) resource.StateUp
 				Locks:                 oldState.Locks,
 				IgnoreCasing:          oldState.IgnoreCasing,
 				IgnoreMissingProperty: oldState.IgnoreMissingProperty,
-				ResponseExportValues:  types.DynamicValue(oldState.ResponseExportValues),
+				ResponseExportValues:  responseExportValues,
 				Retry:                 retry.NewRetryValueNull(),
 				Output:                outputVal,
 				Timeouts:              oldState.Timeouts,

--- a/internal/services/migration/azapi_data_plane_resource_migration_v1_to_v2.go
+++ b/internal/services/migration/azapi_data_plane_resource_migration_v1_to_v2.go
@@ -123,6 +123,12 @@ func AzapiDataPlaneResourceMigrationV1ToV2(ctx context.Context) resource.StateUp
 				response.Diagnostics.AddError("failed to migrate output to dynamic value", err.Error())
 				return
 			}
+
+			responseExportValues := types.DynamicNull()
+			if !oldState.ResponseExportValues.IsNull() {
+				responseExportValues = types.DynamicValue(oldState.ResponseExportValues)
+			}
+
 			newState := newModel{
 				ID:                    oldState.ID,
 				Name:                  oldState.Name,
@@ -132,7 +138,7 @@ func AzapiDataPlaneResourceMigrationV1ToV2(ctx context.Context) resource.StateUp
 				Locks:                 oldState.Locks,
 				IgnoreCasing:          oldState.IgnoreCasing,
 				IgnoreMissingProperty: oldState.IgnoreMissingProperty,
-				ResponseExportValues:  types.DynamicValue(oldState.ResponseExportValues),
+				ResponseExportValues:  responseExportValues,
 				Retry:                 retry.NewRetryValueNull(),
 				Output:                outputVal,
 				Timeouts:              oldState.Timeouts,

--- a/internal/services/migration/azapi_resource_action_migration_v0_to_v2.go
+++ b/internal/services/migration/azapi_resource_action_migration_v0_to_v2.go
@@ -131,6 +131,11 @@ func AzapiResourceActionMigrationV0ToV2(ctx context.Context) resource.StateUpgra
 				return
 			}
 
+			responseExportValues := types.DynamicNull()
+			if !oldState.ResponseExportValues.IsNull() {
+				responseExportValues = types.DynamicValue(oldState.ResponseExportValues)
+			}
+
 			newState := newModel{
 				ID:                   oldState.ID,
 				Type:                 oldState.Type,
@@ -140,7 +145,7 @@ func AzapiResourceActionMigrationV0ToV2(ctx context.Context) resource.StateUpgra
 				Body:                 bodyVal,
 				When:                 when,
 				Locks:                oldState.Locks,
-				ResponseExportValues: types.DynamicValue(oldState.ResponseExportValues),
+				ResponseExportValues: responseExportValues,
 				Output:               outputVal,
 				Timeouts:             oldState.Timeouts,
 				Retry:                retry.NewRetryValueNull(),

--- a/internal/services/migration/azapi_resource_action_migration_v1_to_v2.go
+++ b/internal/services/migration/azapi_resource_action_migration_v1_to_v2.go
@@ -116,6 +116,12 @@ func AzapiResourceActionMigrationV1ToV2(ctx context.Context) resource.StateUpgra
 				response.Diagnostics.AddError("failed to migrate output to dynamic value", err.Error())
 				return
 			}
+
+			responseExportValues := types.DynamicNull()
+			if !oldState.ResponseExportValues.IsNull() {
+				responseExportValues = types.DynamicValue(oldState.ResponseExportValues)
+			}
+
 			newState := newModel{
 				ID:                   oldState.ID,
 				Type:                 oldState.Type,
@@ -125,7 +131,7 @@ func AzapiResourceActionMigrationV1ToV2(ctx context.Context) resource.StateUpgra
 				Body:                 bodyVal,
 				When:                 oldState.When,
 				Locks:                oldState.Locks,
-				ResponseExportValues: types.DynamicValue(oldState.ResponseExportValues),
+				ResponseExportValues: responseExportValues,
 				Output:               outputVal,
 				Timeouts:             oldState.Timeouts,
 				Retry:                retry.NewRetryValueNull(),

--- a/internal/services/migration/azapi_resource_migration_v0_to_v2.go
+++ b/internal/services/migration/azapi_resource_migration_v0_to_v2.go
@@ -186,6 +186,11 @@ func AzapiResourceMigrationV0ToV2(ctx context.Context) resource.StateUpgrader {
 				return
 			}
 
+			responseExportValues := types.DynamicNull()
+			if !oldState.ResponseExportValues.IsNull() {
+				responseExportValues = types.DynamicValue(oldState.ResponseExportValues)
+			}
+
 			newState := newModel{
 				ID:                            oldState.ID,
 				Name:                          oldState.Name,
@@ -199,7 +204,7 @@ func AzapiResourceMigrationV0ToV2(ctx context.Context) resource.StateUpgrader {
 				IgnoreCasing:                  oldState.IgnoreCasing,
 				IgnoreMissingProperty:         oldState.IgnoreMissingProperty,
 				ReplaceTriggersExternalValues: types.DynamicNull(),
-				ResponseExportValues:          types.DynamicValue(oldState.ResponseExportValues),
+				ResponseExportValues:          responseExportValues,
 				Retry:                         retry.NewRetryValueNull(),
 				Output:                        outputVal,
 				Tags:                          oldState.Tags,

--- a/internal/services/migration/azapi_resource_migration_v1_to_v2.go
+++ b/internal/services/migration/azapi_resource_migration_v1_to_v2.go
@@ -185,6 +185,11 @@ func AzapiResourceMigrationV1ToV2(ctx context.Context) resource.StateUpgrader {
 				return
 			}
 
+			responseExportValues := types.DynamicNull()
+			if !oldState.ResponseExportValues.IsNull() {
+				responseExportValues = types.DynamicValue(oldState.ResponseExportValues)
+			}
+
 			newState := newModel{
 				ID:                            oldState.ID,
 				Name:                          oldState.Name,
@@ -198,7 +203,7 @@ func AzapiResourceMigrationV1ToV2(ctx context.Context) resource.StateUpgrader {
 				IgnoreCasing:                  oldState.IgnoreCasing,
 				IgnoreMissingProperty:         oldState.IgnoreMissingProperty,
 				ReplaceTriggersExternalValues: types.DynamicNull(),
-				ResponseExportValues:          types.DynamicValue(oldState.ResponseExportValues),
+				ResponseExportValues:          responseExportValues,
 				Retry:                         retry.NewRetryValueNull(),
 				Output:                        outputVal,
 				Tags:                          oldState.Tags,

--- a/internal/services/migration/azapi_update_resource_migration_v0_to_v2.go
+++ b/internal/services/migration/azapi_update_resource_migration_v0_to_v2.go
@@ -137,6 +137,11 @@ func AzapiUpdateResourceMigrationV0ToV2(ctx context.Context) resource.StateUpgra
 				return
 			}
 
+			responseExportValues := types.DynamicNull()
+			if !oldState.ResponseExportValues.IsNull() {
+				responseExportValues = types.DynamicValue(oldState.ResponseExportValues)
+			}
+
 			newState := newModel{
 				ID:                    oldState.ID,
 				Name:                  oldState.Name,
@@ -147,7 +152,7 @@ func AzapiUpdateResourceMigrationV0ToV2(ctx context.Context) resource.StateUpgra
 				Locks:                 oldState.Locks,
 				IgnoreCasing:          oldState.IgnoreCasing,
 				IgnoreMissingProperty: oldState.IgnoreMissingProperty,
-				ResponseExportValues:  types.DynamicValue(oldState.ResponseExportValues),
+				ResponseExportValues:  responseExportValues,
 				Output:                outputVal,
 				Timeouts:              oldState.Timeouts,
 				Retry:                 retry.NewRetryValueNull(),

--- a/internal/services/migration/azapi_update_resource_migration_v1_to_v2.go
+++ b/internal/services/migration/azapi_update_resource_migration_v1_to_v2.go
@@ -135,6 +135,11 @@ func AzapiUpdateResourceMigrationV1ToV2(ctx context.Context) resource.StateUpgra
 				return
 			}
 
+			responseExportValues := types.DynamicNull()
+			if !oldState.ResponseExportValues.IsNull() {
+				responseExportValues = types.DynamicValue(oldState.ResponseExportValues)
+			}
+
 			newState := newModel{
 				ID:                    oldState.ID,
 				Name:                  oldState.Name,
@@ -145,7 +150,7 @@ func AzapiUpdateResourceMigrationV1ToV2(ctx context.Context) resource.StateUpgra
 				Locks:                 oldState.Locks,
 				IgnoreCasing:          oldState.IgnoreCasing,
 				IgnoreMissingProperty: oldState.IgnoreMissingProperty,
-				ResponseExportValues:  types.DynamicValue(oldState.ResponseExportValues),
+				ResponseExportValues:  responseExportValues,
 				Output:                outputVal,
 				Timeouts:              oldState.Timeouts,
 				Retry:                 retry.NewRetryValueNull(),


### PR DESCRIPTION
This PR fixes the state migration for `response_export_values`. Previously, the null list will be converted to a dynamic value whose underlying value is a null list. If the user doesn't specify the `response_export_values`, the config value should be a null dynamic value, and this will cause a plan diff because the structs are different.