### PR TITLE
`replace_triggers_refs` should use `dynamic.ToJson` to parse the dynamic value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ FEATURES:
 
 ENHANCEMENTS:
 - `azapi_resource` and `azapi_data_plane_resource` resource: Support `replace_triggers_external_values` field which is used to trigger a replacement of the resource.
+- `azapi_resource` and `azapi_data_plane_resource` resource: Support `replace_triggers_refs` field which is used to trigger a replacement of the resource.
 - `azapi` resources and data sources: Support `retry` field, which is used to specify the retry configuration.
 - `azapi` resources and data sources: Support `headers` and `query_parameters` fields, which are used to specify the headers and query parameters.
 - `azapi` resources and data sources: The `response_export_values` field supports JMESPath expressions.

--- a/internal/services/azapi_data_plane_resource.go
+++ b/internal/services/azapi_data_plane_resource.go
@@ -306,21 +306,32 @@ func (r *DataPlaneResource) ModifyPlan(ctx context.Context, request resource.Mod
 		}
 
 		// read previous values from state
-		var data interface{}
-		err := json.Unmarshal([]byte(state.Body.String()), &data)
+		stateData, err := dynamic.ToJSON(state.Body)
 		if err != nil {
 			response.Diagnostics.AddError("Invalid state body configuration", err.Error())
 			return
 		}
-		previousValues := flattenOutputJMES(data, refPaths)
+		var stateModel interface{}
+		err = json.Unmarshal(stateData, &stateModel)
+		if err != nil {
+			response.Diagnostics.AddError("Invalid state body configuration", err.Error())
+			return
+		}
+		previousValues := flattenOutputJMES(stateModel, refPaths)
 
 		// read current values from plan
-		err = json.Unmarshal([]byte(plan.Body.String()), &data)
+		planData, err := dynamic.ToJSON(plan.Body)
 		if err != nil {
 			response.Diagnostics.AddError("Invalid plan body configuration", err.Error())
 			return
 		}
-		currentValues := flattenOutputJMES(data, refPaths)
+		var planModel interface{}
+		err = json.Unmarshal(planData, &planModel)
+		if err != nil {
+			response.Diagnostics.AddError("Invalid plan body configuration", err.Error())
+			return
+		}
+		currentValues := flattenOutputJMES(planModel, refPaths)
 
 		// compare previous and current values
 		if !reflect.DeepEqual(previousValues, currentValues) {

--- a/internal/services/azapi_resource.go
+++ b/internal/services/azapi_resource.go
@@ -515,21 +515,32 @@ func (r *AzapiResource) ModifyPlan(ctx context.Context, request resource.ModifyP
 		}
 
 		// read previous values from state
-		var data interface{}
-		err = json.Unmarshal([]byte(state.Body.String()), &data)
+		stateData, err := dynamic.ToJSON(state.Body)
 		if err != nil {
 			response.Diagnostics.AddError("Invalid state body configuration", err.Error())
 			return
 		}
-		previousValues := flattenOutputJMES(data, refPaths)
+		var stateModel interface{}
+		err = json.Unmarshal(stateData, &stateModel)
+		if err != nil {
+			response.Diagnostics.AddError("Invalid state body configuration", err.Error())
+			return
+		}
+		previousValues := flattenOutputJMES(stateModel, refPaths)
 
 		// read current values from plan
-		err = json.Unmarshal([]byte(plan.Body.String()), &data)
+		planData, err := dynamic.ToJSON(plan.Body)
 		if err != nil {
 			response.Diagnostics.AddError("Invalid plan body configuration", err.Error())
 			return
 		}
-		currentValues := flattenOutputJMES(data, refPaths)
+		var planModel interface{}
+		err = json.Unmarshal(planData, &planModel)
+		if err != nil {
+			response.Diagnostics.AddError("Invalid plan body configuration", err.Error())
+			return
+		}
+		currentValues := flattenOutputJMES(planModel, refPaths)
 
 		// compare previous and current values
 		if !reflect.DeepEqual(previousValues, currentValues) {


### PR DESCRIPTION
This PR updates the logic that parse the dynamic value, previously it uses the "String()" method to get the JSON string, but this method is used to get a human-readable string for logging, and it can't guarantee it'll always be JSON and backward compatible.

