### PR TITLE
bugfix: preflight request doesn not include identity

### DIFF
--- a/docs/guides/2.0-upgrade-guide.md
+++ b/docs/guides/2.0-upgrade-guide.md
@@ -67,6 +67,7 @@ Below is an overview of the changes coming 2.0. Each topic is covered in more de
 * [Headers and Query Parameters Support](#headers-and-query-parameters-support)
 * [Replacement Triggers](#replacement-triggers)
 * [JMESPath Query Support](#jmespath-query-support)
+* [Preflight Validation](#preflight-validation)
 * [Breaking Changes](#breaking-changes)
 
 
@@ -211,14 +212,14 @@ The AzAPI Provider now supports customized retriable configuration for Azure API
 ```hcl
 
 data "azapi_resource" "test" {
-  type      = "Microsoft.Resources/resourceGroups@2024-03-01"
-  name      = "example"
+  type = "Microsoft.Resources/resourceGroups@2024-03-01"
+  name = "example"
 
   retry = {
-    error_message_regex = ["ResourceGroupNotFound"]
-    interval_seconds = 5
+    error_message_regex  = ["ResourceGroupNotFound"]
+    interval_seconds     = 5
     max_interval_seconds = 30
-    multiplier = 1.5
+    multiplier           = 1.5
     randomization_factor = 0.5
   }
 }
@@ -293,7 +294,7 @@ resource "azapi_resource" "example" {
   name      = var.name
   type      = "Microsoft.Network/publicIPAddresses@2023-11-01"
   parent_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/example"
-  body      = {
+  body = {
     properties = {
       sku   = var.sku
       zones = var.zones
@@ -315,7 +316,7 @@ resource "azapi_resource" "example" {
   name      = var.name
   type      = "Microsoft.Network/publicIPAddresses@2023-11-01"
   parent_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/example"
-  body      = {
+  body = {
     properties = {
       sku   = var.sku
       zones = var.zones
@@ -339,13 +340,13 @@ The `response_export_values` attribute accepts a map where the key is the name f
 ```hcl
 
 data "azapi_resource" "example" {
-   type      = "Microsoft.ContainerRegistry/registries@2020-11-01-preview"
-   parent_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/example"
-    name      = "example"
-    response_export_values = {
-      login_server = "properties.loginServer"
-      quarantine_status = "properties.policies.quarantinePolicy.status"
-    }
+  type      = "Microsoft.ContainerRegistry/registries@2020-11-01-preview"
+  parent_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/example"
+  name      = "example"
+  response_export_values = {
+    login_server      = "properties.loginServer"
+    quarantine_status = "properties.policies.quarantinePolicy.status"
+  }
 }
 
 // it will output below object
@@ -365,6 +366,46 @@ output "quarantine_status" {
 }
 
 ```
+
+## Preflight Validation
+
+Preflight validation is a new feature in the AzAPI Provider that helps ensure your configuration will deploy successfully. To enable preflight validation, set the `enable_preflight` attribute to `true` in the provider block.
+
+In the example below, the provider block is configured to enable preflight validation. The `azapi_resource` block defines a virtual network resource with an invalid address prefix. When you run `terraform plan`, the preflight validation will fail and display an error message.
+
+```hcl
+provider "azapi" {
+  enable_preflight = true
+}
+
+resource "azapi_resource" "vnet" {
+  type      = "Microsoft.Network/virtualNetworks@2024-01-01"
+  parent_id = azapi_resource.resourceGroup.id
+  name      = "example-vnet"
+  location  = "westus"
+  body = {
+    properties = {
+      addressSpace = {
+        addressPrefixes = [
+          "10.0.0.0/160",
+        ]
+      }
+    }
+  }
+}
+```
+
+When you run `terraform plan`, you will see the following error message:
+
+```json
+{
+  "code": "InvalidAddressPrefixFormat",
+  "target": "/subscriptions/....../resourceGroups/olgdwamq/providers/Microsoft.Network/virtualNetworks/example-vnet",
+  "message": "Address prefix 10.0.0.0/160 of resource /subscriptions/....../resourceGroups/olgdwamq/providers/Microsoft.Network/virtualNetworks/example-vnet is not formatted correctly. It should follow CIDR notation, for example 10.0.0.0/24.",
+  "details": []
+}
+```
+
 
 ## Breaking Changes
 

--- a/internal/services/azapi_resource.go
+++ b/internal/services/azapi_resource.go
@@ -561,7 +561,7 @@ func (r *AzapiResource) ModifyPlan(ctx context.Context, request resource.ModifyP
 			name = preflight.NamePlaceholder()
 		}
 
-		err = preflight.Validate(ctx, r.ProviderData.ResourceClient, plan.Type.ValueString(), parentId, name, plan.Location.ValueString(), plan.Body)
+		err = preflight.Validate(ctx, r.ProviderData.ResourceClient, plan.Type.ValueString(), parentId, name, plan.Location.ValueString(), plan.Body, plan.Identity)
 		if err != nil {
 			response.Diagnostics.AddError("Preflight Validation: Invalid configuration", err.Error())
 			return

--- a/internal/services/azapi_resource_preflight_test.go
+++ b/internal/services/azapi_resource_preflight_test.go
@@ -78,6 +78,18 @@ func TestAccGenericResource_preflightExtensionResourceValidation(t *testing.T) {
 	})
 }
 
+func TestAccGenericResource_preflightWithIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azapi_resource", "test")
+	r := GenericResource{}
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config:             r.preflightWithIdentity(data),
+			PlanOnly:           true,
+			ExpectNonEmptyPlan: true,
+		},
+	})
+}
+
 func (r GenericResource) preflightMockPropertyValue(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azapi" {

--- a/internal/services/azapi_resource_preflight_test.go
+++ b/internal/services/azapi_resource_preflight_test.go
@@ -199,7 +199,7 @@ resource "azapi_resource" "aksCluster" {
           vmSize = "Standard_DS2_v2"
         },
       ]
-      dnsPrefix = azapi_resource.resourceGroup.id
+      dnsPrefix = "exampleaks"
     }
   }
   schema_validation_enabled = false

--- a/internal/services/azapi_resource_preflight_test.go
+++ b/internal/services/azapi_resource_preflight_test.go
@@ -160,3 +160,37 @@ provider "azapi" {
 %s
 `, r.extensionScope(data))
 }
+
+func (r GenericResource) preflightWithIdentity(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azapi" {
+  enable_preflight = true
+}
+
+%[1]s
+
+resource "azapi_resource" "aksCluster" {
+  type      = "Microsoft.ContainerService/managedClusters@2024-06-02-preview"
+  parent_id = azapi_resource.resourceGroup.id
+  name      = azapi_resource.resourceGroup.id
+  location  = "westus"
+  identity {
+    type = "SystemAssigned"
+  }
+  body = {
+    properties = {
+      agentPoolProfiles = [
+        {
+          count  = 1
+          mode   = "System"
+          name   = "default"
+          vmSize = "Standard_DS2_v2"
+        },
+      ]
+      dnsPrefix = azapi_resource.resourceGroup.id
+    }
+  }
+  schema_validation_enabled = false
+}
+`, r.template(data))
+}

--- a/templates/guides/2.0-upgrade-guide.md
+++ b/templates/guides/2.0-upgrade-guide.md
@@ -212,14 +212,14 @@ The AzAPI Provider now supports customized retriable configuration for Azure API
 ```hcl
 
 data "azapi_resource" "test" {
-  type      = "Microsoft.Resources/resourceGroups@2024-03-01"
-  name      = "example"
+  type = "Microsoft.Resources/resourceGroups@2024-03-01"
+  name = "example"
 
   retry = {
-    error_message_regex = ["ResourceGroupNotFound"]
-    interval_seconds = 5
+    error_message_regex  = ["ResourceGroupNotFound"]
+    interval_seconds     = 5
     max_interval_seconds = 30
-    multiplier = 1.5
+    multiplier           = 1.5
     randomization_factor = 0.5
   }
 }
@@ -294,7 +294,7 @@ resource "azapi_resource" "example" {
   name      = var.name
   type      = "Microsoft.Network/publicIPAddresses@2023-11-01"
   parent_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/example"
-  body      = {
+  body = {
     properties = {
       sku   = var.sku
       zones = var.zones
@@ -316,7 +316,7 @@ resource "azapi_resource" "example" {
   name      = var.name
   type      = "Microsoft.Network/publicIPAddresses@2023-11-01"
   parent_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/example"
-  body      = {
+  body = {
     properties = {
       sku   = var.sku
       zones = var.zones
@@ -340,13 +340,13 @@ The `response_export_values` attribute accepts a map where the key is the name f
 ```hcl
 
 data "azapi_resource" "example" {
-   type      = "Microsoft.ContainerRegistry/registries@2020-11-01-preview"
-   parent_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/example"
-    name      = "example"
-    response_export_values = {
-      login_server = "properties.loginServer"
-      quarantine_status = "properties.policies.quarantinePolicy.status"
-    }
+  type      = "Microsoft.ContainerRegistry/registries@2020-11-01-preview"
+  parent_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/example"
+  name      = "example"
+  response_export_values = {
+    login_server      = "properties.loginServer"
+    quarantine_status = "properties.policies.quarantinePolicy.status"
+  }
 }
 
 // it will output below object


### PR DESCRIPTION
This PR adds identity to the preflight request body, without which the aks cluster's preflight will fail because it requires one of managed identity and service principal profile to be set.

I also added a test for aks preflight to guarantee that. 

<img width="1659" alt="image" src="https://github.com/user-attachments/assets/5dbdf070-4ed0-4f9d-a8e5-ebadee501629">
