### PR TITLE
unwrap NonRetriableError

### DIFF
--- a/internal/clients/resource_client.go
+++ b/internal/clients/resource_client.go
@@ -547,19 +547,9 @@ func (client *ResourceClient) List(ctx context.Context, url string, apiVersion s
 	}, nil
 }
 
-type WrappedError interface {
-	Unwrap() error
-}
-
 func (client *ResourceClient) shouldIgnorePollingError(err error) bool {
 	if err == nil {
 		return true
-	}
-
-	// the error could be wrapped, unwrap it
-	var wrappedError WrappedError
-	if errors.As(err, &wrappedError) {
-		err = wrappedError.Unwrap()
 	}
 
 	// there are some APIs that don't follow the ARM LRO guideline, return the response as is

--- a/internal/clients/resource_client.go
+++ b/internal/clients/resource_client.go
@@ -551,7 +551,6 @@ func (client *ResourceClient) shouldIgnorePollingError(err error) bool {
 	if err == nil {
 		return true
 	}
-
 	// there are some APIs that don't follow the ARM LRO guideline, return the response as is
 	var responseErr *azcore.ResponseError
 	if errors.As(err, &responseErr) {

--- a/internal/services/azapi_resource_test.go
+++ b/internal/services/azapi_resource_test.go
@@ -402,7 +402,7 @@ func TestAccGenericResource_secretsInAsterisks(t *testing.T) {
 }
 
 func TestAccGenericResource_nonstandardLRO(t *testing.T) {
-	t.Skip("This test is passing locally but failing in CI. Skipping for now.")
+	//	t.Skip("This test is passing locally but failing in CI. Skipping for now.")
 	data := acceptance.BuildTestData(t, "azapi_resource", "test")
 	r := GenericResource{}
 	data.ResourceTest(t, r, []resource.TestStep{

--- a/internal/services/azapi_resource_test.go
+++ b/internal/services/azapi_resource_test.go
@@ -402,7 +402,6 @@ func TestAccGenericResource_secretsInAsterisks(t *testing.T) {
 }
 
 func TestAccGenericResource_nonstandardLRO(t *testing.T) {
-	//	t.Skip("This test is passing locally but failing in CI. Skipping for now.")
 	data := acceptance.BuildTestData(t, "azapi_resource", "test")
 	r := GenericResource{}
 	data.ResourceTest(t, r, []resource.TestStep{


### PR DESCRIPTION
fixes https://github.com/Azure/terraform-provider-azapi/issues/575

When running this case in the azure pipeline, it will throws 401 instead of 403 when running locally, and 401 error will be wrapped as a NonRetriableError. This PR unwraps the error.