### PR TITLE
avoid infinite retry

### DIFF
--- a/internal/clients/data_plane_client.go
+++ b/internal/clients/data_plane_client.go
@@ -327,8 +327,8 @@ func (client *DataPlaneClient) Action(ctx context.Context, resourceID string, ac
 }
 
 func (retryclient *DataPlaneClientRetryableErrors) CreateOrUpdateThenPoll(ctx context.Context, id parse.DataPlaneResourceId, body interface{}, options RequestOptions) (interface{}, error) {
-	if retryclient.backoff == nil || len(retryclient.errors) == 0 {
-		return nil, fmt.Errorf("retry is not configured, please call WithRetry() first")
+	if retryclient.backoff == nil {
+		return nil, errors.New("retry is not configured, please call WithRetry() first")
 	}
 	op := backoff.OperationWithData[interface{}](
 		func() (interface{}, error) {
@@ -346,8 +346,8 @@ func (retryclient *DataPlaneClientRetryableErrors) CreateOrUpdateThenPoll(ctx co
 }
 
 func (retryclient *DataPlaneClientRetryableErrors) Get(ctx context.Context, id parse.DataPlaneResourceId, options RequestOptions) (interface{}, error) {
-	if retryclient.backoff == nil || len(retryclient.errors) == 0 {
-		return nil, fmt.Errorf("retry is not configured, please call WithRetry() first")
+	if retryclient.backoff == nil {
+		return nil, errors.New("retry is not configured, please call WithRetry() first")
 	}
 	op := backoff.OperationWithData[interface{}](
 		func() (interface{}, error) {
@@ -365,8 +365,8 @@ func (retryclient *DataPlaneClientRetryableErrors) Get(ctx context.Context, id p
 }
 
 func (retryclient *DataPlaneClientRetryableErrors) DeleteThenPoll(ctx context.Context, id parse.DataPlaneResourceId, options RequestOptions) (interface{}, error) {
-	if retryclient.backoff == nil || len(retryclient.errors) == 0 {
-		return nil, fmt.Errorf("retry is not configured, please call WithRetry() first")
+	if retryclient.backoff == nil {
+		return nil, errors.New("retry is not configured, please call WithRetry() first")
 	}
 	op := backoff.OperationWithData[interface{}](
 		func() (interface{}, error) {
@@ -384,8 +384,8 @@ func (retryclient *DataPlaneClientRetryableErrors) DeleteThenPoll(ctx context.Co
 }
 
 func (retryclient *DataPlaneClientRetryableErrors) Action(ctx context.Context, resourceID string, action string, apiVersion string, method string, body interface{}, options RequestOptions) (interface{}, error) {
-	if retryclient.backoff == nil || len(retryclient.errors) == 0 {
-		return nil, fmt.Errorf("retry is not configured, please call WithRetry() first")
+	if retryclient.backoff == nil {
+		return nil, errors.New("retry is not configured, please call WithRetry() first")
 	}
 	op := backoff.OperationWithData[interface{}](
 		func() (interface{}, error) {

--- a/internal/services/azapi_data_plane_resource.go
+++ b/internal/services/azapi_data_plane_resource.go
@@ -427,7 +427,7 @@ func (r *DataPlaneResource) CreateUpdate(ctx context.Context, plan tfsdk.Plan, s
 		backoff.NewExponentialBackOff(
 			backoff.WithInitialInterval(5*time.Second),
 			backoff.WithMaxInterval(30*time.Second),
-			backoff.WithMaxElapsedTime(2*time.Minute),
+			backoff.WithMaxElapsedTime(Retry404MaxElapsedTime()),
 		),
 		nil,
 		[]int{404},

--- a/internal/services/azapi_data_plane_resource.go
+++ b/internal/services/azapi_data_plane_resource.go
@@ -427,6 +427,7 @@ func (r *DataPlaneResource) CreateUpdate(ctx context.Context, plan tfsdk.Plan, s
 		backoff.NewExponentialBackOff(
 			backoff.WithInitialInterval(5*time.Second),
 			backoff.WithMaxInterval(30*time.Second),
+			backoff.WithMaxElapsedTime(2*time.Minute),
 		),
 		nil,
 		[]int{404},

--- a/internal/services/azapi_resource.go
+++ b/internal/services/azapi_resource.go
@@ -705,7 +705,7 @@ func (r *AzapiResource) CreateUpdate(ctx context.Context, requestPlan tfsdk.Plan
 		backoff.NewExponentialBackOff(
 			backoff.WithInitialInterval(5*time.Second),
 			backoff.WithMaxInterval(30*time.Second),
-			backoff.WithMaxElapsedTime(2*time.Minute),
+			backoff.WithMaxElapsedTime(Retry404MaxElapsedTime()),
 		),
 		nil,
 		[]int{404},

--- a/internal/services/azapi_resource.go
+++ b/internal/services/azapi_resource.go
@@ -705,6 +705,7 @@ func (r *AzapiResource) CreateUpdate(ctx context.Context, requestPlan tfsdk.Plan
 		backoff.NewExponentialBackOff(
 			backoff.WithInitialInterval(5*time.Second),
 			backoff.WithMaxInterval(30*time.Second),
+			backoff.WithMaxElapsedTime(2*time.Minute),
 		),
 		nil,
 		[]int{404},

--- a/internal/services/common.go
+++ b/internal/services/common.go
@@ -3,6 +3,8 @@ package services
 import (
 	"encoding/json"
 	"errors"
+	"os"
+	"time"
 
 	"github.com/Azure/terraform-provider-azapi/internal/docstrings"
 	"github.com/Azure/terraform-provider-azapi/internal/services/dynamic"
@@ -12,6 +14,16 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
+
+func Retry404MaxElapsedTime() time.Duration {
+	if v := os.Getenv("AZAPI_RETRY_404_MAX_ELAPSED_TIME"); v != "" {
+		timeout, err := time.ParseDuration(v)
+		if err != nil {
+			return timeout
+		}
+	}
+	return 2 * time.Minute
+}
 
 func CommonAttributeResponseExportValues() schema.DynamicAttribute {
 	return schema.DynamicAttribute{


### PR DESCRIPTION
https://github.com/Azure/terraform-provider-azapi/pull/621 introduces logics that retry the GET 404 after PUT is successful.

This PR sets the maximum total time for retries. Because I found a case that the resource might not be successfully created, and the GET requests keeps failing.

<img width="1197" alt="image" src="https://github.com/user-attachments/assets/0074e607-1f82-45c4-ae1c-786c009cf16f">
