### PR TITLE
`azapi`: Support `disable_default_output` field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 ENHANCEMENTS:
 - `azapi_data_plane_resource` resource: Support `Microsoft.Purview/accounts/Scanning/managedvirtualnetworks` type.
 - Support a default retry policy that retries when GET request fails with 404 status code after resource creation.
-- The `azapi_resource`, `azapi_update_resource` resources and data sources' `output` field defaults to the readonly fields when the `response_export_values` is not specified.
-- The `azapi_resource_list` data source's `output` field defaults to the response when the `response_export_values` is not specified.
+- `azapi_resource`, `azapi_update_resource` resources and data sources' `output` field defaults to the readonly fields when the `response_export_values` is not specified.
+- `azapi_resource_list` data source's `output` field defaults to the response when the `response_export_values` is not specified.
+- `azapi` provider: Support `disable_default_output` field, which is used to disable the default output for the resources and data sources.
 
 BUG FIXES:
 - Fix a bug that non-standard LRO error responses are not handled properly.

--- a/docs/index.md
+++ b/docs/index.md
@@ -67,6 +67,7 @@ provider "azapi" {
 - `default_name` (String) The default name to create the azure resource. The `name` in each resource block can override the `default_name`. Changing this forces new resources to be created.
 - `default_tags` (Map of String) A mapping of tags which should be assigned to the azure resource as default tags. The`tags` in each resource block can override the `default_tags`.
 - `disable_correlation_request_id` (Boolean) This will disable the x-ms-correlation-request-id header.
+- `disable_default_output` (Boolean) Disable default output. The default is false. When set to false, the provider will output the read-only properties if `response_export_values` is not specified in the resource block. When set to true, the provider will disable this output.
 - `disable_terraform_partner_id` (Boolean) Disable sending the Terraform Partner ID if a custom `partner_id` isn't specified, which allows Microsoft to better understand the usage of Terraform. The Partner ID does not give HashiCorp any direct access to usage information. This can also be sourced from the `ARM_DISABLE_TERRAFORM_PARTNER_ID` environment variable. Defaults to `false`.
 - `enable_preflight` (Boolean) Enable Preflight Validation. The default is false. When set to true, the provider will use Preflight to do static validation before really deploying a new resource. When set to false, the provider will disable this validation.
 - `endpoint` (Attributes List) The Azure API Endpoint Configuration. (see [below for nested schema](#nestedatt--endpoint))

--- a/internal/features/user_flags.go
+++ b/internal/features/user_flags.go
@@ -1,17 +1,19 @@
 package features
 
 type UserFeatures struct {
-	DefaultTags     map[string]string
-	DefaultLocation string
-	DefaultNaming   string
-	EnablePreflight bool
+	DefaultTags          map[string]string
+	DefaultLocation      string
+	DefaultNaming        string
+	EnablePreflight      bool
+	DisableDefaultOutput bool
 }
 
 func Default() UserFeatures {
 	return UserFeatures{
-		DefaultTags:     nil,
-		DefaultLocation: "",
-		DefaultNaming:   "",
-		EnablePreflight: false,
+		DefaultTags:          nil,
+		DefaultLocation:      "",
+		DefaultNaming:        "",
+		EnablePreflight:      false,
+		DisableDefaultOutput: false,
 	}
 }

--- a/internal/services/azapi_resource_data_source.go
+++ b/internal/services/azapi_resource_data_source.go
@@ -255,7 +255,11 @@ func (r *AzapiResourceDataSource) Read(ctx context.Context, request datasource.R
 		}
 	}
 
-	output, err := buildOutputFromBody(responseBody, model.ResponseExportValues, id.ResourceDef.GetReadOnly(responseBody))
+	var defaultOutput interface{}
+	if !r.ProviderData.Features.DisableDefaultOutput {
+		defaultOutput = id.ResourceDef.GetReadOnly(responseBody)
+	}
+	output, err := buildOutputFromBody(responseBody, model.ResponseExportValues, defaultOutput)
 	if err != nil {
 		response.Diagnostics.AddError("Failed to build output", err.Error())
 		return

--- a/internal/services/azapi_resource_list_data_source.go
+++ b/internal/services/azapi_resource_list_data_source.go
@@ -149,8 +149,11 @@ func (r *ResourceListDataSource) Read(ctx context.Context, request datasource.Re
 	}
 
 	model.ID = basetypes.NewStringValue(listUrl)
-
-	output, err := buildOutputFromBody(responseBody, model.ResponseExportValues, responseBody)
+	var defaultOutput interface{}
+	if !r.ProviderData.Features.DisableDefaultOutput {
+		defaultOutput = responseBody
+	}
+	output, err := buildOutputFromBody(responseBody, model.ResponseExportValues, defaultOutput)
 	if err != nil {
 		response.Diagnostics.AddError("Failed to build output", err.Error())
 		return

--- a/internal/services/azapi_update_resource.go
+++ b/internal/services/azapi_update_resource.go
@@ -399,7 +399,11 @@ func (r *AzapiUpdateResource) CreateUpdate(ctx context.Context, plan tfsdk.Plan,
 	model.ParentID = basetypes.NewStringValue(id.ParentId)
 	model.ResourceID = basetypes.NewStringValue(id.AzureResourceId)
 
-	output, err := buildOutputFromBody(responseBody, model.ResponseExportValues, id.ResourceDef.GetReadOnly(responseBody))
+	var defaultOutput interface{}
+	if !r.ProviderData.Features.DisableDefaultOutput {
+		defaultOutput = id.ResourceDef.GetReadOnly(responseBody)
+	}
+	output, err := buildOutputFromBody(responseBody, model.ResponseExportValues, defaultOutput)
 	if err != nil {
 		diagnostics.AddError("Failed to build output", err.Error())
 		return
@@ -479,7 +483,11 @@ func (r *AzapiUpdateResource) Read(ctx context.Context, request resource.ReadReq
 		return
 	}
 
-	output, err := buildOutputFromBody(responseBody, model.ResponseExportValues, id.ResourceDef.GetReadOnly(responseBody))
+	var defaultOutput interface{}
+	if !r.ProviderData.Features.DisableDefaultOutput {
+		defaultOutput = id.ResourceDef.GetReadOnly(responseBody)
+	}
+	output, err := buildOutputFromBody(responseBody, model.ResponseExportValues, defaultOutput)
 	if err != nil {
 		response.Diagnostics.AddError("Failed to build output", err.Error())
 		return


### PR DESCRIPTION
This PR adds a provider feature flag `disable_default_output` which is used to disable the default behavior that output the read only properties.