### PR TITLE
bugfix: provider crash if body contains unknown float value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+BUG FIXES:
+- Fix a bug when `body` contains an unknown float number, the provider will crash.
+
 ## v2.0.1
 ENHANCEMENTS:
 - `azapi_data_plane_resource` resource: Support `Microsoft.Purview/accounts/Scanning/managedvirtualnetworks` type.

--- a/internal/services/dynamic/dynamic.go
+++ b/internal/services/dynamic/dynamic.go
@@ -364,11 +364,15 @@ func attrValueFromJSONImplied(b []byte) (attr.Type, attr.Value, error) {
 }
 
 func SemanticallyEqual(a, b types.Dynamic) bool {
-	aJson, err := ToJSON(a)
+	aJson, err := ToJSONWithUnknownValueHandler(a, func(value attr.Value) ([]byte, error) {
+		return json.Marshal(nil)
+	})
 	if err != nil {
 		return false
 	}
-	bJson, err := ToJSON(b)
+	bJson, err := ToJSONWithUnknownValueHandler(b, func(value attr.Value) ([]byte, error) {
+		return json.Marshal(nil)
+	})
 	if err != nil {
 		return false
 	}


### PR DESCRIPTION
related issue: https://github.com/Azure/terraform-provider-azapi/issues/538#issuecomment-2426940037

When the `body` contains an unknown float number, the provider will crash.

For example: 
```
resource "azapi_resource" "automationAccount1" {
  type      = "Microsoft.Automation/automationAccounts@2023-11-01"
  parent_id = azapi_resource.resourceGroup.id
  name      = "acctesthenglu021"
  location  = "westus"
  body = {
    properties = {
      sku = {
        name = "Basic"
        value = azapi_resource.automationAccount.output.properties.sku.name == "Basic" ? 1.1 : 1.2
      }
    }
  }
  schema_validation_enabled = false
  response_export_values = []
}
```

