### PR TITLE
Fix the crash that occurs when no tenant ID is configured in Azure CLI

### DIFF
--- a/internal/clients/account.go
+++ b/internal/clients/account.go
@@ -41,6 +41,11 @@ func (account *ResourceManagerAccount) GetTenantId() string {
 		log.Printf("[DEBUG] Error getting default tenant ID: %s", err)
 	}
 
+	if account.tenantId == nil {
+		log.Printf("[DEBUG] No default tenant ID found")
+		return ""
+	}
+
 	return *account.tenantId
 }
 


### PR DESCRIPTION
fix crash similar to https://github.com/Azure/terraform-provider-azapi/issues/566 but for tenant ID:
```
Stack trace from the terraform-provider-azapi_v2.0.1 plugin:

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x89b799]

goroutine 36 [running]:
github.com/Azure/terraform-provider-azapi/internal/clients.(*ResourceManagerAccount).GetTenantId(0xc000220e50)
	github.com/Azure/terraform-provider-azapi/internal/clients/account.go:44 +0x139
github.com/Azure/terraform-provider-azapi/internal/services.(*ClientConfigDataSource).Read(0xc001a00018, {0xfacafb8, 0xc001837620}, {{{{0xfad0460, 0xc001837da0}, {0xd2d140, 0xc001837d10}}, {0xfad3040, 0xc001882640}}, {{{0x0, ...}, ...}, ...}, ...}, ...)
	github.com/Azure/terraform-provider-azapi/internal/services/azapi_client_config_data_source.go:79 +0x385
github.com/hashicorp/terraform-plugin-framework/internal/fwserver.(*Server).ReadDataSource(0xc0002741e0, {0xfacafb8, 0xc001837620}, 0xc001a04480, 0xc00014f6d8)
	github.com/hashicorp/terraform-plugin-framework@v1.11.0/internal/fwserver/server_readdatasource.go:103 +0x771
github.com/hashicorp/terraform-plugin-framework/internal/proto6server.(*Server).ReadDataSource(0xc0002741e0, {0xfacafb8?, 0xc001837500?}, 0xc001837470)
	github.com/hashicorp/terraform-plugin-framework@v1.11.0/internal/proto6server/server_readdatasource.go:55 +0x3fc
github.com/hashicorp/terraform-plugin-go/tfprotov6/tf6server.(*server).ReadDataSource(0xc00027b220, {0xfacafb8?, 0xc001836ab0?}, 0xc0000a4820)
	github.com/hashicorp/terraform-plugin-go@v0.23.0/tfprotov6/tf6server/server.go:688 +0x290
github.com/hashicorp/terraform-plugin-go/tfprotov6/internal/tfplugin6._Provider_ReadDataSource_Handler({0xe30f80?, 0xc00027b220}, {0xfacafb8, 0xc001836ab0}, 0xc001a12300, 0x0)
	github.com/hashicorp/terraform-plugin-go@v0.23.0/tfprotov6/internal/tfplugin6/tfplugin6_grpc.pb.go:572 +0x169
google.golang.org/grpc.(*Server).processUnaryRPC(0xc0000d1800, {0xfacafb8, 0xc001836a20}, {0xfad11d8, 0xc000476000}, 0xc001a06a20, 0xc000398c30, 0x1011a820, 0x0)
	google.golang.org/grpc@v1.65.0/server.go:1379 +0xe23
google.golang.org/grpc.(*Server).handleStream(0xc0000d1800, {0xfad11d8, 0xc000476000}, 0xc001a06a20)
	google.golang.org/grpc@v1.65.0/server.go:1790 +0x1016
google.golang.org/grpc.(*Server).serveStreams.func2.1()
	google.golang.org/grpc@v1.65.0/server.go:1029 +0x8b
created by google.golang.org/grpc.(*Server).serveStreams.func2 in goroutine 23
	google.golang.org/grpc@v1.65.0/server.go:1040 +0x135

Error: The terraform-provider-azapi_v2.0.1 plugin crashed!

This is always indicative of a bug within the plugin. It would be immensely
helpful if you could report the crash with the plugin's maintainers so that it
can be fixed. The output above should help diagnose the issue.
}

```