### PR TITLE
add example for `Microsoft.Network/networkManagers`'s nested resources

### DIFF
--- a/examples/Microsoft.Network_networkManagers_ipamPools@2024-01-01-preview/main.tf
+++ b/examples/Microsoft.Network_networkManagers_ipamPools@2024-01-01-preview/main.tf
@@ -1,0 +1,75 @@
+terraform {
+  required_providers {
+    azapi = {
+      source = "Azure/azapi"
+    }
+  }
+}
+
+provider "azapi" {
+  skip_provider_registration = false
+}
+
+variable "resource_name" {
+  type    = string
+  default = "acctest0001"
+}
+
+variable "location" {
+  type    = string
+  default = "westeurope"
+}
+
+data "azapi_client_config" "current" {}
+
+resource "azapi_resource" "resourceGroup" {
+  type     = "Microsoft.Resources/resourceGroups@2020-06-01"
+  name     = var.resource_name
+  location = var.location
+}
+
+resource "azapi_resource" "networkManager" {
+  type      = "Microsoft.Network/networkManagers@2022-09-01"
+  parent_id = azapi_resource.resourceGroup.id
+  name      = var.resource_name
+  location  = var.location
+  body = {
+    properties = {
+      description = ""
+      networkManagerScopeAccesses = [
+        "SecurityAdmin",
+      ]
+      networkManagerScopes = {
+        managementGroups = [
+        ]
+        subscriptions = [
+          "/subscriptions/${data.azapi_client_config.current.subscription_id}",
+        ]
+      }
+    }
+  }
+  retry = {
+    error_message_regex = ["CannotDeleteResource"]
+  }
+}
+
+resource "azapi_resource" "ipamPool" {
+  type      = "Microsoft.Network/networkManagers/ipamPools@2024-01-01-preview"
+  parent_id = azapi_resource.networkManager.id
+  name      = var.resource_name
+  location  = var.location
+  body = {
+    properties = {
+      addressPrefixes = [
+        "10.0.0.0/24",
+      ]
+      description    = "Test description."
+      parentPoolName = ""
+      displayName    = "testDisplayName"
+    }
+  }
+
+  tags = {
+    myTag = "testTag"
+  }
+}

--- a/examples/Microsoft.Network_networkManagers_ipamPools_staticCidr@2024-01-01-preview/main.tf
+++ b/examples/Microsoft.Network_networkManagers_ipamPools_staticCidr@2024-01-01-preview/main.tf
@@ -1,0 +1,90 @@
+terraform {
+  required_providers {
+    azapi = {
+      source = "Azure/azapi"
+    }
+  }
+}
+
+provider "azapi" {
+  skip_provider_registration = false
+}
+
+variable "resource_name" {
+  type    = string
+  default = "acctest0001"
+}
+
+variable "location" {
+  type    = string
+  default = "westeurope"
+}
+
+data "azapi_client_config" "current" {}
+
+resource "azapi_resource" "resourceGroup" {
+  type     = "Microsoft.Resources/resourceGroups@2020-06-01"
+  name     = var.resource_name
+  location = var.location
+}
+
+resource "azapi_resource" "networkManager" {
+  type      = "Microsoft.Network/networkManagers@2022-09-01"
+  parent_id = azapi_resource.resourceGroup.id
+  name      = var.resource_name
+  location  = var.location
+  body = {
+    properties = {
+      description = ""
+      networkManagerScopeAccesses = [
+        "SecurityAdmin",
+      ]
+      networkManagerScopes = {
+        managementGroups = [
+        ]
+        subscriptions = [
+          "/subscriptions/${data.azapi_client_config.current.subscription_id}",
+        ]
+      }
+    }
+  }
+  retry = {
+    error_message_regex = ["CannotDeleteResource"]
+  }
+}
+
+resource "azapi_resource" "ipamPool" {
+  type      = "Microsoft.Network/networkManagers/ipamPools@2024-01-01-preview"
+  parent_id = azapi_resource.networkManager.id
+  name      = var.resource_name
+  location  = var.location
+  body = {
+    properties = {
+      addressPrefixes = [
+        "10.0.0.0/24",
+      ]
+      description    = "Test description."
+      parentPoolName = ""
+      displayName    = "testDisplayName"
+    }
+  }
+
+  tags = {
+    myTag = "testTag"
+  }
+}
+
+resource "azapi_resource" "staticCidr" {
+  type      = "Microsoft.Network/networkManagers/ipamPools/staticCidrs@2024-01-01-preview"
+  parent_id = azapi_resource.ipamPool.id
+  name      = var.resource_name
+  body = {
+    properties = {
+      addressPrefixes = [
+        "10.0.0.0/25",
+      ]
+      numberOfIPAddressesToAllocate = ""
+      description = "test description"
+    }
+  }
+}

--- a/examples/Microsoft.Network_networkManagers_ipamPools_staticCidr@2024-01-01-preview/main.tf
+++ b/examples/Microsoft.Network_networkManagers_ipamPools_staticCidr@2024-01-01-preview/main.tf
@@ -84,7 +84,7 @@ resource "azapi_resource" "staticCidr" {
         "10.0.0.0/25",
       ]
       numberOfIPAddressesToAllocate = ""
-      description = "test description"
+      description                   = "test description"
     }
   }
 }

--- a/examples/Microsoft.Network_networkManagers_verifierWorkspace@2024-01-01-preview/main.tf
+++ b/examples/Microsoft.Network_networkManagers_verifierWorkspace@2024-01-01-preview/main.tf
@@ -1,0 +1,70 @@
+terraform {
+  required_providers {
+    azapi = {
+      source = "Azure/azapi"
+    }
+  }
+}
+
+provider "azapi" {
+  skip_provider_registration = false
+}
+
+variable "resource_name" {
+  type    = string
+  default = "acctest0001"
+}
+
+variable "location" {
+  type    = string
+  default = "westeurope"
+}
+
+data "azapi_client_config" "current" {}
+
+resource "azapi_resource" "resourceGroup" {
+  type     = "Microsoft.Resources/resourceGroups@2020-06-01"
+  name     = var.resource_name
+  location = var.location
+}
+
+resource "azapi_resource" "networkManager" {
+  type      = "Microsoft.Network/networkManagers@2022-09-01"
+  parent_id = azapi_resource.resourceGroup.id
+  name      = var.resource_name
+  location  = var.location
+  body = {
+    properties = {
+      description = ""
+      networkManagerScopeAccesses = [
+        "SecurityAdmin",
+      ]
+      networkManagerScopes = {
+        managementGroups = [
+        ]
+        subscriptions = [
+          "/subscriptions/${data.azapi_client_config.current.subscription_id}",
+        ]
+      }
+    }
+  }
+  retry = {
+    error_message_regex = ["CannotDeleteResource"]
+  }
+}
+
+resource "azapi_resource" "verifierWorkspace" {
+  type      = "Microsoft.Network/networkManagers/verifierWorkspaces@2024-01-01-preview"
+  parent_id = azapi_resource.networkManager.id
+  name      = var.resource_name
+  location  = var.location
+  body = {
+    properties = {
+      description = "A sample workspace"
+    }
+  }
+
+  tags = {
+    myTag = "testTag"
+  }
+}

--- a/examples/Microsoft.Network_networkManagers_verifierWorkspace_reachabilityAnalysisIntent@2024-01-01-preview/main.tf
+++ b/examples/Microsoft.Network_networkManagers_verifierWorkspace_reachabilityAnalysisIntent@2024-01-01-preview/main.tf
@@ -71,7 +71,7 @@ resource "azapi_resource" "subnet" {
       ]
     }
   }
-  ignore_missing_property   = true # ignore serviceEndpointPolicies NOT in GET subnet response
+  ignore_missing_property = true # ignore serviceEndpointPolicies NOT in GET subnet response
 }
 
 resource "azapi_resource" "networkInterface" {
@@ -103,7 +103,7 @@ resource "azapi_resource" "networkInterface" {
 resource "azapi_resource" "virtualMachine" {
   type      = "Microsoft.Compute/virtualMachines@2023-03-01"
   parent_id = azapi_resource.resourceGroup.id
-  name      = "terraform-armstrong-test-vm" 
+  name      = var.resource_name
   location  = var.location
   body = {
     properties = {
@@ -144,7 +144,7 @@ resource "azapi_resource" "virtualMachine" {
       }
     }
   }
-  ignore_missing_property   = true # ignore adminPassword as NOT part of GET vm response
+  ignore_missing_property = true # ignore adminPassword as NOT part of GET vm response
 }
 
 resource "azapi_resource" "networkManager" {

--- a/examples/Microsoft.Network_networkManagers_verifierWorkspace_reachabilityAnalysisIntent@2024-01-01-preview/main.tf
+++ b/examples/Microsoft.Network_networkManagers_verifierWorkspace_reachabilityAnalysisIntent@2024-01-01-preview/main.tf
@@ -1,0 +1,231 @@
+terraform {
+  required_providers {
+    azapi = {
+      source = "Azure/azapi"
+    }
+  }
+}
+
+provider "azapi" {
+  skip_provider_registration = false
+}
+
+variable "resource_name" {
+  type    = string
+  default = "acctest0001"
+}
+
+variable "location" {
+  type    = string
+  default = "westeurope"
+}
+
+data "azapi_client_config" "current" {}
+
+resource "azapi_resource" "resourceGroup" {
+  type     = "Microsoft.Resources/resourceGroups@2020-06-01"
+  name     = var.resource_name
+  location = var.location
+}
+
+resource "azapi_resource" "virtualNetwork" {
+  type      = "Microsoft.Network/virtualNetworks@2022-07-01"
+  parent_id = azapi_resource.resourceGroup.id
+  name      = var.resource_name
+  location  = var.location
+  body = {
+    properties = {
+      addressSpace = {
+        addressPrefixes = [
+          "10.0.0.0/16",
+        ]
+      }
+      dhcpOptions = {
+        dnsServers = [
+        ]
+      }
+      subnets = [
+      ]
+    }
+  }
+  lifecycle {
+    ignore_changes = [body.properties.subnets]
+  }
+  schema_validation_enabled = false
+}
+
+resource "azapi_resource" "subnet" {
+  type      = "Microsoft.Network/virtualNetworks/subnets@2022-07-01"
+  parent_id = azapi_resource.virtualNetwork.id
+  name      = var.resource_name
+  body = {
+    properties = {
+      addressPrefix = "10.0.2.0/24"
+      delegations = [
+      ]
+      privateEndpointNetworkPolicies    = "Enabled"
+      privateLinkServiceNetworkPolicies = "Enabled"
+      serviceEndpointPolicies = [
+      ]
+      serviceEndpoints = [
+      ]
+    }
+  }
+  ignore_missing_property   = true # ignore serviceEndpointPolicies NOT in GET subnet response
+}
+
+resource "azapi_resource" "networkInterface" {
+  type      = "Microsoft.Network/networkInterfaces@2022-07-01"
+  parent_id = azapi_resource.resourceGroup.id
+  name      = var.resource_name
+  location  = var.location
+  body = {
+    properties = {
+      enableAcceleratedNetworking = false
+      enableIPForwarding          = false
+      ipConfigurations = [
+        {
+          name = "testconfiguration1"
+          properties = {
+            primary                   = true
+            privateIPAddressVersion   = "IPv4"
+            privateIPAllocationMethod = "Dynamic"
+            subnet = {
+              id = azapi_resource.subnet.id
+            }
+          }
+        },
+      ]
+    }
+  }
+}
+
+resource "azapi_resource" "virtualMachine" {
+  type      = "Microsoft.Compute/virtualMachines@2023-03-01"
+  parent_id = azapi_resource.resourceGroup.id
+  name      = "terraform-armstrong-test-vm" 
+  location  = var.location
+  body = {
+    properties = {
+      hardwareProfile = {
+        vmSize = "Standard_F2"
+      }
+      networkProfile = {
+        networkInterfaces = [
+          {
+            id = azapi_resource.networkInterface.id
+            properties = {
+              primary = false
+            }
+          },
+        ]
+      }
+      osProfile = {
+        adminPassword = "Password1234!"
+        adminUsername = "testadmin"
+        computerName  = "hostname230630032848831819"
+        linuxConfiguration = {
+          disablePasswordAuthentication = false
+        }
+      }
+      storageProfile = {
+        imageReference = {
+          offer     = "UbuntuServer"
+          publisher = "Canonical"
+          sku       = "16.04-LTS"
+          version   = "latest"
+        }
+        osDisk = {
+          caching                 = "ReadWrite"
+          createOption            = "FromImage"
+          name                    = "myosdisk1"
+          writeAcceleratorEnabled = false
+        }
+      }
+    }
+  }
+  ignore_missing_property   = true # ignore adminPassword as NOT part of GET vm response
+}
+
+resource "azapi_resource" "networkManager" {
+  type      = "Microsoft.Network/networkManagers@2022-09-01"
+  parent_id = azapi_resource.resourceGroup.id
+  name      = var.resource_name
+  location  = var.location
+  body = {
+    properties = {
+      description = ""
+      networkManagerScopeAccesses = [
+        "SecurityAdmin",
+      ]
+      networkManagerScopes = {
+        managementGroups = [
+        ]
+        subscriptions = [
+          "/subscriptions/${data.azapi_client_config.current.subscription_id}",
+        ]
+      }
+    }
+  }
+  retry = {
+    error_message_regex = ["CannotDeleteResource"]
+  }
+}
+
+resource "azapi_resource" "verifierWorkspace" {
+  type      = "Microsoft.Network/networkManagers/verifierWorkspaces@2024-01-01-preview"
+  parent_id = azapi_resource.networkManager.id
+  name      = var.resource_name
+  location  = var.location
+  body = {
+    properties = {
+      description = "A sample workspace"
+    }
+  }
+
+  tags = {
+    myTag = "testTag"
+  }
+}
+
+resource "azapi_resource" "reachabilityAnalysisIntent" {
+  type      = "Microsoft.Network/networkManagers/verifierWorkspaces/reachabilityAnalysisIntents@2024-01-01-preview"
+  parent_id = azapi_resource.verifierWorkspace.id
+  name      = var.resource_name
+  body = {
+    properties = {
+      description           = "A sample reachability analysis intent"
+      destinationResourceId = azapi_resource.virtualMachine.id
+      ipTraffic = {
+        destinationIps = [
+          "10.4.0.1",
+        ]
+        destinationPorts = [
+          "0",
+        ]
+        protocols = [
+          "Any",
+        ]
+        sourceIps = [
+          "10.4.0.0",
+        ]
+        sourcePorts = [
+          "0",
+        ]
+      }
+      sourceResourceId = azapi_resource.virtualMachine.id
+    }
+  }
+}
+
+resource "azapi_resource" "reachabilityAnalysisRun" {
+  type      = "Microsoft.Network/networkManagers/verifierWorkspaces/reachabilityAnalysisRuns@2024-01-01-preview"
+  parent_id = azapi_resource.verifierWorkspace.id
+  name      = var.resource_name
+  body = {
+    properties = {
+      description = "A sample reachability analysis run"
+      intentId    = azapi_resource.reachabilityAnalysisIntent.id
+    }
+  }
+}

--- a/examples/Microsoft.Network_networkManagers_verifierWorkspace_reachabilityAnalysisIntent_reachabilityAnalysisRun@2024-01-01-preview/main.tf
+++ b/examples/Microsoft.Network_networkManagers_verifierWorkspace_reachabilityAnalysisIntent_reachabilityAnalysisRun@2024-01-01-preview/main.tf
@@ -1,0 +1,219 @@
+terraform {
+  required_providers {
+    azapi = {
+      source = "Azure/azapi"
+    }
+  }
+}
+
+provider "azapi" {
+  skip_provider_registration = false
+}
+
+variable "resource_name" {
+  type    = string
+  default = "acctest0001"
+}
+
+variable "location" {
+  type    = string
+  default = "westeurope"
+}
+
+data "azapi_client_config" "current" {}
+
+resource "azapi_resource" "resourceGroup" {
+  type     = "Microsoft.Resources/resourceGroups@2020-06-01"
+  name     = var.resource_name
+  location = var.location
+}
+
+resource "azapi_resource" "virtualNetwork" {
+  type      = "Microsoft.Network/virtualNetworks@2022-07-01"
+  parent_id = azapi_resource.resourceGroup.id
+  name      = var.resource_name
+  location  = var.location
+  body = {
+    properties = {
+      addressSpace = {
+        addressPrefixes = [
+          "10.0.0.0/16",
+        ]
+      }
+      dhcpOptions = {
+        dnsServers = [
+        ]
+      }
+      subnets = [
+      ]
+    }
+  }
+  lifecycle {
+    ignore_changes = [body.properties.subnets]
+  }
+  schema_validation_enabled = false
+}
+
+resource "azapi_resource" "subnet" {
+  type      = "Microsoft.Network/virtualNetworks/subnets@2022-07-01"
+  parent_id = azapi_resource.virtualNetwork.id
+  name      = var.resource_name
+  body = {
+    properties = {
+      addressPrefix = "10.0.2.0/24"
+      delegations = [
+      ]
+      privateEndpointNetworkPolicies    = "Enabled"
+      privateLinkServiceNetworkPolicies = "Enabled"
+      serviceEndpointPolicies = [
+      ]
+      serviceEndpoints = [
+      ]
+    }
+  }
+  ignore_missing_property   = true # ignore serviceEndpointPolicies NOT in GET subnet response
+}
+
+resource "azapi_resource" "networkInterface" {
+  type      = "Microsoft.Network/networkInterfaces@2022-07-01"
+  parent_id = azapi_resource.resourceGroup.id
+  name      = var.resource_name
+  location  = var.location
+  body = {
+    properties = {
+      enableAcceleratedNetworking = false
+      enableIPForwarding          = false
+      ipConfigurations = [
+        {
+          name = "testconfiguration1"
+          properties = {
+            primary                   = true
+            privateIPAddressVersion   = "IPv4"
+            privateIPAllocationMethod = "Dynamic"
+            subnet = {
+              id = azapi_resource.subnet.id
+            }
+          }
+        },
+      ]
+    }
+  }
+}
+
+resource "azapi_resource" "virtualMachine" {
+  type      = "Microsoft.Compute/virtualMachines@2023-03-01"
+  parent_id = azapi_resource.resourceGroup.id
+  name      = "terraform-armstrong-test-vm" 
+  location  = var.location
+  body = {
+    properties = {
+      hardwareProfile = {
+        vmSize = "Standard_F2"
+      }
+      networkProfile = {
+        networkInterfaces = [
+          {
+            id = azapi_resource.networkInterface.id
+            properties = {
+              primary = false
+            }
+          },
+        ]
+      }
+      osProfile = {
+        adminPassword = "Password1234!"
+        adminUsername = "testadmin"
+        computerName  = "hostname230630032848831819"
+        linuxConfiguration = {
+          disablePasswordAuthentication = false
+        }
+      }
+      storageProfile = {
+        imageReference = {
+          offer     = "UbuntuServer"
+          publisher = "Canonical"
+          sku       = "16.04-LTS"
+          version   = "latest"
+        }
+        osDisk = {
+          caching                 = "ReadWrite"
+          createOption            = "FromImage"
+          name                    = "myosdisk1"
+          writeAcceleratorEnabled = false
+        }
+      }
+    }
+  }
+  ignore_missing_property   = true # ignore adminPassword as NOT part of GET vm response
+}
+
+resource "azapi_resource" "networkManager" {
+  type      = "Microsoft.Network/networkManagers@2022-09-01"
+  parent_id = azapi_resource.resourceGroup.id
+  name      = var.resource_name
+  location  = var.location
+  body = {
+    properties = {
+      description = ""
+      networkManagerScopeAccesses = [
+        "SecurityAdmin",
+      ]
+      networkManagerScopes = {
+        managementGroups = [
+        ]
+        subscriptions = [
+          "/subscriptions/${data.azapi_client_config.current.subscription_id}",
+        ]
+      }
+    }
+  }
+  retry = {
+    error_message_regex = ["CannotDeleteResource"]
+  }
+}
+
+resource "azapi_resource" "verifierWorkspace" {
+  type      = "Microsoft.Network/networkManagers/verifierWorkspaces@2024-01-01-preview"
+  parent_id = azapi_resource.networkManager.id
+  name      = var.resource_name
+  location  = var.location
+  body = {
+    properties = {
+      description = "A sample workspace"
+    }
+  }
+
+  tags = {
+    myTag = "testTag"
+  }
+}
+
+resource "azapi_resource" "reachabilityAnalysisIntent" {
+  type      = "Microsoft.Network/networkManagers/verifierWorkspaces/reachabilityAnalysisIntents@2024-01-01-preview"
+  parent_id = azapi_resource.verifierWorkspace.id
+  name      = var.resource_name
+  body = {
+    properties = {
+      description           = "A sample reachability analysis intent"
+      destinationResourceId = azapi_resource.virtualMachine.id
+      ipTraffic = {
+        destinationIps = [
+          "10.4.0.1",
+        ]
+        destinationPorts = [
+          "0",
+        ]
+        protocols = [
+          "Any",
+        ]
+        sourceIps = [
+          "10.4.0.0",
+        ]
+        sourcePorts = [
+          "0",
+        ]
+      }
+      sourceResourceId = azapi_resource.virtualMachine.id
+    }
+  }
+}

--- a/examples/Microsoft.Network_networkManagers_verifierWorkspace_reachabilityAnalysisIntent_reachabilityAnalysisRun@2024-01-01-preview/main.tf
+++ b/examples/Microsoft.Network_networkManagers_verifierWorkspace_reachabilityAnalysisIntent_reachabilityAnalysisRun@2024-01-01-preview/main.tf
@@ -71,7 +71,7 @@ resource "azapi_resource" "subnet" {
       ]
     }
   }
-  ignore_missing_property   = true # ignore serviceEndpointPolicies NOT in GET subnet response
+  ignore_missing_property = true # ignore serviceEndpointPolicies NOT in GET subnet response
 }
 
 resource "azapi_resource" "networkInterface" {
@@ -103,7 +103,7 @@ resource "azapi_resource" "networkInterface" {
 resource "azapi_resource" "virtualMachine" {
   type      = "Microsoft.Compute/virtualMachines@2023-03-01"
   parent_id = azapi_resource.resourceGroup.id
-  name      = "terraform-armstrong-test-vm" 
+  name      = var.resource_name
   location  = var.location
   body = {
     properties = {
@@ -144,7 +144,7 @@ resource "azapi_resource" "virtualMachine" {
       }
     }
   }
-  ignore_missing_property   = true # ignore adminPassword as NOT part of GET vm response
+  ignore_missing_property = true # ignore adminPassword as NOT part of GET vm response
 }
 
 resource "azapi_resource" "networkManager" {

--- a/examples/Microsoft.VoiceServices_communicationsGateways_testLines@2023-01-31/main.tf
+++ b/examples/Microsoft.VoiceServices_communicationsGateways_testLines@2023-01-31/main.tf
@@ -79,7 +79,7 @@ resource "azapi_resource" "communicationsGateway" {
 }
 
 resource "azapi_resource" "TestLine" {
-  type = "Microsoft.VoiceServices/communicationsGateways/testLines@2023-01-31"
+  type      = "Microsoft.VoiceServices/communicationsGateways/testLines@2023-01-31"
   parent_id = azapi_resource.communicationsGateway.id
   name      = var.resource_name
   location  = var.location


### PR DESCRIPTION
This PR adds examples for the below resource types:
- Microsoft.Network/networkManagers/ipamPools
- Microsoft.Network/networkManagers/ipamPools/staticCidr
- Microsoft.Network/networkManagers/verifierWorkspace
- Microsoft.Network/networkManagers/verifierWorkspace/reachabilityAnalysisIntent
- Microsoft.Network/networkManagers/verifierWorkspace/reachabilityAnalysisIntent/reachabilityAnalysisRun

Tests:
```bash
=== RUN   TestAccExamples
--- PASS: TestAccExamples (0.00s)
=== RUN   TestAccExamples/0-Microsoft.Network_networkManagers_ipamPools@2024-01-01-preview
    azapi_resource_example_test.go:23: Running example ../../examples/0-Microsoft.Network_networkManagers_ipamPools@2024-01-01-preview
=== PAUSE TestAccExamples/0-Microsoft.Network_networkManagers_ipamPools@2024-01-01-preview
=== CONT  TestAccExamples/0-Microsoft.Network_networkManagers_ipamPools@2024-01-01-preview
    --- PASS: TestAccExamples/0-Microsoft.Network_networkManagers_ipamPools@2024-01-01-preview (75.39s)
PASS


=== RUN   TestAccExamples
--- PASS: TestAccExamples (0.00s)
=== RUN   TestAccExamples/0-Microsoft.Network_networkManagers_ipamPools_staticCidr@2024-01-01-preview
    azapi_resource_example_test.go:23: Running example ../../examples/0-Microsoft.Network_networkManagers_ipamPools_staticCidr@2024-01-01-preview
=== PAUSE TestAccExamples/0-Microsoft.Network_networkManagers_ipamPools_staticCidr@2024-01-01-preview
=== CONT  TestAccExamples/0-Microsoft.Network_networkManagers_ipamPools_staticCidr@2024-01-01-preview
    --- PASS: TestAccExamples/0-Microsoft.Network_networkManagers_ipamPools_staticCidr@2024-01-01-preview (84.80s)
PASS


=== RUN   TestAccExamples
--- PASS: TestAccExamples (0.01s)
=== RUN   TestAccExamples/0-Microsoft.Network_networkManagers_verifierWorkspace@2024-01-01-preview
    azapi_resource_example_test.go:23: Running example ../../examples/0-Microsoft.Network_networkManagers_verifierWorkspace@2024-01-01-preview
=== PAUSE TestAccExamples/0-Microsoft.Network_networkManagers_verifierWorkspace@2024-01-01-preview
=== CONT  TestAccExamples/0-Microsoft.Network_networkManagers_verifierWorkspace@2024-01-01-preview
    --- PASS: TestAccExamples/0-Microsoft.Network_networkManagers_verifierWorkspace@2024-01-01-preview (81.08s)
PASS


=== RUN   TestAccExamples
--- PASS: TestAccExamples (0.01s)
=== RUN   TestAccExamples/0-Microsoft.Network_networkManagers_verifierWorkspace_reachabilityAnalysisIntent@2024-01-01-preview
    azapi_resource_example_test.go:23: Running example ../../examples/0-Microsoft.Network_networkManagers_verifierWorkspace_reachabilityAnalysisIntent@2024-01-01-preview
=== PAUSE TestAccExamples/0-Microsoft.Network_networkManagers_verifierWorkspace_reachabilityAnalysisIntent@2024-01-01-preview
=== CONT  TestAccExamples/0-Microsoft.Network_networkManagers_verifierWorkspace_reachabilityAnalysisIntent@2024-01-01-preview
    --- PASS: TestAccExamples/0-Microsoft.Network_networkManagers_verifierWorkspace_reachabilityAnalysisIntent@2024-01-01-preview (251.72s)
PASS

=== RUN   TestAccExamples
--- PASS: TestAccExamples (0.01s)
=== RUN   TestAccExamples/0-Microsoft.Network_networkManagers_verifierWorkspace_reachabilityAnalysisIntent_reachabilityAnalysisRun@2024-01-01-preview
    azapi_resource_example_test.go:23: Running example ../../examples/0-Microsoft.Network_networkManagers_verifierWorkspace_reachabilityAnalysisIntent_reachabilityAnalysisRun@2024-01-01-preview
=== PAUSE TestAccExamples/0-Microsoft.Network_networkManagers_verifierWorkspace_reachabilityAnalysisIntent_reachabilityAnalysisRun@2024-01-01-preview
=== CONT  TestAccExamples/0-Microsoft.Network_networkManagers_verifierWorkspace_reachabilityAnalysisIntent_reachabilityAnalysisRun@2024-01-01-preview
    --- PASS: TestAccExamples/0-Microsoft.Network_networkManagers_verifierWorkspace_reachabilityAnalysisIntent_reachabilityAnalysisRun@2024-01-01-preview (262.16s)
PASS

```