### PR TITLE
bugfix: resource manager account is not initialized correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 FEATURES:
 - `azapi_resource` resource: Support resource move operation, it allows moving resources from `azurerm` provider.
+- `azapi_client_config` data source: Support `object_id` field.
 
 BUG FIXES:
 - Fix a bug when `body` contains an unknown float number, the provider will crash.

--- a/internal/clients/client.go
+++ b/internal/clients/client.go
@@ -133,7 +133,7 @@ func (client *Client) Build(ctx context.Context, o *Option) error {
 	}
 	client.DataPlaneClient = dataPlaneClient
 
-	client.Account = NewResourceManagerAccount(client)
+	client.Account = NewResourceManagerAccount(o.TenantId, o.SubscriptionId, ParsedTokenClaimsObjectIDProvider(ctx, o.Cred, o.TenantId, o.CloudCfg))
 
 	return nil
 }

--- a/internal/clients/client.go
+++ b/internal/clients/client.go
@@ -133,7 +133,7 @@ func (client *Client) Build(ctx context.Context, o *Option) error {
 	}
 	client.DataPlaneClient = dataPlaneClient
 
-	client.Account = NewResourceManagerAccount(o.TenantId, o.SubscriptionId, ParsedTokenClaimsObjectIDProvider(ctx, o.Cred, o.TenantId, o.CloudCfg))
+	client.Account = NewResourceManagerAccount(o.TenantId, o.SubscriptionId, ParsedTokenClaimsObjectIDProvider(o.Cred, o.CloudCfg))
 
 	return nil
 }

--- a/internal/services/azapi_client_config_data_source.go
+++ b/internal/services/azapi_client_config_data_source.go
@@ -90,7 +90,7 @@ func (r *ClientConfigDataSource) Read(ctx context.Context, request datasource.Re
 
 	subscriptionId := r.ProviderData.Account.GetSubscriptionId()
 	tenantId := r.ProviderData.Account.GetTenantId()
-	objectId := r.ProviderData.Account.GetObjectId()
+	objectId := r.ProviderData.Account.GetObjectId(ctx)
 
 	model.ID = types.StringValue(fmt.Sprintf("clientConfigs/subscriptionId=%s;tenantId=%s", subscriptionId, tenantId))
 	model.SubscriptionID = types.StringValue(subscriptionId)


### PR DESCRIPTION
Previously the resource manager account is initialized incorrectly, because it uses the same structure to initialize the resource manager.

This PR fixes above bug and abstracts the object ID lazy load function to an interface to simplify the implementation.