### PR TITLE
fix: improve retry behavior with resources at MG scope

### DIFF
--- a/internal/clients/data_plane_client.go
+++ b/internal/clients/data_plane_client.go
@@ -20,6 +20,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/terraform-provider-azapi/internal/services/parse"
 	"github.com/cenkalti/backoff/v4"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 type DataPlaneClient struct {
@@ -48,6 +49,22 @@ var (
 	_ DataPlaneRequester = &DataPlaneClient{}
 	_ DataPlaneRequester = &DataPlaneClientRetryableErrors{}
 )
+
+func (retryclient *DataPlaneClientRetryableErrors) updateContext(ctx context.Context) context.Context {
+	ctx = tflog.SetField(ctx, "backoff_max_elapsed_time", retryclient.backoff.MaxElapsedTime.String())
+	ctx = tflog.SetField(ctx, "backoff_initial_interval", retryclient.backoff.InitialInterval.String())
+	ctx = tflog.SetField(ctx, "backoff_max_interval", retryclient.backoff.MaxInterval.String())
+	ctx = tflog.SetField(ctx, "backoff_multiplier", retryclient.backoff.Multiplier)
+	ctx = tflog.SetField(ctx, "backoff_randomization_factor", retryclient.backoff.RandomizationFactor)
+	ctx = tflog.SetField(ctx, "retryable_http_status_codes", retryclient.statusCodes)
+	ctx = tflog.SetField(ctx, "retryable_data_callback_funcs_length", len(retryclient.dataCallbackFuncs))
+	re := make([]string, len(retryclient.errors))
+	for i, r := range retryclient.errors {
+		re[i] = r.String()
+	}
+	ctx = tflog.SetField(ctx, "retryable_errors", re)
+	return ctx
+}
 
 // NewDataPlaneClientRetryableErrors creates a new ResourceClientRetryableErrors.
 func NewDataPlaneClientRetryableErrors(client DataPlaneRequester, bkof *backoff.ExponentialBackOff, errRegExps []regexp.Regexp, statusCodes []int, dataCallbackFuncs []func(any) bool) *DataPlaneClientRetryableErrors {
@@ -330,13 +347,29 @@ func (retryclient *DataPlaneClientRetryableErrors) CreateOrUpdateThenPoll(ctx co
 	if retryclient.backoff == nil {
 		return nil, errors.New("retry is not configured, please call WithRetry() first")
 	}
+	ctx = tflog.SetField(ctx, "request", "CreateOrUpdateThenPoll")
+	ctx = retryclient.updateContext(ctx)
+	tflog.Debug(ctx, "retryclient: Begin")
+	i := 0
 	op := backoff.OperationWithData[interface{}](
 		func() (interface{}, error) {
 			data, err := retryclient.client.CreateOrUpdateThenPoll(ctx, id, body, options)
 			if err != nil {
-				if isDataPlaneRetryable(*retryclient, data, err) {
+				if isDataPlaneRetryable(ctx, *retryclient, data, err) {
+					tflog.Debug(ctx, "retryclient: Retry attempt", map[string]interface{}{
+						"err":     err,
+						"attempt": i,
+					})
+					i++
 					return data, err
 				}
+				tflog.Debug(ctx, "retryclient: PermanentError", map[string]interface{}{
+					"err":     err,
+					"attempt": i,
+				})
+				tflog.Debug(ctx, "retryclient: Success", map[string]interface{}{
+					"attempt": i,
+				})
 				return nil, &backoff.PermanentError{Err: err}
 			}
 			return data, err
@@ -349,15 +382,31 @@ func (retryclient *DataPlaneClientRetryableErrors) Get(ctx context.Context, id p
 	if retryclient.backoff == nil {
 		return nil, errors.New("retry is not configured, please call WithRetry() first")
 	}
+	ctx = tflog.SetField(ctx, "request", "Get")
+	ctx = retryclient.updateContext(ctx)
+	tflog.Debug(ctx, "retryclient: Begin")
+	i := 0
 	op := backoff.OperationWithData[interface{}](
 		func() (interface{}, error) {
 			data, err := retryclient.client.Get(ctx, id, options)
 			if err != nil {
-				if isDataPlaneRetryable(*retryclient, data, err) {
+				if isDataPlaneRetryable(ctx, *retryclient, data, err) {
+					tflog.Debug(ctx, "retryclient: Retry attempt", map[string]interface{}{
+						"err":     err,
+						"attempt": i,
+					})
+					i++
 					return data, err
 				}
+				tflog.Debug(ctx, "retryclient: PermanentError", map[string]interface{}{
+					"err":     err,
+					"attempt": i,
+				})
 				return nil, &backoff.PermanentError{Err: err}
 			}
+			tflog.Debug(ctx, "retryclient: Success", map[string]interface{}{
+				"attempt": i,
+			})
 			return data, err
 		})
 	exbo := backoff.WithContext(retryclient.backoff, ctx)
@@ -368,15 +417,31 @@ func (retryclient *DataPlaneClientRetryableErrors) DeleteThenPoll(ctx context.Co
 	if retryclient.backoff == nil {
 		return nil, errors.New("retry is not configured, please call WithRetry() first")
 	}
+	ctx = tflog.SetField(ctx, "request", "DeleteThenPoll")
+	ctx = retryclient.updateContext(ctx)
+	tflog.Debug(ctx, "retryclient: Begin")
+	i := 0
 	op := backoff.OperationWithData[interface{}](
 		func() (interface{}, error) {
 			data, err := retryclient.client.DeleteThenPoll(ctx, id, options)
 			if err != nil {
-				if isDataPlaneRetryable(*retryclient, data, err) {
+				if isDataPlaneRetryable(ctx, *retryclient, data, err) {
+					tflog.Debug(ctx, "retryclient: Retry attempt", map[string]interface{}{
+						"err":     err,
+						"attempt": i,
+					})
+					i++
 					return data, err
 				}
+				tflog.Debug(ctx, "retryclient: PermanentError", map[string]interface{}{
+					"err":     err,
+					"attempt": i,
+				})
 				return nil, &backoff.PermanentError{Err: err}
 			}
+			tflog.Debug(ctx, "retryclient: Success", map[string]interface{}{
+				"attempt": i,
+			})
 			return data, err
 		})
 	exbo := backoff.WithContext(retryclient.backoff, ctx)
@@ -387,35 +452,63 @@ func (retryclient *DataPlaneClientRetryableErrors) Action(ctx context.Context, r
 	if retryclient.backoff == nil {
 		return nil, errors.New("retry is not configured, please call WithRetry() first")
 	}
+	ctx = tflog.SetField(ctx, "request", "Action")
+	ctx = retryclient.updateContext(ctx)
+	tflog.Debug(ctx, "retryclient: Begin")
+	i := 0
 	op := backoff.OperationWithData[interface{}](
 		func() (interface{}, error) {
 			data, err := retryclient.client.Action(ctx, resourceID, action, apiVersion, method, body, options)
 			if err != nil {
-				if isDataPlaneRetryable(*retryclient, data, err) {
+				if isDataPlaneRetryable(ctx, *retryclient, data, err) {
+					tflog.Debug(ctx, "retryclient: Retry attempt", map[string]interface{}{
+						"err":     err,
+						"attempt": i,
+					})
+					i++
 					return data, err
 				}
+				tflog.Debug(ctx, "retryclient: PermanentError", map[string]interface{}{
+					"err":     err,
+					"attempt": i,
+				})
 				return nil, &backoff.PermanentError{Err: err}
 			}
+			tflog.Debug(ctx, "retryclient: Success", map[string]interface{}{
+				"attempt": i,
+			})
 			return data, err
 		})
 	exbo := backoff.WithContext(retryclient.backoff, ctx)
 	return backoff.RetryWithData[interface{}](op, exbo)
 }
 
-func isDataPlaneRetryable(retryclient DataPlaneClientRetryableErrors, data interface{}, err error) bool {
+func isDataPlaneRetryable(ctx context.Context, retryclient DataPlaneClientRetryableErrors, data interface{}, err error) bool {
 	for _, e := range retryclient.errors {
 		if e.MatchString(err.Error()) {
+			tflog.Debug(ctx, "isDataPlaneRetryable: Error is retryable by regex", map[string]interface{}{
+				"err":    err,
+				"regexp": e.String(),
+			})
 			return true
 		}
 	}
 	var respErr *azcore.ResponseError
 	if errors.As(err, &respErr) {
 		if slices.Contains(retryclient.statusCodes, respErr.StatusCode) {
+			tflog.Debug(ctx, "isDataPlaneRetryable: Error is retryable by status code", map[string]interface{}{
+				"err":        err,
+				"statusCode": respErr.StatusCode,
+			})
 			return true
 		}
 	}
-	for _, f := range retryclient.dataCallbackFuncs {
+	for i, f := range retryclient.dataCallbackFuncs {
 		if f(data) {
+			tflog.Debug(ctx, "isDataPlaneRetryable: Error is retryable by function callback", map[string]interface{}{
+				"err":               err,
+				"callback_func_idx": i,
+			})
 			return true
 		}
 	}

--- a/internal/clients/resource_client.go
+++ b/internal/clients/resource_client.go
@@ -17,6 +17,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/cenkalti/backoff/v4"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 const (
@@ -120,15 +121,29 @@ func (retryclient *ResourceClientRetryableErrors) CreateOrUpdate(ctx context.Con
 	if retryclient.backoff == nil {
 		return nil, errors.New("retry is not configured, please call WithRetry() first")
 	}
+	ctx = tflog.SetField(ctx, "request", "CreateOrUpdate")
+	tflog.Debug(ctx, "retryclient: Begin")
+	i := 0
 	op := backoff.OperationWithData[interface{}](
 		func() (interface{}, error) {
 			data, err := retryclient.client.CreateOrUpdate(ctx, resourceID, apiVersion, body, options)
 			if err != nil {
-				if isRetryable(*retryclient, data, err) {
+				if isRetryable(ctx, *retryclient, data, err) {
+					tflog.Debug(ctx, "retryclient: Retry attempt", map[string]interface{}{
+						"err":     err,
+						"attempt": i,
+					})
 					return data, err
 				}
+				tflog.Debug(ctx, "retryclient: PermanentError", map[string]interface{}{
+					"err":     err,
+					"attempt": i,
+				})
 				return nil, &backoff.PermanentError{Err: err}
 			}
+			tflog.Debug(ctx, "retryclient: Success", map[string]interface{}{
+				"attempt": i,
+			})
 			return data, err
 		})
 	exbo := backoff.WithContext(retryclient.backoff, ctx)
@@ -201,15 +216,29 @@ func (retryclient *ResourceClientRetryableErrors) Get(ctx context.Context, resou
 	if retryclient.backoff == nil {
 		return nil, errors.New("retry is not configured, please call WithRetry() first")
 	}
+	ctx = tflog.SetField(ctx, "request", "Get")
+	tflog.Debug(ctx, "retryclient: Begin")
+	i := 0
 	op := backoff.OperationWithData[interface{}](
 		func() (interface{}, error) {
 			data, err := retryclient.client.Get(ctx, resourceID, apiVersion, options)
 			if err != nil {
-				if isRetryable(*retryclient, data, err) {
+				if isRetryable(ctx, *retryclient, data, err) {
+					tflog.Debug(ctx, "retryclient: Retry attempt", map[string]interface{}{
+						"err":     err,
+						"attempt": i,
+					})
 					return data, err
 				}
+				tflog.Debug(ctx, "retryclient: PermanentError", map[string]interface{}{
+					"err":     err,
+					"attempt": i,
+				})
 				return nil, &backoff.PermanentError{Err: err}
 			}
+			tflog.Debug(ctx, "retryclient: Success", map[string]interface{}{
+				"attempt": i,
+			})
 			return data, err
 		})
 	exbo := backoff.WithContext(retryclient.backoff, ctx)
@@ -263,15 +292,29 @@ func (retryclient *ResourceClientRetryableErrors) Delete(ctx context.Context, re
 	if retryclient.backoff == nil {
 		return nil, errors.New("retry is not configured, please call WithRetry() first")
 	}
+	ctx = tflog.SetField(ctx, "request", "Delete")
+	tflog.Debug(ctx, "retryclient: Begin")
+	i := 0
 	op := backoff.OperationWithData[interface{}](
 		func() (interface{}, error) {
 			data, err := retryclient.client.Delete(ctx, resourceID, apiVersion, options)
 			if err != nil {
-				if isRetryable(*retryclient, data, err) {
+				if isRetryable(ctx, *retryclient, data, err) {
+					tflog.Debug(ctx, "retryclient: Retry attempt", map[string]interface{}{
+						"err":     err,
+						"attempt": i,
+					})
 					return data, err
 				}
+				tflog.Debug(ctx, "retryclient: PermanentError", map[string]interface{}{
+					"err":     err,
+					"attempt": i,
+				})
 				return nil, &backoff.PermanentError{Err: err}
 			}
+			tflog.Debug(ctx, "retryclient: Success", map[string]interface{}{
+				"attempt": i,
+			})
 			return data, err
 		})
 	exbo := backoff.WithContext(retryclient.backoff, ctx)
@@ -344,15 +387,29 @@ func (retryclient *ResourceClientRetryableErrors) Action(ctx context.Context, re
 	if retryclient.backoff == nil {
 		return nil, errors.New("retry is not configured, please call WithRetry() first")
 	}
+	ctx = tflog.SetField(ctx, "request", "Action")
+	tflog.Debug(ctx, "retryclient: Begin")
+	i := 0
 	op := backoff.OperationWithData[interface{}](
 		func() (interface{}, error) {
 			data, err := retryclient.client.Action(ctx, resourceID, action, apiVersion, method, body, options)
 			if err != nil {
-				if isRetryable(*retryclient, data, err) {
+				if isRetryable(ctx, *retryclient, data, err) {
+					tflog.Debug(ctx, "retryclient: Retry attempt", map[string]interface{}{
+						"err":     err,
+						"attempt": i,
+					})
 					return data, err
 				}
+				tflog.Debug(ctx, "retryclient: PermanentError", map[string]interface{}{
+					"err":     err,
+					"attempt": i,
+				})
 				return nil, &backoff.PermanentError{Err: err}
 			}
+			tflog.Debug(ctx, "retryclient: Success", map[string]interface{}{
+				"attempt": i,
+			})
 			return data, err
 		})
 	exbo := backoff.WithContext(retryclient.backoff, ctx)
@@ -443,15 +500,29 @@ func (retryclient *ResourceClientRetryableErrors) List(ctx context.Context, url 
 	if retryclient.backoff == nil {
 		return nil, errors.New("retry is not configured, please call WithRetry() first")
 	}
+	ctx = tflog.SetField(ctx, "request", "List")
+	tflog.Debug(ctx, "retryclient: Begin")
+	i := 0
 	op := backoff.OperationWithData[interface{}](
 		func() (interface{}, error) {
 			data, err := retryclient.client.List(ctx, url, apiVersion, options)
 			if err != nil {
-				if isRetryable(*retryclient, data, err) {
+				if isRetryable(ctx, *retryclient, data, err) {
+					tflog.Debug(ctx, "retryclient: Retry attempt", map[string]interface{}{
+						"err":     err,
+						"attempt": i,
+					})
 					return data, err
 				}
+				tflog.Debug(ctx, "retryclient: PermanentError", map[string]interface{}{
+					"err":     err,
+					"attempt": i,
+				})
 				return nil, &backoff.PermanentError{Err: err}
 			}
+			tflog.Debug(ctx, "retryclient: Success", map[string]interface{}{
+				"attempt": i,
+			})
 			return data, err
 		})
 	exbo := backoff.WithContext(retryclient.backoff, ctx)
@@ -569,22 +640,35 @@ func (client *ResourceClient) shouldIgnorePollingError(err error) bool {
 	return false
 }
 
-func isRetryable(retryclient ResourceClientRetryableErrors, data interface{}, err error) bool {
+func isRetryable(ctx context.Context, retryclient ResourceClientRetryableErrors, data interface{}, err error) bool {
 	for _, e := range retryclient.errors {
 		if e.MatchString(err.Error()) {
+			tflog.Debug(ctx, "isRetryable: Error is retryable by regex", map[string]interface{}{
+				"err":    err,
+				"regexp": e.String(),
+			})
 			return true
 		}
 	}
 	var respErr *azcore.ResponseError
 	if errors.As(err, &respErr) {
 		if slices.Contains(retryclient.statusCodes, respErr.StatusCode) {
+			tflog.Debug(ctx, "isRetryable: Error is retryable by status code", map[string]interface{}{
+				"err":        err,
+				"statusCode": respErr.StatusCode,
+			})
 			return true
 		}
 	}
-	for _, f := range retryclient.dataCallbackFuncs {
+	for i, f := range retryclient.dataCallbackFuncs {
 		if f(data) {
+			tflog.Debug(ctx, "isRetryable: Error is retryable by function callback", map[string]interface{}{
+				"err":               err,
+				"callback_func_idx": i,
+			})
 			return true
 		}
 	}
+	tflog.Debug(ctx, "isRetryable: Error is not retryable")
 	return false
 }

--- a/internal/clients/resource_client.go
+++ b/internal/clients/resource_client.go
@@ -119,6 +119,8 @@ func (retryclient *ResourceClientRetryableErrors) updateContext(ctx context.Cont
 	ctx = tflog.SetField(ctx, "backoff_max_interval", retryclient.backoff.MaxInterval.String())
 	ctx = tflog.SetField(ctx, "backoff_multiplier", retryclient.backoff.Multiplier)
 	ctx = tflog.SetField(ctx, "backoff_randomization_factor", retryclient.backoff.RandomizationFactor)
+	ctx = tflog.SetField(ctx, "retryable_http_status_codes", retryclient.statusCodes)
+	ctx = tflog.SetField(ctx, "retryable_data_callback_funcs_length", len(retryclient.dataCallbackFuncs))
 	re := make([]string, len(retryclient.errors))
 	for i, r := range retryclient.errors {
 		re[i] = r.String()

--- a/internal/clients/resource_client.go
+++ b/internal/clients/resource_client.go
@@ -113,6 +113,20 @@ func (client *ResourceClient) WithRetry(bkof *backoff.ExponentialBackOff, errReg
 	return rcre
 }
 
+func (retryclient *ResourceClientRetryableErrors) updateContext(ctx context.Context) context.Context {
+	ctx = tflog.SetField(ctx, "backoff_max_elapsed_time", retryclient.backoff.MaxElapsedTime.String())
+	ctx = tflog.SetField(ctx, "backoff_initial_interval", retryclient.backoff.InitialInterval.String())
+	ctx = tflog.SetField(ctx, "backoff_max_interval", retryclient.backoff.MaxInterval.String())
+	ctx = tflog.SetField(ctx, "backoff_multiplier", retryclient.backoff.Multiplier)
+	ctx = tflog.SetField(ctx, "backoff_randomization_factor", retryclient.backoff.RandomizationFactor)
+	re := make([]string, len(retryclient.errors))
+	for i, r := range retryclient.errors {
+		re[i] = r.String()
+	}
+	ctx = tflog.SetField(ctx, "retryable_errors", re)
+	return ctx
+}
+
 // CreateOrUpdate configures the retryable errors for the client.
 // It calls CreateOrUpdate, then checks if the error is contained in the retryable errors list.
 // If it is, it will retry the operation with the configured backoff.
@@ -122,6 +136,7 @@ func (retryclient *ResourceClientRetryableErrors) CreateOrUpdate(ctx context.Con
 		return nil, errors.New("retry is not configured, please call WithRetry() first")
 	}
 	ctx = tflog.SetField(ctx, "request", "CreateOrUpdate")
+	ctx = retryclient.updateContext(ctx)
 	tflog.Debug(ctx, "retryclient: Begin")
 	i := 0
 	op := backoff.OperationWithData[interface{}](
@@ -218,6 +233,7 @@ func (retryclient *ResourceClientRetryableErrors) Get(ctx context.Context, resou
 		return nil, errors.New("retry is not configured, please call WithRetry() first")
 	}
 	ctx = tflog.SetField(ctx, "request", "Get")
+	ctx = retryclient.updateContext(ctx)
 	tflog.Debug(ctx, "retryclient: Begin")
 	i := 0
 	op := backoff.OperationWithData[interface{}](
@@ -295,6 +311,7 @@ func (retryclient *ResourceClientRetryableErrors) Delete(ctx context.Context, re
 		return nil, errors.New("retry is not configured, please call WithRetry() first")
 	}
 	ctx = tflog.SetField(ctx, "request", "Delete")
+	ctx = retryclient.updateContext(ctx)
 	tflog.Debug(ctx, "retryclient: Begin")
 	i := 0
 	op := backoff.OperationWithData[interface{}](
@@ -391,6 +408,7 @@ func (retryclient *ResourceClientRetryableErrors) Action(ctx context.Context, re
 		return nil, errors.New("retry is not configured, please call WithRetry() first")
 	}
 	ctx = tflog.SetField(ctx, "request", "Action")
+	ctx = retryclient.updateContext(ctx)
 	tflog.Debug(ctx, "retryclient: Begin")
 	i := 0
 	op := backoff.OperationWithData[interface{}](
@@ -505,6 +523,7 @@ func (retryclient *ResourceClientRetryableErrors) List(ctx context.Context, url 
 		return nil, errors.New("retry is not configured, please call WithRetry() first")
 	}
 	ctx = tflog.SetField(ctx, "request", "List")
+	ctx = retryclient.updateContext(ctx)
 	tflog.Debug(ctx, "retryclient: Begin")
 	i := 0
 	op := backoff.OperationWithData[interface{}](

--- a/internal/clients/resource_client.go
+++ b/internal/clients/resource_client.go
@@ -133,6 +133,7 @@ func (retryclient *ResourceClientRetryableErrors) CreateOrUpdate(ctx context.Con
 						"err":     err,
 						"attempt": i,
 					})
+					i++
 					return data, err
 				}
 				tflog.Debug(ctx, "retryclient: PermanentError", map[string]interface{}{
@@ -228,6 +229,7 @@ func (retryclient *ResourceClientRetryableErrors) Get(ctx context.Context, resou
 						"err":     err,
 						"attempt": i,
 					})
+					i++
 					return data, err
 				}
 				tflog.Debug(ctx, "retryclient: PermanentError", map[string]interface{}{
@@ -304,6 +306,7 @@ func (retryclient *ResourceClientRetryableErrors) Delete(ctx context.Context, re
 						"err":     err,
 						"attempt": i,
 					})
+					i++
 					return data, err
 				}
 				tflog.Debug(ctx, "retryclient: PermanentError", map[string]interface{}{
@@ -399,6 +402,7 @@ func (retryclient *ResourceClientRetryableErrors) Action(ctx context.Context, re
 						"err":     err,
 						"attempt": i,
 					})
+					i++
 					return data, err
 				}
 				tflog.Debug(ctx, "retryclient: PermanentError", map[string]interface{}{
@@ -512,6 +516,7 @@ func (retryclient *ResourceClientRetryableErrors) List(ctx context.Context, url 
 						"err":     err,
 						"attempt": i,
 					})
+					i++
 					return data, err
 				}
 				tflog.Debug(ctx, "retryclient: PermanentError", map[string]interface{}{

--- a/internal/retry/retryable_errors.go
+++ b/internal/retry/retryable_errors.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math/big"
+	"regexp"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -575,7 +576,7 @@ func (v RetryValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
 	}
 }
 
-func (v RetryValue) GetErrorMessageRegex() []string {
+func (v RetryValue) GetErrorMessages() []string {
 	if v.IsNull() {
 		return nil
 	}
@@ -585,6 +586,18 @@ func (v RetryValue) GetErrorMessageRegex() []string {
 	res := make([]string, len(v.ErrorMessageRegex.Elements()))
 	for i, elem := range v.ErrorMessageRegex.Elements() {
 		res[i] = elem.(types.String).ValueString()
+	}
+	return res
+}
+
+func (v RetryValue) GetErrorMessagesRegex() []regexp.Regexp {
+	msgs := v.GetErrorMessages()
+	if msgs == nil {
+		return nil
+	}
+	res := make([]regexp.Regexp, len(msgs))
+	for i, msg := range msgs {
+		res[i] = *regexp.MustCompile(msg)
 	}
 	return res
 }

--- a/internal/retry/retryable_errors.go
+++ b/internal/retry/retryable_errors.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math/big"
+	"regexp"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -585,6 +586,19 @@ func (v RetryValue) GetErrorMessageRegex() []string {
 	res := make([]string, len(v.ErrorMessageRegex.Elements()))
 	for i, elem := range v.ErrorMessageRegex.Elements() {
 		res[i] = elem.(types.String).ValueString()
+	}
+	return res
+}
+
+func (v RetryValue) GetErrorMessageRegexAsRegexp() []regexp.Regexp {
+	regexs := v.GetErrorMessageRegex()
+	if regexs == nil {
+		return nil
+	}
+	res := make([]regexp.Regexp, len(regexs))
+	for i, str := range regexs {
+		re := regexp.MustCompile(str)
+		res[i] = *re
 	}
 	return res
 }

--- a/internal/retry/retryable_errors.go
+++ b/internal/retry/retryable_errors.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"math/big"
-	"regexp"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -586,19 +585,6 @@ func (v RetryValue) GetErrorMessageRegex() []string {
 	res := make([]string, len(v.ErrorMessageRegex.Elements()))
 	for i, elem := range v.ErrorMessageRegex.Elements() {
 		res[i] = elem.(types.String).ValueString()
-	}
-	return res
-}
-
-func (v RetryValue) GetErrorMessageRegexAsRegexp() []regexp.Regexp {
-	regexs := v.GetErrorMessageRegex()
-	if regexs == nil {
-		return nil
-	}
-	res := make([]regexp.Regexp, len(regexs))
-	for i, str := range regexs {
-		re := regexp.MustCompile(str)
-		res[i] = *re
 	}
 	return res
 }

--- a/internal/services/azapi_client_config_data_source.go
+++ b/internal/services/azapi_client_config_data_source.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 type ClientConfigDataSourceModel struct {
@@ -80,8 +79,6 @@ func (r *ClientConfigDataSource) Read(ctx context.Context, request datasource.Re
 	if response.Diagnostics.Append(request.Config.Get(ctx, &model)...); response.Diagnostics.HasError() {
 		return
 	}
-	tflog.Info(ctx, "azapi_client_config: Read begin")
-	defer tflog.Info(ctx, "azapi_client_config: Read end")
 
 	readTimeout, diags := model.Timeouts.Read(ctx, 5*time.Minute)
 	response.Diagnostics.Append(diags...)

--- a/internal/services/azapi_client_config_data_source.go
+++ b/internal/services/azapi_client_config_data_source.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 type ClientConfigDataSourceModel struct {
@@ -79,6 +80,8 @@ func (r *ClientConfigDataSource) Read(ctx context.Context, request datasource.Re
 	if response.Diagnostics.Append(request.Config.Get(ctx, &model)...); response.Diagnostics.HasError() {
 		return
 	}
+	tflog.Info(ctx, "azapi_client_config: Read begin")
+	defer tflog.Info(ctx, "azapi_client_config: Read end")
 
 	readTimeout, diags := model.Timeouts.Read(ctx, 5*time.Minute)
 	response.Diagnostics.Append(diags...)

--- a/internal/services/azapi_data_plane_resource.go
+++ b/internal/services/azapi_data_plane_resource.go
@@ -73,6 +73,7 @@ var _ resource.ResourceWithModifyPlan = &DataPlaneResource{}
 var _ resource.ResourceWithUpgradeState = &DataPlaneResource{}
 
 func (r *DataPlaneResource) Configure(ctx context.Context, request resource.ConfigureRequest, response *resource.ConfigureResponse) {
+	tflog.Debug(ctx, "Configuring azapi_data_plane_resource")
 	if v, ok := request.ProviderData.(*clients.Client); ok {
 		r.ProviderData = v
 	}
@@ -371,6 +372,8 @@ func (r *DataPlaneResource) CreateUpdate(ctx context.Context, plan tfsdk.Plan, s
 		return
 	}
 
+	ctx = tflog.SetField(ctx, "resource_id", id.ID())
+
 	var client clients.DataPlaneRequester
 	client = r.ProviderData.DataPlaneClient
 	if !model.Retry.IsNull() {
@@ -381,6 +384,7 @@ func (r *DataPlaneResource) CreateUpdate(ctx context.Context, plan tfsdk.Plan, s
 			model.Retry.GetRandomizationFactor(),
 			model.Retry.GetErrorMessageRegex(),
 		)
+		tflog.Debug(ctx, "azapi_data_plane_resource.CreateUpdate is using retry")
 		client = r.ProviderData.DataPlaneClient.WithRetry(bkof, regexps, nil, nil)
 	}
 	isNewResource := state == nil || state.Raw.IsNull()
@@ -434,11 +438,11 @@ func (r *DataPlaneResource) CreateUpdate(ctx context.Context, plan tfsdk.Plan, s
 	}
 
 	// Create a new retry client to handle specific case of transient 404 after resource creation
-	clientRetry404 := r.ProviderData.DataPlaneClient.WithRetry(
+	clientGetAfterPut := r.ProviderData.DataPlaneClient.WithRetry(
 		backoff.NewExponentialBackOff(
 			backoff.WithInitialInterval(5*time.Second),
 			backoff.WithMaxInterval(30*time.Second),
-			backoff.WithMaxElapsedTime(Retry404MaxElapsedTime()),
+			backoff.WithMaxElapsedTime(RetryGetAfterPut()),
 		),
 		nil,
 		[]int{404},
@@ -448,7 +452,7 @@ func (r *DataPlaneResource) CreateUpdate(ctx context.Context, plan tfsdk.Plan, s
 			},
 		},
 	)
-	responseBody, err := clientRetry404.Get(ctx, id, clients.NewRequestOptions(model.ReadHeaders, model.ReadQueryParameters))
+	responseBody, err := clientGetAfterPut.Get(ctx, id, clients.NewRequestOptions(model.ReadHeaders, model.ReadQueryParameters))
 	if err != nil {
 		if utils.ResponseErrorWasNotFound(err) {
 			tflog.Info(ctx, fmt.Sprintf("Error reading %q - removing from state", id.ID()))
@@ -491,6 +495,7 @@ func (r *DataPlaneResource) Read(ctx context.Context, request resource.ReadReque
 		response.Diagnostics.AddError("Error parsing ID", err.Error())
 		return
 	}
+	ctx = tflog.SetField(ctx, "resource_id", id.ID())
 
 	var client clients.DataPlaneRequester
 	client = r.ProviderData.DataPlaneClient
@@ -502,6 +507,7 @@ func (r *DataPlaneResource) Read(ctx context.Context, request resource.ReadReque
 			model.Retry.GetRandomizationFactor(),
 			model.Retry.GetErrorMessageRegex(),
 		)
+		tflog.Debug(ctx, "azapi_data_plane_resource.Read is using retry")
 		client = r.ProviderData.DataPlaneClient.WithRetry(bkof, regexps, nil, nil)
 	}
 	responseBody, err := client.Get(ctx, id, clients.NewRequestOptions(model.ReadHeaders, model.ReadQueryParameters))
@@ -567,6 +573,22 @@ func (r *DataPlaneResource) Delete(ctx context.Context, request resource.DeleteR
 		return
 	}
 
+	deleteTimeout, diags := model.Timeouts.Delete(ctx, 30*time.Minute)
+	response.Diagnostics.Append(diags...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
+	defer cancel()
+
+	id, err := parse.DataPlaneResourceIDWithResourceType(model.ID.ValueString(), model.Type.ValueString())
+	if err != nil {
+		response.Diagnostics.AddError("Error parsing ID", err.Error())
+		return
+	}
+
+	ctx = tflog.SetField(ctx, "resource_id", id.ID())
+
 	var client clients.DataPlaneRequester
 	client = r.ProviderData.DataPlaneClient
 	if !model.Retry.IsNull() && !model.Retry.IsUnknown() {
@@ -577,22 +599,8 @@ func (r *DataPlaneResource) Delete(ctx context.Context, request resource.DeleteR
 			model.Retry.GetRandomizationFactor(),
 			model.Retry.GetErrorMessageRegex(),
 		)
+		tflog.Debug(ctx, "azapi_data_plane_resource.Delete is using retry")
 		client = r.ProviderData.DataPlaneClient.WithRetry(bkof, regexps, nil, nil)
-	}
-
-	deleteTimeout, diags := model.Timeouts.Delete(ctx, 30*time.Minute)
-	response.Diagnostics.Append(diags...)
-	if response.Diagnostics.HasError() {
-		return
-	}
-
-	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
-	defer cancel()
-
-	id, err := parse.DataPlaneResourceIDWithResourceType(model.ID.ValueString(), model.Type.ValueString())
-	if err != nil {
-		response.Diagnostics.AddError("Error parsing ID", err.Error())
-		return
 	}
 
 	lockIds := AsStringList(model.Locks)

--- a/internal/services/azapi_data_plane_resource.go
+++ b/internal/services/azapi_data_plane_resource.go
@@ -382,7 +382,7 @@ func (r *DataPlaneResource) CreateUpdate(ctx context.Context, plan tfsdk.Plan, s
 			model.Retry.GetMaxIntervalSeconds(),
 			model.Retry.GetMultiplier(),
 			model.Retry.GetRandomizationFactor(),
-			model.Retry.GetErrorMessageRegex(),
+			model.Retry.GetErrorMessages(),
 		)
 		tflog.Debug(ctx, "azapi_data_plane_resource.CreateUpdate is using retry")
 		client = r.ProviderData.DataPlaneClient.WithRetry(bkof, regexps, nil, nil)
@@ -444,7 +444,7 @@ func (r *DataPlaneResource) CreateUpdate(ctx context.Context, plan tfsdk.Plan, s
 			backoff.WithMaxInterval(30*time.Second),
 			backoff.WithMaxElapsedTime(RetryGetAfterPut()),
 		),
-		nil,
+		model.Retry.GetErrorMessagesRegex(),
 		[]int{404},
 		[]func(d interface{}) bool{
 			func(d interface{}) bool {
@@ -505,7 +505,7 @@ func (r *DataPlaneResource) Read(ctx context.Context, request resource.ReadReque
 			model.Retry.GetMaxIntervalSeconds(),
 			model.Retry.GetMultiplier(),
 			model.Retry.GetRandomizationFactor(),
-			model.Retry.GetErrorMessageRegex(),
+			model.Retry.GetErrorMessages(),
 		)
 		tflog.Debug(ctx, "azapi_data_plane_resource.Read is using retry")
 		client = r.ProviderData.DataPlaneClient.WithRetry(bkof, regexps, nil, nil)
@@ -597,7 +597,7 @@ func (r *DataPlaneResource) Delete(ctx context.Context, request resource.DeleteR
 			model.Retry.GetMaxIntervalSeconds(),
 			model.Retry.GetMultiplier(),
 			model.Retry.GetRandomizationFactor(),
-			model.Retry.GetErrorMessageRegex(),
+			model.Retry.GetErrorMessages(),
 		)
 		tflog.Debug(ctx, "azapi_data_plane_resource.Delete is using retry")
 		client = r.ProviderData.DataPlaneClient.WithRetry(bkof, regexps, nil, nil)

--- a/internal/services/azapi_resource.go
+++ b/internal/services/azapi_resource.go
@@ -615,7 +615,7 @@ func (r *AzapiResource) CreateUpdate(ctx context.Context, requestPlan tfsdk.Plan
 			plan.Retry.GetMaxIntervalSeconds(),
 			plan.Retry.GetMultiplier(),
 			plan.Retry.GetRandomizationFactor(),
-			plan.Retry.GetErrorMessageRegex(),
+			plan.Retry.GetErrorMessages(),
 		)
 		tflog.Debug(ctx, "azapi_resource.CreateUpdate is using retry")
 		client = r.ProviderData.ResourceClient.WithRetry(bkof, regexps, nil, nil)
@@ -732,7 +732,7 @@ func (r *AzapiResource) CreateUpdate(ctx context.Context, requestPlan tfsdk.Plan
 			backoff.WithMaxInterval(30*time.Second),
 			backoff.WithMaxElapsedTime(RetryGetAfterPut()),
 		),
-		nil,
+		plan.Retry.GetErrorMessagesRegex(),
 		[]int{404},
 		[]func(d interface{}) bool{
 			func(d interface{}) bool {
@@ -813,7 +813,7 @@ func (r *AzapiResource) Read(ctx context.Context, request resource.ReadRequest, 
 			model.Retry.GetMaxIntervalSeconds(),
 			model.Retry.GetMultiplier(),
 			model.Retry.GetRandomizationFactor(),
-			model.Retry.GetErrorMessageRegex(),
+			model.Retry.GetErrorMessages(),
 		)
 		tflog.Debug(ctx, "azapi_resource.Read is using retry")
 		client = r.ProviderData.ResourceClient.WithRetry(bkof, regexps, nil, nil)
@@ -953,7 +953,7 @@ func (r *AzapiResource) Delete(ctx context.Context, request resource.DeleteReque
 			model.Retry.GetMaxIntervalSeconds(),
 			model.Retry.GetMultiplier(),
 			model.Retry.GetRandomizationFactor(),
-			model.Retry.GetErrorMessageRegex(),
+			model.Retry.GetErrorMessages(),
 		)
 		tflog.Debug(ctx, "azapi_resource.Delete is using retry")
 		client = r.ProviderData.ResourceClient.WithRetry(bkof, regexps, nil, nil)

--- a/internal/services/azapi_resource.go
+++ b/internal/services/azapi_resource.go
@@ -606,7 +606,7 @@ func (r *AzapiResource) CreateUpdate(ctx context.Context, requestPlan tfsdk.Plan
 		return
 	}
 
-	ctx = tflog.SetField(ctx, "id", types.StringValue(id.ID()))
+	ctx = tflog.SetField(ctx, "resource_id", id.String())
 	tflog.Info(ctx, "azapi_resource: CreateUpdate begin")
 	defer tflog.Info(ctx, "azapi_resource: CreateUpdate end")
 
@@ -621,9 +621,9 @@ func (r *AzapiResource) CreateUpdate(ctx context.Context, requestPlan tfsdk.Plan
 			plan.Retry.GetErrorMessageRegex(),
 		)
 		tflog.Debug(ctx, "azapi_resource.CreateUpdate using retry for create/update", map[string]interface{}{
-			"backoff_interval":         bkof.InitialInterval,
-			"backoff_max_interval":     bkof.MaxInterval,
-			"backoff_max_elapsed_time": bkof.MaxElapsedTime,
+			"backoff_interval":         bkof.InitialInterval.String(),
+			"backoff_max_interval":     bkof.MaxInterval.String(),
+			"backoff_max_elapsed_time": bkof.MaxElapsedTime.String(),
 			"backoff_multiplier":       bkof.Multiplier,
 			"retryable_errors":         plan.Retry.GetErrorMessageRegex(),
 		})

--- a/internal/services/azapi_resource_action_data_source.go
+++ b/internal/services/azapi_resource_action_data_source.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 type ResourceActionDataSourceModel struct {
@@ -155,6 +156,8 @@ func (r *ResourceActionDataSource) Read(ctx context.Context, request datasource.
 		return
 	}
 
+	ctx = tflog.SetField(ctx, "resource_id", id.ID())
+
 	var requestBody interface{}
 	if err := unmarshalBody(model.Body, &requestBody); err != nil {
 		response.Diagnostics.AddError("Invalid body", fmt.Sprintf(`The argument "body" is invalid: %s`, err.Error()))
@@ -176,6 +179,7 @@ func (r *ResourceActionDataSource) Read(ctx context.Context, request datasource.
 			model.Retry.GetRandomizationFactor(),
 			model.Retry.GetErrorMessageRegex(),
 		)
+		tflog.Debug(ctx, "data.azapi_resource_action.Read is using retry")
 		client = r.ProviderData.ResourceClient.WithRetry(bkof, regexps, nil, nil)
 	}
 

--- a/internal/services/azapi_resource_action_data_source.go
+++ b/internal/services/azapi_resource_action_data_source.go
@@ -177,7 +177,7 @@ func (r *ResourceActionDataSource) Read(ctx context.Context, request datasource.
 			model.Retry.GetMaxIntervalSeconds(),
 			model.Retry.GetMultiplier(),
 			model.Retry.GetRandomizationFactor(),
-			model.Retry.GetErrorMessageRegex(),
+			model.Retry.GetErrorMessages(),
 		)
 		tflog.Debug(ctx, "data.azapi_resource_action.Read is using retry")
 		client = r.ProviderData.ResourceClient.WithRetry(bkof, regexps, nil, nil)

--- a/internal/services/azapi_resource_action_resource.go
+++ b/internal/services/azapi_resource_action_resource.go
@@ -28,6 +28,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 type ActionResourceModel struct {
@@ -310,6 +311,8 @@ func (r *ActionResource) Action(ctx context.Context, model ActionResourceModel, 
 		return
 	}
 
+	ctx = tflog.SetField(ctx, "resource_id", id.ID())
+
 	var requestBody interface{}
 	if err := unmarshalBody(model.Body, &requestBody); err != nil {
 		diagnostics.AddError("Invalid body", fmt.Sprintf(`The argument "body" is invalid: %s`, err.Error()))
@@ -333,6 +336,7 @@ func (r *ActionResource) Action(ctx context.Context, model ActionResourceModel, 
 			model.Retry.GetRandomizationFactor(),
 			model.Retry.GetErrorMessageRegex(),
 		)
+		tflog.Debug(ctx, "azapi_resource_action.Read is using retry")
 		client = r.ProviderData.ResourceClient.WithRetry(bkof, regexps, nil, nil)
 	}
 

--- a/internal/services/azapi_resource_action_resource.go
+++ b/internal/services/azapi_resource_action_resource.go
@@ -334,7 +334,7 @@ func (r *ActionResource) Action(ctx context.Context, model ActionResourceModel, 
 			model.Retry.GetMaxIntervalSeconds(),
 			model.Retry.GetMultiplier(),
 			model.Retry.GetRandomizationFactor(),
-			model.Retry.GetErrorMessageRegex(),
+			model.Retry.GetErrorMessages(),
 		)
 		tflog.Debug(ctx, "azapi_resource_action.Read is using retry")
 		client = r.ProviderData.ResourceClient.WithRetry(bkof, regexps, nil, nil)

--- a/internal/services/azapi_resource_data_source.go
+++ b/internal/services/azapi_resource_data_source.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 type AzapiResourceDataSourceModel struct {
@@ -220,6 +221,8 @@ func (r *AzapiResourceDataSource) Read(ctx context.Context, request datasource.R
 		id = buildId
 	}
 
+	ctx = tflog.SetField(ctx, "resource_id", id.ID())
+
 	var client clients.Requester
 	client = r.ProviderData.ResourceClient
 	if !model.Retry.IsNull() && !model.Retry.IsUnknown() {
@@ -230,6 +233,7 @@ func (r *AzapiResourceDataSource) Read(ctx context.Context, request datasource.R
 			model.Retry.GetRandomizationFactor(),
 			model.Retry.GetErrorMessageRegex(),
 		)
+		tflog.Debug(ctx, "data.azapi_resource.Read is using retry")
 		client = r.ProviderData.ResourceClient.WithRetry(bkof, regexps, nil, nil)
 	}
 	responseBody, err := client.Get(ctx, id.AzureResourceId, id.ApiVersion, clients.NewRequestOptions(model.Headers, model.QueryParameters))

--- a/internal/services/azapi_resource_data_source.go
+++ b/internal/services/azapi_resource_data_source.go
@@ -231,7 +231,7 @@ func (r *AzapiResourceDataSource) Read(ctx context.Context, request datasource.R
 			model.Retry.GetMaxIntervalSeconds(),
 			model.Retry.GetMultiplier(),
 			model.Retry.GetRandomizationFactor(),
-			model.Retry.GetErrorMessageRegex(),
+			model.Retry.GetErrorMessages(),
 		)
 		tflog.Debug(ctx, "data.azapi_resource.Read is using retry")
 		client = r.ProviderData.ResourceClient.WithRetry(bkof, regexps, nil, nil)

--- a/internal/services/azapi_resource_list_data_source.go
+++ b/internal/services/azapi_resource_list_data_source.go
@@ -143,7 +143,7 @@ func (r *ResourceListDataSource) Read(ctx context.Context, request datasource.Re
 			model.Retry.GetMaxIntervalSeconds(),
 			model.Retry.GetMultiplier(),
 			model.Retry.GetRandomizationFactor(),
-			model.Retry.GetErrorMessageRegex(),
+			model.Retry.GetErrorMessages(),
 		)
 		tflog.Debug(ctx, "data.azapi_resource_list.Read is using retry")
 		client = r.ProviderData.ResourceClient.WithRetry(bkof, regexps, nil, nil)

--- a/internal/services/azapi_resource_list_data_source.go
+++ b/internal/services/azapi_resource_list_data_source.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 type ResourceListDataSourceModel struct {
@@ -130,6 +131,8 @@ func (r *ResourceListDataSource) Read(ctx context.Context, request datasource.Re
 		return
 	}
 
+	ctx = tflog.SetField(ctx, "resource_id", id.ID())
+
 	listUrl := strings.TrimSuffix(id.AzureResourceId, "/")
 
 	var client clients.Requester
@@ -142,6 +145,7 @@ func (r *ResourceListDataSource) Read(ctx context.Context, request datasource.Re
 			model.Retry.GetRandomizationFactor(),
 			model.Retry.GetErrorMessageRegex(),
 		)
+		tflog.Debug(ctx, "data.azapi_resource_list.Read is using retry")
 		client = r.ProviderData.ResourceClient.WithRetry(bkof, regexps, nil, nil)
 	}
 

--- a/internal/services/azapi_update_resource.go
+++ b/internal/services/azapi_update_resource.go
@@ -358,7 +358,7 @@ func (r *AzapiUpdateResource) CreateUpdate(ctx context.Context, plan tfsdk.Plan,
 			model.Retry.GetMaxIntervalSeconds(),
 			model.Retry.GetMultiplier(),
 			model.Retry.GetRandomizationFactor(),
-			model.Retry.GetErrorMessageRegex(),
+			model.Retry.GetErrorMessages(),
 		)
 		client = r.ProviderData.ResourceClient.WithRetry(bkof, regexps, nil, nil)
 	}
@@ -458,7 +458,7 @@ func (r *AzapiUpdateResource) Read(ctx context.Context, request resource.ReadReq
 			model.Retry.GetMaxIntervalSeconds(),
 			model.Retry.GetMultiplier(),
 			model.Retry.GetRandomizationFactor(),
-			model.Retry.GetErrorMessageRegex(),
+			model.Retry.GetErrorMessages(),
 		)
 		client = r.ProviderData.ResourceClient.WithRetry(bkof, regexps, nil, nil)
 	}

--- a/internal/services/azapi_update_resource.go
+++ b/internal/services/azapi_update_resource.go
@@ -348,6 +348,8 @@ func (r *AzapiUpdateResource) CreateUpdate(ctx context.Context, plan tfsdk.Plan,
 		id = buildId
 	}
 
+	ctx = tflog.SetField(ctx, "resource_id", id.ID())
+
 	var client clients.Requester
 	client = r.ProviderData.ResourceClient
 	if !model.Retry.IsNull() && !model.Retry.IsUnknown() {
@@ -445,6 +447,8 @@ func (r *AzapiUpdateResource) Read(ctx context.Context, request resource.ReadReq
 		response.Diagnostics.AddError("Invalid resource id", err.Error())
 		return
 	}
+
+	ctx = tflog.SetField(ctx, "resource_id", id.ID())
 
 	var client clients.Requester
 	client = r.ProviderData.ResourceClient

--- a/internal/services/common.go
+++ b/internal/services/common.go
@@ -14,7 +14,7 @@ import (
 func Retry404MaxElapsedTime() time.Duration {
 	if v := os.Getenv("AZAPI_RETRY_404_MAX_ELAPSED_TIME"); v != "" {
 		timeout, err := time.ParseDuration(v)
-		if err != nil {
+		if err == nil {
 			return timeout
 		}
 	}

--- a/internal/services/common.go
+++ b/internal/services/common.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-func Retry404MaxElapsedTime() time.Duration {
-	if v := os.Getenv("AZAPI_RETRY_404_MAX_ELAPSED_TIME"); v != "" {
+func RetryGetAfterPut() time.Duration {
+	if v := os.Getenv("AZAPI_RETRY_GET_AFTER_PUT_MAX_TIME"); v != "" {
 		timeout, err := time.ParseDuration(v)
 		if err == nil {
 			return timeout


### PR DESCRIPTION
As per internal thread:

- Improved 403 handling for MG resources to include child resources
- Fix bug in get after put retry timeout so the environment variable works properly
- Added debug output to retry

I could also pass the regex to the get after put retry, but since the body is nil then the retry func catches the issue where we get a 403. WDYT @ms-henglu 