### PR TITLE
clarify client certificate authentication limitation

### DIFF
--- a/docs/guides/service_principal_client_certificate.md
+++ b/docs/guides/service_principal_client_certificate.md
@@ -33,8 +33,10 @@ $ openssl x509 -signkey "service-principal.key" -in "service-principal.csr" -req
 Finally we can generate a PFX file which can be used to authenticate with Azure:
 
 ```shell
-$ openssl pkcs12 -export -out "service-principal.pfx" -inkey "service-principal.key" -in "service-principal.crt"
+$ openssl pkcs12 -certpbe PBE-SHA1-3DES -keypbe PBE-SHA1-3DES -export -macalg sha1 -out "service-principal.pfx" -inkey "service-principal.key" -in "service-principal.crt"
 ```
+
+~> **NOTE:** The certificate support in AzAPI provider has limitations, for example it can't decrypt keys in PEM format or PKCS#12 certificates that use SHA256 for message authentication. If you encounter such limitations, please generate the PFX file with above command.
 
 Now that we've generated a certificate, we can create the Azure Active Directory Application.
 

--- a/templates/guides/service_principal_client_certificate.md
+++ b/templates/guides/service_principal_client_certificate.md
@@ -33,8 +33,10 @@ $ openssl x509 -signkey "service-principal.key" -in "service-principal.csr" -req
 Finally we can generate a PFX file which can be used to authenticate with Azure:
 
 ```shell
-$ openssl pkcs12 -export -out "service-principal.pfx" -inkey "service-principal.key" -in "service-principal.crt"
+$ openssl pkcs12 -certpbe PBE-SHA1-3DES -keypbe PBE-SHA1-3DES -export -macalg sha1 -out "service-principal.pfx" -inkey "service-principal.key" -in "service-principal.crt"
 ```
+
+~> **NOTE:** The certificate support in AzAPI provider has limitations, for example it can't decrypt keys in PEM format or PKCS#12 certificates that use SHA256 for message authentication. If you encounter such limitations, please generate the PFX file with above command.
 
 Now that we've generated a certificate, we can create the Azure Active Directory Application.
 


### PR DESCRIPTION
fixes https://github.com/Azure/terraform-provider-azapi/issues/609

The parse certificate function provided by azure track 2 SDK has limitations, this PR adds them in the docs.

refs: https://github.com/Azure/azure-sdk-for-go/issues/22906#issuecomment-2121458876