### PR TITLE
improve validation for azapi_resource data source

### DIFF
--- a/docs/data-sources/resource.md
+++ b/docs/data-sources/resource.md
@@ -68,7 +68,7 @@ output "quarantine_policy" {
 ### Optional
 
 - `headers` (Map of String) A map of headers to include in the request
-- `name` (String) Specifies the name of the Azure resource.
+- `name` (String) Specifies the name of the Azure resource. Exactly one of the arguments `name` or `resource_id` must be set. It could be omitted if the `type` is `Microsoft.Resources/subscriptions`.
 - `parent_id` (String) The ID of the azure resource in which this resource is created. It supports different kinds of deployment scope for **top level** resources:
 
   - resource group scope: `parent_id` should be the ID of a resource group, it's recommended to manage a resource group by azurerm_resource_group.
@@ -81,7 +81,7 @@ output "quarantine_policy" {
 
   For type `Microsoft.Resources/resourceGroups`, the `parent_id` could be omitted, it defaults to subscription ID specified in provider or the default subscription (You could check the default subscription by azure cli command: `az account show`).
 - `query_parameters` (Map of List of String) A map of query parameters to include in the request
-- `resource_id` (String) The ID of the Azure resource to retrieve.
+- `resource_id` (String) The ID of the Azure resource to retrieve. Exactly one of the arguments `name` or `resource_id` must be set. It could be omitted if the `type` is `Microsoft.Resources/subscriptions`.
 - `response_export_values` (Dynamic) The attribute can accept either a list or a map.
 
 - **List**: A list of paths that need to be exported from the response body. Setting it to `["*"]` will export the full response body. Here's an example. If it sets to `["properties.loginServer", "properties.policies.quarantinePolicy.status"]`, it will set the following HCL object to the computed property output.


### PR DESCRIPTION
Tests:

```
data "azapi_resource" "rg" {
  type = "Microsoft.Resources/resourceGroups@2024-03-01"
  name = "myRG"
}

data "azapi_resource" "subscription" {
  type = "Microsoft.Resources/subscriptions@2024-03-01"
}

data "azapi_resource" "vnet" {
  type      = "Microsoft.Network/virtualNetworks@2024-03-01"
  name      = "myVnet"
  parent_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myRG"
}

data "azapi_resource" "vnet2" {
  type        = "Microsoft.Network/virtualNetworks@2024-03-01"
  resource_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myRG/providers/Microsoft.Network/virtualNetworks/myVnet"
}


# Success! The configuration is valid, but there were some validation warnings as shown above.

```