### PR TITLE
fix: priroitise azure pipelines creds

### DIFF
--- a/.github/workflows/acc-test.yaml
+++ b/.github/workflows/acc-test.yaml
@@ -15,6 +15,11 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: '1.21'
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: latest
+          terraform_wrapper: false
       - run: chmod -R +x ./scripts
       - run: bash scripts/gogetcookie.sh
       - run: make acctests

--- a/.github/workflows/tflint.yaml
+++ b/.github/workflows/tflint.yaml
@@ -18,6 +18,11 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: '1.21'
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: latest
+          terraform_wrapper: false
       - run: chmod -R +x ./scripts
       - run: bash scripts/gogetcookie.sh
       - run: make tools

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -36,6 +36,11 @@ jobs:
       fail-fast: true
     steps:
       - uses: actions/checkout@v2
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: latest
+          terraform_wrapper: false
       - uses: actions/setup-go@v2
         with:
           go-version: '1.21'

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -21,6 +21,11 @@ jobs:
         with:
           go-version-file: 'go.mod'
           cache: true
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: latest
+          terraform_wrapper: false
       - run: go generate ./...
       - name: git diff
         run: |
@@ -36,14 +41,14 @@ jobs:
       fail-fast: true
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.21'
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: latest
           terraform_wrapper: false
-      - uses: actions/setup-go@v2
-        with:
-          go-version: '1.21'
       - run: chmod -R +x ./scripts
       - run: bash scripts/gogetcookie.sh
       - run: make test

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -775,18 +775,18 @@ func buildChainedTokenCredential(model providerData, options azidentity.DefaultA
 	var creds []azcore.TokenCredential
 
 	if model.UseOIDC.ValueBool() || model.UseAKSWorkloadIdentity.ValueBool() {
-		log.Printf("[DEBUG] oidc credential or AKS Workload Identity enabled")
-		if cred, err := buildOidcCredential(model, options); err == nil {
-			creds = append(creds, cred)
-		} else {
-			log.Printf("[DEBUG] failed to initialize oidc credential: %v", err)
-		}
-
 		log.Printf("[DEBUG] azure pipelines credential enabled")
 		if cred, err := buildAzurePipelinesCredential(model, options); err == nil {
 			creds = append(creds, cred)
 		} else {
 			log.Printf("[DEBUG] failed to initialize azure pipelines credential: %v", err)
+		}
+		
+		log.Printf("[DEBUG] oidc credential or AKS Workload Identity enabled")
+		if cred, err := buildOidcCredential(model, options); err == nil {
+			creds = append(creds, cred)
+		} else {
+			log.Printf("[DEBUG] failed to initialize oidc credential: %v", err)
 		}
 	}
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -781,7 +781,7 @@ func buildChainedTokenCredential(model providerData, options azidentity.DefaultA
 		} else {
 			log.Printf("[DEBUG] failed to initialize azure pipelines credential: %v", err)
 		}
-		
+
 		log.Printf("[DEBUG] oidc credential or AKS Workload Identity enabled")
 		if cred, err := buildOidcCredential(model, options); err == nil {
 			creds = append(creds, cred)


### PR DESCRIPTION
This PR is to re-order the creds, so that settings for Azure Pipelines OIDC auth are prioritised over static token creds.

For example with these pipeline settings, it will prioritise azure pipeline auth over the `ARM_OIDC_TOKEN`:

```hcl
steps:
  - task: AzureCLI@2
    displayName: Terraform Plan
    inputs:
      azureSubscription: "My-Service-Conbnection"
      scriptType: pscore
      scriptLocation: inlineScript
      addSpnToEnvironment: true
      inlineScript: |
        # Get settings from service connection
        az account show 2>$null | ConvertFrom-Json | Set-Variable account
        $clientId = $account.user.name
        $oidcToken = $env:idToken
        $subscriptionId = $account.id
        $tenantId = $account.tenantId

        $env:ARM_TENANT_ID = $account.tenantId
        $env:ARM_SUBSCRIPTION_ID = $account.id
       
        $env:ARM_USE_OIDC = "true"
        $env:ARM_CLIENT_ID = $clientId
        $env:ARM_USE_AZUREAD = "true"

        # Prioritise for `azapi` provider
        $env:ARM_OIDC_AZURE_SERVICE_CONNECTION_ID = "My-Service-Conbnection"
        $env:ARM_OIDC_REQUEST_TOKEN ="$(System.AccessToken)"

        # Fallback for `azurerm` and `azuread` providers
        $env:ARM_OIDC_TOKEN = $oidcToken

        # Run Terraform Plan
        $command = "terraform"
        $arguments = @()
        $arguments += "plan"
        $arguments += "-out=tfplan"
        $arguments += "-input=false"

        Write-Host "Running: $command $arguments"
        & $command $arguments

```