### PR TITLE
bugfix: remove volatile fields from the default output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ FEATURES:
 
 BUG FIXES:
 - Fix a bug that query parameters and headers don't work properly with unknown values
+- Fix more edge cases that the provider produced inconsistent result after apply when default output feature is enabled.
 
 ## v2.2.0
 

--- a/internal/services/common.go
+++ b/internal/services/common.go
@@ -76,5 +76,8 @@ func volatileFieldList() []string {
 		"lastModifiedAt",
 		"lastModifiedBy",
 		"lastModifiedByType",
+		"freeTrialRemainingTime",
+		"trialDaysRemaining",
+		"daysTrialRemaining",
 	}
 }


### PR DESCRIPTION
fixes https://github.com/Azure/terraform-provider-azapi/issues/724