### PR TITLE
fix(retry): add WithMaxElapsedTime to retry options and refactor to use functional options

### DIFF
--- a/internal/clients/data_plane_client_test.go
+++ b/internal/clients/data_plane_client_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/Azure/terraform-provider-azapi/internal/clients"
 	"github.com/Azure/terraform-provider-azapi/internal/services/parse"
+	"github.com/cenkalti/backoff/v4"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -27,9 +28,16 @@ import (
 //
 // We check these timings are expected using the assert.InDeltaSlice function.
 func TestRetryDataPlaneClient(t *testing.T) {
+	t.Parallel()
 	mock := NewMockDataPlaneClient(t, nil, nil, 3, errors.New("retry error"))
-	bkof, errRegExps := clients.NewRetryableErrors(1, 30, 2, 0.0, []string{"retry error"})
-	retryClient := clients.NewDataPlaneClientRetryableErrors(mock, bkof, errRegExps, nil, nil)
+	bkof := backoff.NewExponentialBackOff(
+		backoff.WithInitialInterval(1*time.Second),
+		backoff.WithMaxInterval(30*time.Second),
+		backoff.WithMultiplier(2),
+		backoff.WithRandomizationFactor(0.0),
+	)
+	rexs := clients.StringSliceToRegexpSliceMust([]string{"retry error"})
+	retryClient := clients.NewDataPlaneClientRetryableErrors(mock, bkof, rexs, nil, nil)
 	_, err := retryClient.Get(context.Background(), parse.DataPlaneResourceId{}, clients.DefaultRequestOptions())
 	assert.NoError(t, err)
 	assert.Equal(t, 3, mock.requestCount)
@@ -47,36 +55,64 @@ func TestRetryDataPlaneClient(t *testing.T) {
 }
 
 func TestRetryDataPlaneClientRegexp(t *testing.T) {
+	t.Parallel()
 	mock := NewMockDataPlaneClient(t, nil, nil, 3, errors.New("retry error"))
-	bkof, errRegExps := clients.NewRetryableErrors(1, 5, 1.5, 0.0, []string{"^retry"})
-	retryClient := clients.NewDataPlaneClientRetryableErrors(mock, bkof, errRegExps, nil, nil)
+	bkof := backoff.NewExponentialBackOff(
+		backoff.WithInitialInterval(1*time.Second),
+		backoff.WithMaxInterval(5*time.Second),
+		backoff.WithMultiplier(1.5),
+		backoff.WithRandomizationFactor(0.0),
+	)
+	rexs := clients.StringSliceToRegexpSliceMust([]string{"^retry"})
+	retryClient := clients.NewDataPlaneClientRetryableErrors(mock, bkof, rexs, nil, nil)
 	_, err := retryClient.Get(context.Background(), parse.DataPlaneResourceId{}, clients.DefaultRequestOptions())
 	assert.NoError(t, err)
 	assert.Equal(t, 3, mock.RequestCount())
 }
 
 func TestRetryDataPlaneClientMultiRegexp(t *testing.T) {
+	t.Parallel()
 	mock := NewMockDataPlaneClient(t, nil, nil, 3, errors.New("retry error"))
-	bkof, errRegExps := clients.NewRetryableErrors(1, 5, 1.5, 0.0, []string{"nomatch", "^retry"})
-	retryClient := clients.NewDataPlaneClientRetryableErrors(mock, bkof, errRegExps, nil, nil)
+	bkof := backoff.NewExponentialBackOff(
+		backoff.WithInitialInterval(1*time.Second),
+		backoff.WithMaxInterval(5*time.Second),
+		backoff.WithMultiplier(1.5),
+		backoff.WithRandomizationFactor(0.0),
+	)
+	rexs := clients.StringSliceToRegexpSliceMust([]string{"nomatch", "^retry"})
+	retryClient := clients.NewDataPlaneClientRetryableErrors(mock, bkof, rexs, nil, nil)
 	_, err := retryClient.Get(context.Background(), parse.DataPlaneResourceId{}, clients.DefaultRequestOptions())
 	assert.NoError(t, err)
 	assert.Equal(t, 3, mock.RequestCount())
 }
 
 func TestRetryDataPlaneClientMultiRegexpNoMatchWithPermError(t *testing.T) {
+	t.Parallel()
 	mock := NewMockDataPlaneClient(t, nil, errors.New("perm error"), 3, errors.New("retry error"))
-	bkof, errRegExps := clients.NewRetryableErrors(1, 5, 1.5, 0.0, []string{"retry"})
-	retryClient := clients.NewDataPlaneClientRetryableErrors(mock, bkof, errRegExps, nil, nil)
+	bkof := backoff.NewExponentialBackOff(
+		backoff.WithInitialInterval(1*time.Second),
+		backoff.WithMaxInterval(5*time.Second),
+		backoff.WithMultiplier(1.5),
+		backoff.WithRandomizationFactor(0.0),
+	)
+	rexs := clients.StringSliceToRegexpSliceMust([]string{"retry"})
+	retryClient := clients.NewDataPlaneClientRetryableErrors(mock, bkof, rexs, nil, nil)
 	_, err := retryClient.Get(context.Background(), parse.DataPlaneResourceId{}, clients.DefaultRequestOptions())
 	assert.ErrorContains(t, err, "perm error")
 	assert.Equal(t, 3, mock.RequestCount())
 }
 
 func TestRetryDataPlaneClientContextDeadline(t *testing.T) {
+	t.Parallel()
 	mock := NewMockDataPlaneClient(t, nil, nil, 3, errors.New("retry error"))
-	bkof, errRegExps := clients.NewRetryableErrors(60, 60, 1.5, 0.0, []string{"^retry"})
-	retryClient := clients.NewDataPlaneClientRetryableErrors(mock, bkof, errRegExps, nil, nil)
+	bkof := backoff.NewExponentialBackOff(
+		backoff.WithInitialInterval(60*time.Second),
+		backoff.WithMaxInterval(60*time.Second),
+		backoff.WithMultiplier(1.5),
+		backoff.WithRandomizationFactor(0.0),
+	)
+	rexs := clients.StringSliceToRegexpSliceMust([]string{"^retry"})
+	retryClient := clients.NewDataPlaneClientRetryableErrors(mock, bkof, rexs, nil, nil)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	start := time.Now()

--- a/internal/clients/resource_client.go
+++ b/internal/clients/resource_client.go
@@ -84,22 +84,6 @@ func NewResourceClient(credential azcore.TokenCredential, opt *arm.ClientOptions
 	}, nil
 }
 
-// // NewRetryableErrors creates the backoff and error regexs for retryable errors.
-// func NewRetryableErrors(intervalSeconds, maxIntervalSeconds int, multiplier, randomizationFactor float64, errorRegexs []string) (*backoff.ExponentialBackOff, []regexp.Regexp) {
-// 	bkof := backoff.NewExponentialBackOff(
-// 		backoff.WithInitialInterval(time.Duration(intervalSeconds)*time.Second),
-// 		backoff.WithRandomizationFactor(randomizationFactor),
-// 		backoff.WithMaxInterval(time.Duration(maxIntervalSeconds)*time.Second),
-// 		backoff.WithRandomizationFactor(randomizationFactor),
-// 		backoff.WithMultiplier(multiplier),
-// 	)
-// 	res := make([]regexp.Regexp, len(errorRegexs))
-// 	for i, e := range errorRegexs {
-// 		res[i] = *regexp.MustCompile(e) // MustCompile as schema has custom validation so we know it's valid
-// 	}
-// 	return bkof, res
-// }
-
 // StringSliceToRegexpSliceMust converts a slice of strings to a slice of regexps.
 // It panics if any of the strings are invalid regexps.
 func StringSliceToRegexpSliceMust(ss []string) []regexp.Regexp {

--- a/internal/clients/resource_client.go
+++ b/internal/clients/resource_client.go
@@ -84,20 +84,30 @@ func NewResourceClient(credential azcore.TokenCredential, opt *arm.ClientOptions
 	}, nil
 }
 
-// NewRetryableErrors creates the backoff and error regexs for retryable errors.
-func NewRetryableErrors(intervalSeconds, maxIntervalSeconds int, multiplier, randomizationFactor float64, errorRegexs []string) (*backoff.ExponentialBackOff, []regexp.Regexp) {
-	bkof := backoff.NewExponentialBackOff(
-		backoff.WithInitialInterval(time.Duration(intervalSeconds)*time.Second),
-		backoff.WithRandomizationFactor(randomizationFactor),
-		backoff.WithMaxInterval(time.Duration(maxIntervalSeconds)*time.Second),
-		backoff.WithRandomizationFactor(randomizationFactor),
-		backoff.WithMultiplier(multiplier),
-	)
-	res := make([]regexp.Regexp, len(errorRegexs))
-	for i, e := range errorRegexs {
-		res[i] = *regexp.MustCompile(e) // MustCompile as schema has custom validation so we know it's valid
+// // NewRetryableErrors creates the backoff and error regexs for retryable errors.
+// func NewRetryableErrors(intervalSeconds, maxIntervalSeconds int, multiplier, randomizationFactor float64, errorRegexs []string) (*backoff.ExponentialBackOff, []regexp.Regexp) {
+// 	bkof := backoff.NewExponentialBackOff(
+// 		backoff.WithInitialInterval(time.Duration(intervalSeconds)*time.Second),
+// 		backoff.WithRandomizationFactor(randomizationFactor),
+// 		backoff.WithMaxInterval(time.Duration(maxIntervalSeconds)*time.Second),
+// 		backoff.WithRandomizationFactor(randomizationFactor),
+// 		backoff.WithMultiplier(multiplier),
+// 	)
+// 	res := make([]regexp.Regexp, len(errorRegexs))
+// 	for i, e := range errorRegexs {
+// 		res[i] = *regexp.MustCompile(e) // MustCompile as schema has custom validation so we know it's valid
+// 	}
+// 	return bkof, res
+// }
+
+// StringSliceToRegexpSliceMust converts a slice of strings to a slice of regexps.
+// It panics if any of the strings are invalid regexps.
+func StringSliceToRegexpSliceMust(ss []string) []regexp.Regexp {
+	res := make([]regexp.Regexp, len(ss))
+	for i, e := range ss {
+		res[i] = *regexp.MustCompile(e)
 	}
-	return bkof, res
+	return res
 }
 
 // WithRetry configures the retryable errors for the client.

--- a/internal/retry/retryable_errors.go
+++ b/internal/retry/retryable_errors.go
@@ -6,6 +6,7 @@ import (
 	"math/big"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -606,8 +607,16 @@ func (v RetryValue) GetIntervalSeconds() int {
 	return v.getInt64AttrValue(intervalSecondsAttributeName)
 }
 
+func (v RetryValue) GetIntervalSecondsAsDuration() time.Duration {
+	return time.Duration(v.IntervalSeconds.ValueInt64()) * time.Second
+}
+
 func (v RetryValue) GetMaxIntervalSeconds() int {
 	return v.getInt64AttrValue(maxIntervalSecondsAttributeName)
+}
+
+func (v RetryValue) GetMaxIntervalSecondsAsDuration() time.Duration {
+	return time.Duration(v.MaxIntervalSeconds.ValueInt64()) * time.Second
 }
 
 func (v RetryValue) GetMultiplier() float64 {

--- a/internal/services/azapi_resource_action_data_source.go
+++ b/internal/services/azapi_resource_action_data_source.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/terraform-provider-azapi/internal/retry"
 	"github.com/Azure/terraform-provider-azapi/internal/services/myvalidator"
 	"github.com/Azure/terraform-provider-azapi/internal/services/parse"
+	"github.com/cenkalti/backoff/v4"
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -185,12 +186,13 @@ func (r *ResourceActionDataSource) Read(ctx context.Context, request datasource.
 	var client clients.Requester
 	client = r.ProviderData.ResourceClient
 	if !model.Retry.IsNull() && !model.Retry.IsUnknown() {
-		bkof, regexps := clients.NewRetryableErrors(
-			model.Retry.GetIntervalSeconds(),
-			model.Retry.GetMaxIntervalSeconds(),
-			model.Retry.GetMultiplier(),
-			model.Retry.GetRandomizationFactor(),
-			model.Retry.GetErrorMessages(),
+		regexps := clients.StringSliceToRegexpSliceMust(model.Retry.GetErrorMessages())
+		bkof := backoff.NewExponentialBackOff(
+			backoff.WithInitialInterval(model.Retry.GetIntervalSecondsAsDuration()),
+			backoff.WithMaxInterval(model.Retry.GetMaxIntervalSecondsAsDuration()),
+			backoff.WithMultiplier(model.Retry.GetMultiplier()),
+			backoff.WithRandomizationFactor(model.Retry.GetRandomizationFactor()),
+			backoff.WithMaxElapsedTime(readTimeout),
 		)
 		tflog.Debug(ctx, "data.azapi_resource_action.Read is using retry")
 		client = r.ProviderData.ResourceClient.WithRetry(bkof, regexps, nil, nil)

--- a/internal/services/azapi_resource_action_ephemeral.go
+++ b/internal/services/azapi_resource_action_ephemeral.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/terraform-provider-azapi/internal/retry"
 	"github.com/Azure/terraform-provider-azapi/internal/services/myvalidator"
 	"github.com/Azure/terraform-provider-azapi/internal/services/parse"
+	"github.com/cenkalti/backoff/v4"
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -191,12 +192,13 @@ func (r *ActionEphemeral) Open(ctx context.Context, request ephemeral.OpenReques
 	var client clients.Requester
 	client = r.ProviderData.ResourceClient
 	if !model.Retry.IsNull() && !model.Retry.IsUnknown() {
-		bkof, regexps := clients.NewRetryableErrors(
-			model.Retry.GetIntervalSeconds(),
-			model.Retry.GetMaxIntervalSeconds(),
-			model.Retry.GetMultiplier(),
-			model.Retry.GetRandomizationFactor(),
-			model.Retry.GetErrorMessages(),
+		regexps := clients.StringSliceToRegexpSliceMust(model.Retry.GetErrorMessages())
+		bkof := backoff.NewExponentialBackOff(
+			backoff.WithInitialInterval(model.Retry.GetIntervalSecondsAsDuration()),
+			backoff.WithMaxInterval(model.Retry.GetMaxIntervalSecondsAsDuration()),
+			backoff.WithMultiplier(model.Retry.GetMultiplier()),
+			backoff.WithRandomizationFactor(model.Retry.GetRandomizationFactor()),
+			backoff.WithMaxElapsedTime(readTimeout),
 		)
 		tflog.Debug(ctx, "azapi_resource_action.Read is using retry")
 		client = r.ProviderData.ResourceClient.WithRetry(bkof, regexps, nil, nil)

--- a/internal/services/azapi_resource_action_resource.go
+++ b/internal/services/azapi_resource_action_resource.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Azure/terraform-provider-azapi/internal/services/myplanmodifier"
 	"github.com/Azure/terraform-provider-azapi/internal/services/myvalidator"
 	"github.com/Azure/terraform-provider-azapi/internal/services/parse"
+	"github.com/cenkalti/backoff/v4"
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -354,12 +355,13 @@ func (r *ActionResource) Action(ctx context.Context, model ActionResourceModel, 
 	var client clients.Requester
 	client = r.ProviderData.ResourceClient
 	if !model.Retry.IsNull() && !model.Retry.IsUnknown() {
-		bkof, regexps := clients.NewRetryableErrors(
-			model.Retry.GetIntervalSeconds(),
-			model.Retry.GetMaxIntervalSeconds(),
-			model.Retry.GetMultiplier(),
-			model.Retry.GetRandomizationFactor(),
-			model.Retry.GetErrorMessages(),
+		regexps := clients.StringSliceToRegexpSliceMust(model.Retry.GetErrorMessages())
+		bkof := backoff.NewExponentialBackOff(
+			backoff.WithInitialInterval(model.Retry.GetIntervalSecondsAsDuration()),
+			backoff.WithMaxInterval(model.Retry.GetMaxIntervalSecondsAsDuration()),
+			backoff.WithMultiplier(model.Retry.GetMultiplier()),
+			backoff.WithRandomizationFactor(model.Retry.GetRandomizationFactor()),
+			backoff.WithMaxElapsedTime(actionTimeout),
 		)
 		tflog.Debug(ctx, "azapi_resource_action.Read is using retry")
 		client = r.ProviderData.ResourceClient.WithRetry(bkof, regexps, nil, nil)

--- a/internal/services/azapi_resource_list_data_source.go
+++ b/internal/services/azapi_resource_list_data_source.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/terraform-provider-azapi/internal/services/myvalidator"
 	"github.com/Azure/terraform-provider-azapi/internal/services/parse"
 	"github.com/Azure/terraform-provider-azapi/utils"
+	"github.com/cenkalti/backoff/v4"
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
@@ -139,12 +140,13 @@ func (r *ResourceListDataSource) Read(ctx context.Context, request datasource.Re
 	var client clients.Requester
 	client = r.ProviderData.ResourceClient
 	if !model.Retry.IsNull() && !model.Retry.IsUnknown() {
-		bkof, regexps := clients.NewRetryableErrors(
-			model.Retry.GetIntervalSeconds(),
-			model.Retry.GetMaxIntervalSeconds(),
-			model.Retry.GetMultiplier(),
-			model.Retry.GetRandomizationFactor(),
-			model.Retry.GetErrorMessages(),
+		regexps := clients.StringSliceToRegexpSliceMust(model.Retry.GetErrorMessages())
+		bkof := backoff.NewExponentialBackOff(
+			backoff.WithInitialInterval(model.Retry.GetMaxIntervalSecondsAsDuration()),
+			backoff.WithMaxInterval(model.Retry.GetMaxIntervalSecondsAsDuration()),
+			backoff.WithMultiplier(model.Retry.GetMultiplier()),
+			backoff.WithRandomizationFactor(model.Retry.GetRandomizationFactor()),
+			backoff.WithMaxElapsedTime(readTimeout),
 		)
 		tflog.Debug(ctx, "data.azapi_resource_list.Read is using retry")
 		client = r.ProviderData.ResourceClient.WithRetry(bkof, regexps, nil, nil)


### PR DESCRIPTION
@jaredfholgate discovered an issue with long resource operations and retry.

The package we use has a [default max elapsed time of 15m](https://github.com/cenkalti/backoff/blob/720b78985a65c0452fd37bb155c7cac4157a7c45/exponential.go#L83).

This causes an issue when the resource's `timeout` values were set to longer than 15m.

This PR adds the `backoff.WithMaxElapsedTime()` setting into the retry configuration. It sets this to the resource's timeout value. Since we use the context aware retry function in the backoff package this value just needs to be equal to or higher than the timeout value. Once the context deadline is exceeded then the retry package will exit anyway (we already have unit tests for this).

I have also refactored to remove the unnecessary `NewRetryableErrors()` function from the clients package. This was inflexible and using the functional options variadic pattern provided by the backoff package is much cleaner.

To support the conversion of `[]string` to `[]regexp` I have added a small function.

WDYT @ms-henglu ?