### PR TITLE
feat: ephemeral resource sensitive output

### DIFF
--- a/docs/ephemeral-resources/resource_action.md
+++ b/docs/ephemeral-resources/resource_action.md
@@ -99,6 +99,33 @@ ephemeral "azapi_resource_action" "listKeys" {
 
 To learn more about JMESPath, visit [JMESPath](https://jmespath.org/).
 - `retry` (Attributes) The retry block supports the following arguments: (see [below for nested schema](#nestedatt--retry))
+- `sensitive_response_export_values` (Dynamic) The attribute can accept either a list or a map.
+
+- **List**: A list of paths that need to be exported from the response body. Setting it to `["*"]` will export the full response body. Here's an example. If it sets to `["properties.loginServer", "properties.policies.quarantinePolicy.status"]`, it will set the following HCL object to the computed property output.
+
+	```text
+	{
+		properties = {
+			loginServer = "registry1.azurecr.io"
+			policies = {
+				quarantinePolicy = {
+					status = "disabled"
+				}
+			}
+		}
+	}
+	```
+
+- **Map**: A map where the key is the name for the result and the value is a JMESPath query string to filter the response. Here's an example. If it sets to `{"login_server": "properties.loginServer", "quarantine_status": "properties.policies.quarantinePolicy.status"}`, it will set the following HCL object to the computed property output.
+
+	```text
+	{
+		"login_server" = "registry1.azurecr.io"
+		"quarantine_status" = "disabled"
+	}
+	```
+
+To learn more about JMESPath, visit [JMESPath](https://jmespath.org/).
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only
@@ -115,6 +142,21 @@ To learn more about JMESPath, visit [JMESPath](https://jmespath.org/).
 	// it will output "disabled"
 	output "quarantine_policy" {
 		value = ephemeral.azapi_resource_action.example.output.properties.policies.quarantinePolicy.status
+	}
+	```
+- `sensitive_output` (Dynamic, Sensitive) The output HCL object containing the properties specified in `sensitive_response_export_values`. Here are some examples to use the values.
+
+	```terraform
+	// it will output "registry1.azurecr.io"
+	output "login_server" {
+		value     = ephemeral.azapi_resource_action.example.sensitive_output.properties.loginServer
+        sensitive = true
+	}
+
+	// it will output "disabled"
+	output "quarantine_policy" {
+		value     = ephemeral.azapi_resource_action.example.sensitive_output.properties.policies.quarantinePolicy.status
+        sensitive = true
 	}
 	```
 


### PR DESCRIPTION
Given that ephemeral resources are likely to be sensitive, do we need to add the sensitive outputs from `azapi_resource_action`?

WDYT @ms-henglu