### PR TITLE
bugfix: `azapi_update_resource` produced inconsistent results when only `error_message_regex` is changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v2.4.0 (unreleased)
+
+BUG FIXES:
+- Fix a bug that `azapi_update_resource` resource produced inconsistent results when only `error_message_regex` is changed.
+
+
 ## v2.3.0
 FEATURES:
 - **New Ephemeral Resource**: azapi_resource_action

--- a/internal/services/azapi_update_resource.go
+++ b/internal/services/azapi_update_resource.go
@@ -312,7 +312,7 @@ func (r *AzapiUpdateResource) Update(ctx context.Context, request resource.Updat
 	}
 	if skip.CanSkipExternalRequest(plan, state, "update") {
 		tflog.Debug(ctx, "azapi_resource.CreateUpdate skipping external request as no unskippable changes were detected")
-		response.Diagnostics.Append(request.State.Set(ctx, plan)...)
+		response.Diagnostics.Append(response.State.Set(ctx, plan)...)
 		return
 	}
 	tflog.Debug(ctx, "azapi_resource.CreateUpdate proceeding with external request as no skippable changes were detected")


### PR DESCRIPTION
…


fixes https://github.com/Azure/terraform-provider-azapi/issues/812