### PR TITLE
bugfix: `azapi_resource_action` migration failed if body is empty string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 BUG FIXES:
 - Fix a bug that `azapi_update_resource` resource produced inconsistent results when only `error_message_regex` is changed.
-
+- Fix a bug that `azapi_resource_action` resource could not be migrated correctly when the `body` is empty string.
 
 ## v2.3.0
 FEATURES:

--- a/internal/services/migration/azapi_resource_migration_v1_to_v2.go
+++ b/internal/services/migration/azapi_resource_migration_v1_to_v2.go
@@ -228,6 +228,9 @@ func migrateToDynamicValue(input types.Dynamic) (types.Dynamic, error) {
 	if !ok {
 		return input, nil
 	}
+	if stringVal.ValueString() == "" {
+		return types.DynamicNull(), nil
+	}
 	dynamicVal, err := dynamic.FromJSONImplied([]byte(stringVal.ValueString()))
 	if err != nil {
 		return input, err


### PR DESCRIPTION
fixes https://github.com/Azure/terraform-provider-azapi/issues/801