### PR TITLE
add example for qumulo storage

### DIFF
--- a/examples/Qumulo.Storage_fileSystems@2024-06-19/main.tf
+++ b/examples/Qumulo.Storage_fileSystems@2024-06-19/main.tf
@@ -21,8 +21,8 @@ variable "location" {
 }
 
 variable "qumulo_password" {
-  type    = string
-  default = ")^X#ZX#JRyIY}t9"
+  type      = string
+  default   = ")^X#ZX#JRyIY}t9"
   sensitive = true
 }
 
@@ -44,11 +44,16 @@ resource "azapi_resource" "vnet" {
         addressPrefixes = ["10.0.0.0/16"]
       }
       privateEndpointVNetPolicies = "Disabled"
+      subnets = []
     }
   }
 
   schema_validation_enabled = false
   response_export_values    = ["*"]
+  lifecycle {
+    # This is to avoid vnet change to overwrite the subnets
+    ignore_changes = [body.properties.subnets]
+  }
 }
 
 resource "azapi_resource" "subnet" {
@@ -101,8 +106,8 @@ resource "azapi_resource" "qumuloFileSystem" {
   }
 
   tags = {
-    environment       = "terraform-acctests"
-    some_key          = "some-value"
+    environment = "terraform-acctests"
+    some_key    = "some-value"
   }
 
   schema_validation_enabled = false

--- a/examples/Qumulo.Storage_fileSystems@2024-06-19/main.tf
+++ b/examples/Qumulo.Storage_fileSystems@2024-06-19/main.tf
@@ -11,27 +11,32 @@ provider "azapi" {
 }
 
 variable "resource_name" {
-  type = string
+  type    = string
   default = "acctest0001"
 }
 
-//variable "location" {
-//  type    = string
-//  default = "westeurope"
-//}
+variable "location" {
+  type    = string
+  default = "westeurope"
+}
 
-data "azapi_resource" "resourceGroup" {
-  type = "Microsoft.Resources/resourceGroups@2020-06-01"
-  // name = var.resource_name
-  name = "terraform-testing-qumulo"
-  //  location = var.location
+variable "qumulo_password" {
+  type    = string
+  default = ")^X#ZX#JRyIY}t9"
+  sensitive = true
+}
+
+resource "azapi_resource" "resourceGroup" {
+  type     = "Microsoft.Resources/resourceGroups@2020-06-01"
+  name     = var.resource_name
+  location = var.location
 }
 
 resource "azapi_resource" "vnet" {
   type      = "Microsoft.Network/virtualNetworks@2024-05-01"
   name      = var.resource_name
-  parent_id = data.azapi_resource.resourceGroup.id
-  location  = data.azapi_resource.resourceGroup.location
+  location  = var.location
+  parent_id = azapi_resource.resourceGroup.id
 
   body = {
     properties = {
@@ -49,8 +54,8 @@ resource "azapi_resource" "vnet" {
 resource "azapi_resource" "subnet" {
   type      = "Microsoft.Network/virtualNetworks/subnets@2024-05-01"
   name      = var.resource_name
+  location  = var.location
   parent_id = azapi_resource.vnet.id
-  location  = data.azapi_resource.resourceGroup.location
 
   body = {
     properties = {
@@ -75,12 +80,12 @@ resource "azapi_resource" "subnet" {
 resource "azapi_resource" "qumuloFileSystem" {
   type      = "Qumulo.Storage/fileSystems@2024-06-19"
   name      = var.resource_name
-  location  = data.azapi_resource.resourceGroup.location
-  parent_id = data.azapi_resource.resourceGroup.id
+  location  = var.location
+  parent_id = azapi_resource.resourceGroup.id
 
   body = {
     properties = {
-      adminPassword     = ")^X#ZX#JRyIY}t9"
+      adminPassword     = var.qumulo_password
       availabilityZone  = "1"
       delegatedSubnetId = azapi_resource.subnet.id
       marketplaceDetails = {
@@ -96,7 +101,6 @@ resource "azapi_resource" "qumuloFileSystem" {
   }
 
   tags = {
-    provisionResource = "55e031c5d497a3508838f44ec8767c84" // this is for test purpose to not to create real qumulo resource
     environment       = "terraform-acctests"
     some_key          = "some-value"
   }

--- a/examples/Qumulo.Storage_fileSystems@2024-06-19/main.tf
+++ b/examples/Qumulo.Storage_fileSystems@2024-06-19/main.tf
@@ -1,0 +1,106 @@
+terraform {
+  required_providers {
+    azapi = {
+      source = "Azure/azapi"
+    }
+  }
+}
+
+provider "azapi" {
+  skip_provider_registration = false
+}
+
+variable "resource_name" {
+  type = string
+  default = "acctest0001"
+}
+
+//variable "location" {
+//  type    = string
+//  default = "westeurope"
+//}
+
+data "azapi_resource" "resourceGroup" {
+  type = "Microsoft.Resources/resourceGroups@2020-06-01"
+  // name = var.resource_name
+  name = "terraform-testing-qumulo"
+  //  location = var.location
+}
+
+resource "azapi_resource" "vnet" {
+  type      = "Microsoft.Network/virtualNetworks@2024-05-01"
+  name      = var.resource_name
+  parent_id = data.azapi_resource.resourceGroup.id
+  location  = data.azapi_resource.resourceGroup.location
+
+  body = {
+    properties = {
+      addressSpace = {
+        addressPrefixes = ["10.0.0.0/16"]
+      }
+      privateEndpointVNetPolicies = "Disabled"
+    }
+  }
+
+  schema_validation_enabled = false
+  response_export_values    = ["*"]
+}
+
+resource "azapi_resource" "subnet" {
+  type      = "Microsoft.Network/virtualNetworks/subnets@2024-05-01"
+  name      = var.resource_name
+  parent_id = azapi_resource.vnet.id
+  location  = data.azapi_resource.resourceGroup.location
+
+  body = {
+    properties = {
+      addressPrefix         = "10.0.1.0/24"
+      defaultOutboundAccess = true
+      delegations = [{
+        name = "delegation"
+        properties = {
+          actions     = ["Microsoft.Network/virtualNetworks/subnets/join/action"]
+          serviceName = "Qumulo.Storage/fileSystems"
+        }
+      }]
+      privateEndpointNetworkPolicies    = "Disabled"
+      privateLinkServiceNetworkPolicies = "Enabled"
+    }
+  }
+
+  schema_validation_enabled = false
+  response_export_values    = ["*"]
+}
+
+resource "azapi_resource" "qumuloFileSystem" {
+  type      = "Qumulo.Storage/fileSystems@2024-06-19"
+  name      = var.resource_name
+  location  = data.azapi_resource.resourceGroup.location
+  parent_id = data.azapi_resource.resourceGroup.id
+
+  body = {
+    properties = {
+      adminPassword     = ")^X#ZX#JRyIY}t9"
+      availabilityZone  = "1"
+      delegatedSubnetId = azapi_resource.subnet.id
+      marketplaceDetails = {
+        offerId     = "qumulo-saas-mpp"
+        planId      = "azure-native-qumulo-v3"
+        publisherId = "qumulo1584033880660"
+      }
+      storageSku = "Cold_LRS"
+      userDetails = {
+        email = "test@test.com"
+      }
+    }
+  }
+
+  tags = {
+    provisionResource = "55e031c5d497a3508838f44ec8767c84" // this is for test purpose to not to create real qumulo resource
+    environment       = "terraform-acctests"
+    some_key          = "some-value"
+  }
+
+  schema_validation_enabled = false
+  response_export_values    = ["*"]
+}


### PR DESCRIPTION
The test needs to be run in a subscription associated with [valid payment method](https://learn.microsoft.com/en-us/azure/partner-solutions/qumulo/troubleshoot#purchase-errors), in my case the test is run in a Resource Group provided by the service team:

![image](https://github.com/user-attachments/assets/e0196d7f-3ac0-4755-9a7d-9f3bee3e10f9)

Due to payment limitation, maybe we can skip this in daily test