### PR TITLE
fix(azapi_resource): set context deadline before config retry

### DIFF
--- a/internal/services/azapi_resource.go
+++ b/internal/services/azapi_resource.go
@@ -789,6 +789,7 @@ func (r *AzapiResource) Read(ctx context.Context, request resource.ReadRequest, 
 		return
 	}
 
+	// Ensure the context deadline has been set before calling ConfigureClientWithCustomRetry().
 	ctx, cancel := context.WithTimeout(ctx, readTimeout)
 	defer cancel()
 
@@ -935,10 +936,11 @@ func (r *AzapiResource) Delete(ctx context.Context, request resource.DeleteReque
 		return
 	}
 
-	client := r.ProviderData.ResourceClient.ConfigureClientWithCustomRetry(ctx, model.Retry, false)
-
+	// Ensure the context deadline has been set before calling ConfigureClientWithCustomRetry().
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
+
+	client := r.ProviderData.ResourceClient.ConfigureClientWithCustomRetry(ctx, model.Retry, false)
 
 	lockIds := AsStringList(model.Locks)
 	slices.Sort(lockIds)


### PR DESCRIPTION
@ms-henglu

Please see this small fix that was missed on the last update to the retry code.

This fixes the Delete() method of azapi_resource and brings it in line with the other CRUD methods. This fix ensures that the retry client has the correct max elapsed time, rahter than the default of 15 minutes.