### PR TITLE
bugfix: `azapi_resource` cannot be updated correctly after moving from `azurerm` provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ ENHANCEMENTS:
 BUG FIXES:
 - Fix a bug that `azapi_update_resource` resource produced inconsistent results when only `error_message_regex` is changed.
 - Fix a bug that `azapi_resource_action` resource could not be migrated correctly when the `body` is empty string.
+- Fix a bug that after moving resource from `azurerm` provider, the `azapi_resource` resource could not be updated correctly.
 
 ## v2.3.0
 FEATURES:

--- a/internal/services/azapi_resource.go
+++ b/internal/services/azapi_resource.go
@@ -886,6 +886,7 @@ func (r *AzapiResource) Read(ctx context.Context, request resource.ReadRequest, 
 			return
 		}
 		state.Body = payload
+		response.Diagnostics.Append(response.Private.SetKey(ctx, FlagMoveState, []byte("false"))...)
 	}
 
 	response.Diagnostics.Append(response.State.Set(ctx, state)...)


### PR DESCRIPTION
After moving resource, `azapi` sets the private data to indicate the resource is moved from `azurerm` provider, but in the read func, this flag is not removed. This will cause the resource could not be updated correctly.

This PR fixes this bug and adds a test case for it.