### PR TITLE
bugfix: don't replace the resource if API returns readonly location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ BUG FIXES:
 - Fix a bug that `azapi_update_resource` resource produced inconsistent results when only `error_message_regex` is changed.
 - Fix a bug that `azapi_resource_action` resource could not be migrated correctly when the `body` is empty string.
 - Fix a bug that after moving resource from `azurerm` provider, the `azapi_resource` resource could not be updated correctly.
+- Fix a bug that `azapi_resource` is replaced if the API returns a readonly location.
 
 ## v2.3.0
 FEATURES:

--- a/internal/services/azapi_resource.go
+++ b/internal/services/azapi_resource.go
@@ -1129,7 +1129,12 @@ func (r *AzapiResource) locationWithDefaultLocation(configLocation types.String,
 		}
 	}
 
-	// 3. use the default location if it's not null and the resource supports location
+	// 3. use the state location if it's not specified in config but returned by the API
+	if state != nil && state.Location.ValueString() != "" {
+		return state.Location
+	}
+
+	// 4. use the default location if it's not null and the resource supports location
 	if len(r.ProviderData.Features.DefaultLocation) != 0 && canResourceHaveProperty(resourceDef, "location") {
 		defaultLocation := r.ProviderData.Features.DefaultLocation
 
@@ -1147,12 +1152,12 @@ func (r *AzapiResource) locationWithDefaultLocation(configLocation types.String,
 		return state.Location
 	}
 
-	// 4. To suppress the diff of config: location = null and state: location = ""
+	// 5. To suppress the diff of config: location = null and state: location = ""
 	if state != nil && !state.Location.IsUnknown() && state.Location.ValueString() == "" {
 		return state.Location
 	}
 
-	// 5. return null if all the above cases are null
+	// 6. return null if all the above cases are null
 	return types.StringNull()
 }
 

--- a/internal/services/azapi_resource_test.go
+++ b/internal/services/azapi_resource_test.go
@@ -428,6 +428,20 @@ func TestAccGenericResource_nullLocation(t *testing.T) {
 	})
 }
 
+func TestAccGenericResource_computedLocation(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azapi_resource", "test")
+	r := GenericResource{}
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config:            r.computedLocation(data),
+			ExternalProviders: externalProvidersAzurerm(),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+	})
+}
+
 func TestAccGenericResource_unknownName(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azapi_resource", "test")
 	r := GenericResource{}
@@ -1756,6 +1770,47 @@ resource "azapi_resource" "test" {
     }
   }
   locks = [azurerm_machine_learning_workspace.test.id]
+}
+`, r.template(data), data.RandomString)
+}
+
+func (r GenericResource) computedLocation(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azapi_resource" "namespace" {
+  type      = "Microsoft.EventHub/namespaces@2022-01-01-preview"
+  parent_id = azapi_resource.resourceGroup.id
+  name      = "acctest%[2]s"
+  location  = azapi_resource.resourceGroup.location
+  body = {
+    properties = {
+      disableLocalAuth     = false
+      isAutoInflateEnabled = false
+      publicNetworkAccess  = "Enabled"
+      zoneRedundant        = true
+    }
+    sku = {
+      capacity = 1
+      name     = "Basic"
+      tier     = "Basic"
+    }
+  }
+}
+
+resource "azapi_resource" "test" {
+  type      = "Microsoft.EventHub/namespaces/authorizationRules@2021-11-01"
+  parent_id = azapi_resource.namespace.id
+  name      = "acctest%[2]s"
+  body = {
+    properties = {
+      rights = [
+        "Listen",
+        "Send",
+        "Manage",
+      ]
+    }
+  }
 }
 `, r.template(data), data.RandomString)
 }


### PR DESCRIPTION
fixes https://github.com/Azure/terraform-provider-azapi/issues/655