### PR TITLE
Branch 240428 fix sensitive body migration

### DIFF
--- a/internal/services/ephemeral_body_private.go
+++ b/internal/services/ephemeral_body_private.go
@@ -74,7 +74,7 @@ func (m EphemeralBodyPrivateMgr) Diff(ctx context.Context, d PrivateData, ebody 
 	}
 	if b == nil {
 		// In case private state doesn't store the key yet, it only diffs when the ebody is not nil.
-		return ebody != nil, diags
+		return ebody != nil && string(ebody) != "null", diags
 	}
 	var mm map[string]interface{}
 	if err := json.Unmarshal(b, &mm); err != nil {

--- a/internal/services/migration/azapi_resource_migration_v0_to_v2.go
+++ b/internal/services/migration/azapi_resource_migration_v0_to_v2.go
@@ -147,6 +147,7 @@ func AzapiResourceMigrationV0ToV2(ctx context.Context) resource.StateUpgrader {
 				Location                      types.String        `tfsdk:"location"`
 				Identity                      types.List          `tfsdk:"identity"`
 				Body                          types.Dynamic       `tfsdk:"body"`
+				SensitiveBody                 types.Dynamic       `tfsdk:"sensitive_body"`
 				Locks                         types.List          `tfsdk:"locks"`
 				SchemaValidationEnabled       types.Bool          `tfsdk:"schema_validation_enabled"`
 				IgnoreCasing                  types.Bool          `tfsdk:"ignore_casing"`

--- a/internal/services/migration/azapi_resource_migration_v1_to_v2.go
+++ b/internal/services/migration/azapi_resource_migration_v1_to_v2.go
@@ -148,6 +148,7 @@ func AzapiResourceMigrationV1ToV2(ctx context.Context) resource.StateUpgrader {
 				Location                      types.String        `tfsdk:"location"`
 				Identity                      types.List          `tfsdk:"identity"`
 				Body                          types.Dynamic       `tfsdk:"body"`
+				SensitiveBody                 types.Dynamic       `tfsdk:"sensitive_body"`
 				Locks                         types.List          `tfsdk:"locks"`
 				SchemaValidationEnabled       types.Bool          `tfsdk:"schema_validation_enabled"`
 				IgnoreCasing                  types.Bool          `tfsdk:"ignore_casing"`

--- a/internal/services/migration/azapi_update_resource_migration_v0_to_v2.go
+++ b/internal/services/migration/azapi_update_resource_migration_v0_to_v2.go
@@ -105,6 +105,7 @@ func AzapiUpdateResourceMigrationV0ToV2(ctx context.Context) resource.StateUpgra
 				ResourceID            types.String        `tfsdk:"resource_id"`
 				Type                  types.String        `tfsdk:"type"`
 				Body                  types.Dynamic       `tfsdk:"body"`
+				SensitiveBody         types.Dynamic       `tfsdk:"sensitive_body"`
 				IgnoreCasing          types.Bool          `tfsdk:"ignore_casing"`
 				IgnoreMissingProperty types.Bool          `tfsdk:"ignore_missing_property"`
 				ResponseExportValues  types.Dynamic       `tfsdk:"response_export_values"`

--- a/internal/services/migration/azapi_update_resource_migration_v1_to_v2.go
+++ b/internal/services/migration/azapi_update_resource_migration_v1_to_v2.go
@@ -105,6 +105,7 @@ func AzapiUpdateResourceMigrationV1ToV2(ctx context.Context) resource.StateUpgra
 				ResourceID            types.String        `tfsdk:"resource_id"`
 				Type                  types.String        `tfsdk:"type"`
 				Body                  types.Dynamic       `tfsdk:"body"`
+				SensitiveBody         types.Dynamic       `tfsdk:"sensitive_body"`
 				IgnoreCasing          types.Bool          `tfsdk:"ignore_casing"`
 				IgnoreMissingProperty types.Bool          `tfsdk:"ignore_missing_property"`
 				ResponseExportValues  types.Dynamic       `tfsdk:"response_export_values"`


### PR DESCRIPTION
This PR fixes the state migration because a `sensitive_body` field is recently added.