### PR TITLE
bugfix: `azapi_update_resource` does not update the correct item in an array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ ENHANCEMENTS:
 
 BUG FIXES:
 - Fix a bug that schema validation fails to validate unknown string values when both `body` and `sensitive_body` are specified.
+- Fix a bug that `azapi_update_resource` does not update the correct items in an array when the order of the items is different from the remote state.
 
 ## v2.4.0
 

--- a/utils/json.go
+++ b/utils/json.go
@@ -48,12 +48,39 @@ func MergeObject(old interface{}, new interface{}) interface{} {
 		}
 	case []interface{}:
 		if newArr, ok := new.([]interface{}); ok {
-			if len(oldValue) != len(newArr) {
+			if len(oldValue) == 0 || len(newArr) == 0 {
 				return newArr
 			}
+
+			hasIdentifier := identifierOfArrayItem(oldValue[0]) != "" && identifierOfArrayItem(newArr[0]) != ""
+			if !hasIdentifier {
+				if len(oldValue) != len(newArr) {
+					return newArr
+				}
+				res := make([]interface{}, 0)
+				for index := range oldValue {
+					res = append(res, MergeObject(oldValue[index], newArr[index]))
+				}
+				return res
+			}
+
 			res := make([]interface{}, 0)
-			for index := range oldValue {
-				res = append(res, MergeObject(oldValue[index], newArr[index]))
+			used := make([]bool, len(newArr))
+
+			for _, oldItem := range oldValue {
+				found := false
+				for index, newItem := range newArr {
+					if areSameArrayItems(oldItem, newItem) && !used[index] {
+						res = append(res, MergeObject(oldItem, newItem))
+						used[index] = true
+						found = true
+						break
+					}
+				}
+				if found {
+					continue
+				}
+				res = append(res, oldItem)
 			}
 			return res
 		}

--- a/utils/json_test.go
+++ b/utils/json_test.go
@@ -424,24 +424,31 @@ func Test_UpdateObject(t *testing.T) {
 }
 
 func Test_MergeObject(t *testing.T) {
-	oldJson := `
- {
+	testcases := []struct {
+		Name       string
+		OldJson    string
+		NewJson    string
+		ExpectJson string
+	}{
+		{
+			Name: "Merge simple objects",
+			OldJson: ` 
+{
 	"a":1,
     "b": {
 		"b1": "b1",
 		"b2": []
 	}
 }
-`
-
-	newJson := `
+`,
+			NewJson: `
 {
 	"b": {
 		"b3": "b3"
 	}
 }
-`
-	expectedJson := `
+`,
+			ExpectJson: `
 {
 	"a":1,
     "b": {
@@ -449,18 +456,66 @@ func Test_MergeObject(t *testing.T) {
 		"b2": [],
 		"b3": "b3"
 	}
+}`,
+		},
+		{
+			Name: "Merge objects with arrays",
+			OldJson: `
+{
+  "array": [
+    {
+      "name": "item1",
+      "key1": "value1"
+    },
+    {
+      "name": "item2",
+      "key2": "value2"
+    }
+  ]
+}`,
+			NewJson: `
+{
+  "array": [
+    {
+      "name": "item2",
+      "key2": "value3"
+    },
+    {
+      "name": "item1",
+      "key1": "value2"
+    }
+  ]
+}`,
+			ExpectJson: `
+{
+  "array": [
+    {
+      "name": "item1",
+      "key1": "value2"
+    },
+    {
+      "name": "item2",
+      "key2": "value3"
+    }
+  ]
 }
-`
-	var new, old, expected interface{}
-	_ = json.Unmarshal([]byte(oldJson), &old)
-	_ = json.Unmarshal([]byte(newJson), &new)
-	_ = json.Unmarshal([]byte(expectedJson), &expected)
+`,
+		},
+	}
 
-	result := utils.MergeObject(old, new)
-	if !reflect.DeepEqual(result, expected) {
-		expectedJson, _ := json.Marshal(expected)
-		resultJson, _ := json.Marshal(result)
-		t.Fatalf("Expected %s but got %s", expectedJson, resultJson)
+	for _, testcase := range testcases {
+		t.Logf("Running test case: %s", testcase.Name)
+		var new, old, expected interface{}
+		_ = json.Unmarshal([]byte(testcase.OldJson), &old)
+		_ = json.Unmarshal([]byte(testcase.NewJson), &new)
+		_ = json.Unmarshal([]byte(testcase.ExpectJson), &expected)
+
+		result := utils.MergeObject(old, new)
+		if !reflect.DeepEqual(result, expected) {
+			expectedJson, _ := json.Marshal(expected)
+			resultJson, _ := json.Marshal(result)
+			t.Fatalf("Test %s: Expected %s but got %s", testcase.Name, expectedJson, resultJson)
+		}
 	}
 }
 


### PR DESCRIPTION
This PR updates the logic that `azapi_update_resource` uses item's identifier "name" to match with the correct item in an array.