### PR TITLE
`azapi_update_resource`: remove identity's readonly fields in request body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ENHANCEMENTS:
 - `azapi_resource` resource: ignore the order of the `identity_ids` array.
+- `azapi_update_resource` resource: remove the readonly fields from `identity.userAssignedIdentities` in the request body.
 
 BUG FIXES:
 - Fix a bug that schema validation fails to validate unknown string values when both `body` and `sensitive_body` are specified.

--- a/internal/azure/fix/fix.go
+++ b/internal/azure/fix/fix.go
@@ -1,0 +1,29 @@
+package fix
+
+// GetWriteOnlyFix is a function that contains hardcoded logic to fix the write-only properties in the resource body.
+func GetWriteOnlyFix(input interface{}) interface{} {
+	if input == nil {
+		return nil
+	}
+	input = fixUserAssignedIdentities(input)
+	return input
+}
+
+// fixUserAssignedIdentities is a helper function to ensure that userAssignedIdentities in the identity object are set to an empty map
+func fixUserAssignedIdentities(input interface{}) interface{} {
+	if input == nil {
+		return nil
+	}
+	if v, ok := input.(map[string]interface{}); ok && v["identity"] != nil {
+		if identity, ok := v["identity"].(map[string]interface{}); ok && identity["userAssignedIdentities"] != nil {
+			if userAssignedIdentities, ok := identity["userAssignedIdentities"].(map[string]interface{}); ok {
+				for key := range userAssignedIdentities {
+					// Ensure that each userAssignedIdentity is an empty map
+					userAssignedIdentities[key] = map[string]interface{}{}
+				}
+			}
+			return v
+		}
+	}
+	return input
+}

--- a/internal/azure/fix/fix_test.go
+++ b/internal/azure/fix/fix_test.go
@@ -1,0 +1,93 @@
+package fix
+
+import (
+	"reflect"
+	"testing"
+)
+
+func Test_fixUserAssignedIdentities(t *testing.T) {
+	testcases := []struct {
+		name     string
+		input    interface{}
+		expected interface{}
+	}{
+		{
+			name:     "nil input",
+			input:    nil,
+			expected: nil,
+		},
+
+		{
+			name:     "empty input",
+			input:    map[string]interface{}{},
+			expected: map[string]interface{}{},
+		},
+
+		{
+			name: "input with no identity",
+			input: map[string]interface{}{
+				"name": "testResource",
+				"type": "Microsoft.Test/testResources",
+			},
+			expected: map[string]interface{}{
+				"name": "testResource",
+				"type": "Microsoft.Test/testResources",
+			},
+		},
+
+		{
+			name: "input with identity but no userAssignedIdentities",
+			input: map[string]interface{}{
+				"name": "testResource",
+				"type": "Microsoft.Test/testResources",
+				"identity": map[string]interface{}{
+					"type": "SystemAssigned",
+				},
+			},
+			expected: map[string]interface{}{
+				"name": "testResource",
+				"type": "Microsoft.Test/testResources",
+				"identity": map[string]interface{}{
+					"type": "SystemAssigned",
+				},
+			},
+		},
+
+		{
+			name: "input with userAssignedIdentities",
+			input: map[string]interface{}{
+				"name": "testResource",
+				"type": "Microsoft.Test/testResources",
+				"identity": map[string]interface{}{
+					"type": "UserAssigned",
+					"userAssignedIdentities": map[string]interface{}{
+						"/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/testGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/testIdentity1": map[string]interface{}{
+							"clientId":    "12345678-1234-1234-1234-123456789012",
+							"principalId": "12345678-1234-1234-1234-123456789012",
+						},
+					},
+				},
+			},
+			expected: map[string]interface{}{
+				"name": "testResource",
+				"type": "Microsoft.Test/testResources",
+				"identity": map[string]interface{}{
+					"type": "UserAssigned",
+					"userAssignedIdentities": map[string]interface{}{
+						"/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/testGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/testIdentity1": map[string]interface{}{},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := fixUserAssignedIdentities(tc.input)
+			if !reflect.DeepEqual(result, tc.expected) {
+				t.Errorf("expected %v, got %v", tc.expected, result)
+			}
+		})
+	}
+
+}

--- a/internal/services/azapi_update_resource.go
+++ b/internal/services/azapi_update_resource.go
@@ -7,6 +7,7 @@ import (
 	"slices"
 	"time"
 
+	"github.com/Azure/terraform-provider-azapi/internal/azure/fix"
 	"github.com/Azure/terraform-provider-azapi/internal/clients"
 	"github.com/Azure/terraform-provider-azapi/internal/docstrings"
 	"github.com/Azure/terraform-provider-azapi/internal/locks"
@@ -440,6 +441,7 @@ func (r *AzapiUpdateResource) CreateUpdate(ctx context.Context, requestConfig tf
 	if id.ResourceDef != nil {
 		requestBody = (*id.ResourceDef).GetWriteOnly(utils.NormalizeObject(requestBody))
 	}
+	requestBody = fix.GetWriteOnlyFix(requestBody)
 
 	lockIds := common.AsStringList(model.Locks)
 	slices.Sort(lockIds)


### PR DESCRIPTION
fixes https://github.com/Azure/terraform-provider-azapi/issues/840