### PR TITLE
example - `Microsoft.StandbyPool_standbyContainerGroupPools@2025-03-01`

### DIFF
--- a/docs/resources/Microsoft.StandbyPool_standbyContainerGroupPools.md
+++ b/docs/resources/Microsoft.StandbyPool_standbyContainerGroupPools.md
@@ -1,0 +1,203 @@
+---
+subcategory: "Microsoft.StandbyPool - Standby Pools"
+page_title: "standbyContainerGroupPools"
+description: |-
+  Manages a Microsoft Standby pools for Container Groups.
+---
+
+# Microsoft.StandbyPool/standbyContainerGroupPools - Microsoft Standby pools for Container Groups
+
+This article demonstrates how to use `azapi` provider to manage the Microsoft Standby pools for Container Groups resource in Azure.
+
+## Example Usage
+
+### basic
+
+```hcl
+terraform {
+  required_providers {
+    azapi = {
+      source = "Azure/azapi"
+    }
+  }
+}
+
+provider "azapi" {
+  skip_provider_registration = false
+}
+
+variable "resource_name" {
+  type    = string
+  default = "acctest0001"
+}
+
+variable "location" {
+  type    = string
+  default = "eastus"
+}
+
+resource "azapi_resource" "resourceGroup" {
+  type     = "Microsoft.Resources/resourceGroups@2020-06-01"
+  name     = "${var.resource_name}-rg"
+  location = var.location
+}
+
+resource "azapi_resource" "virtualNetwork" {
+  type      = "Microsoft.Network/virtualNetworks@2022-07-01"
+  parent_id = azapi_resource.resourceGroup.id
+  name      = "${var.resource_name}-vnet"
+  location  = var.location
+  body = {
+    properties = {
+      addressSpace = {
+        addressPrefixes = [
+          "10.0.0.0/16",
+        ]
+      }
+      dhcpOptions = {
+        dnsServers = [
+        ]
+      }
+      subnets = [
+      ]
+    }
+  }
+  schema_validation_enabled = false
+  response_export_values    = ["*"]
+  lifecycle {
+    ignore_changes = [body.properties.subnets]
+  }
+}
+
+resource "azapi_resource" "subnet" {
+  type      = "Microsoft.Network/virtualNetworks/subnets@2022-07-01"
+  parent_id = azapi_resource.virtualNetwork.id
+  name      = "${var.resource_name}-subnet"
+  body = {
+    properties = {
+      addressPrefix = "10.0.2.0/24"
+      delegations = [
+      ]
+      privateEndpointNetworkPolicies    = "Enabled"
+      privateLinkServiceNetworkPolicies = "Enabled"
+      serviceEndpointPolicies = [
+      ]
+      serviceEndpoints = [
+      ]
+    }
+  }
+  schema_validation_enabled = false
+  response_export_values    = ["*"]
+}
+
+resource "azapi_resource" "containerGroupProfile" {
+  type      = "Microsoft.ContainerInstance/containerGroupProfiles@2024-05-01-preview"
+  parent_id = azapi_resource.resourceGroup.id
+  name      = "${var.resource_name}-contianerGroup"
+  location  = var.location
+
+  body = {
+    properties = {
+      "containers" : [
+        {
+          "name" : "mycontainergroupprofile",
+          "properties" : {
+            "command" : [],
+            "environmentVariables" : [],
+            "image" : "mcr.microsoft.com/azuredocs/aci-helloworld:latest",
+            "ports" : [
+              {
+                "port" : 8000
+              }
+            ],
+            "resources" : {
+              "requests" : {
+                "cpu" : 1,
+                "memoryInGB" : 1.5
+              }
+            }
+          }
+        }
+      ],
+      "imageRegistryCredentials" : [],
+      "ipAddress" : {
+        "ports" : [
+          {
+            "protocol" : "TCP",
+            "port" : 8000
+          }
+        ],
+        "type" : "Public"
+      },
+      "osType" : "Linux",
+      "sku" : "Standard"
+    }
+  }
+
+  schema_validation_enabled = false
+}
+
+
+
+resource "azapi_resource" "standbyContainerGroupPool" {
+  type      = "Microsoft.StandbyPool/standbyContainerGroupPools@2025-03-01"
+  parent_id = azapi_resource.resourceGroup.id
+  name      = "${var.resource_name}-CGPool"
+  body = {
+    properties = {
+      containerGroupProperties = {
+        containerGroupProfile = {
+          id       = azapi_resource.containerGroupProfile.id
+          revision = 1
+        }
+        subnetIds = [
+          {
+            id = azapi_resource.subnet.id
+          },
+        ]
+      }
+      elasticityProfile = {
+        maxReadyCapacity = 5
+        refillPolicy     = "always"
+      }
+      zones = [
+        "1",
+        "2",
+        "3",
+      ]
+    },
+    location = "${var.location}"
+  }
+  schema_validation_enabled = false
+  ignore_casing             = false
+  ignore_missing_property   = false
+}
+
+```
+
+
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `type` - (Required) The type of the resource. This should be set to `Microsoft.StandbyPool/standbyContainerGroupPools@api-version`. The available api-versions for this resource are: [`2023-12-01-preview`, `2024-03-01`, `2024-03-01-preview`, `2025-03-01`].
+
+* `parent_id` - (Required) The ID of the azure resource in which this resource is created. The allowed values are:  
+  `/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}`
+
+* `name` - (Required) Specifies the name of the azure resource. Changing this forces a new resource to be created.
+
+* `body` - (Required) Specifies the configuration of the resource. More information about the arguments in `body` can be found in the [Microsoft documentation](https://learn.microsoft.com/en-us/azure/templates/Microsoft.StandbyPool/standbyContainerGroupPools?pivots=deployment-language-terraform).
+
+For other arguments, please refer to the [azapi_resource](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource) documentation.
+
+## Import
+
+ ```shell
+ # Azure resource can be imported using the resource id, e.g.
+ terraform import azapi_resource.example /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.StandbyPool/standbyContainerGroupPools/{resourceName}
+ 
+ # It also supports specifying API version by using the resource id with api-version as a query parameter, e.g.
+ terraform import azapi_resource.example /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.StandbyPool/standbyContainerGroupPools/{resourceName}?api-version=2025-03-01
+ ```

--- a/docs/resources/Microsoft.StandbyPool_standbyvirtualmachinepools.md
+++ b/docs/resources/Microsoft.StandbyPool_standbyvirtualmachinepools.md
@@ -14,7 +14,6 @@ This article demonstrates how to use `azapi` provider to manage the Microsoft St
 ### basic
 
 ```hcl
-
 terraform {
   required_providers {
     azapi = {

--- a/examples/Microsoft.StandbyPool_standbyContainerGroupPools@2025-03-01/basic/README.md
+++ b/examples/Microsoft.StandbyPool_standbyContainerGroupPools@2025-03-01/basic/README.md
@@ -1,0 +1,2 @@
+[Requirements]
+To set up Standby Container Pool, some permissions need to be configured in advance. Please follow [this document](https://learn.microsoft.com/en-us/azure/container-instances/container-instances-standby-pool-configure-permissions) to configure.

--- a/examples/Microsoft.StandbyPool_standbyContainerGroupPools@2025-03-01/basic/README.md
+++ b/examples/Microsoft.StandbyPool_standbyContainerGroupPools@2025-03-01/basic/README.md
@@ -1,2 +1,36 @@
-[Requirements]
-To set up Standby Container Pool, some permissions need to be configured in advance. Please follow [this document](https://learn.microsoft.com/en-us/azure/container-instances/container-instances-standby-pool-configure-permissions) to configure.
+# Use Standby Pool for Container Group 
+
+## Overview
+
+This example shows how to setup Standby Pool for Container Group. Standby Pools allow you to create a pool of pre-provisioned, pre-initialized container groups that are ready to receive workloads instantly. This capability significantly reduces cold start latency and enhances responsiveness for bursty, event-driven, or latency-sensitive applications.
+
+In this example, we will create a Container Group and a Standby Pool for it.
+
+## Prerequisites
+
+1. You need an Azure account with an active subscription. [Create an account for free.](https://azure.microsoft.com/free/?WT.mc_id=A261C142F)
+2. [Install and configure Terraform.](https://learn.microsoft.com/en-us/azure/developer/terraform/quickstart-configure)
+3. [Configure Permission for Standby Pool.](https://learn.microsoft.com/en-us/azure/container-instances/container-instances-standby-pool-configure-permissions)
+
+## Implement the Terraform code
+
+1. Create a directory in which to test and run the sample Terraform code and make it the current directory.
+
+2. Create a `main.tf` file and copy the content of the [main.tf](./main.tf) file into it.
+
+3. Update the below variables in the `main.tf` file:
+    - `resource_name`: The name of the resource group and resources.
+    - `location`: The location for the resource group and resources.
+    - `subscription_id`: The subscription ID to use.
+
+4. Initialize Terraform  
+Run `terraform init` to initialize the Terraform deployment. This command downloads the Azure provider required to manage your Azure resources.
+
+5. Login to Azure  
+Run `az login` to log in to your Azure account.
+
+6. Create a Terraform execution plan  
+Run `terraform plan` to create an execution plan.
+
+6. Apply a Terraform execution plan  
+Run `terraform apply` to apply the execution plan to your cloud infrastructure.

--- a/examples/Microsoft.StandbyPool_standbyContainerGroupPools@2025-03-01/basic/main.tf
+++ b/examples/Microsoft.StandbyPool_standbyContainerGroupPools@2025-03-01/basic/main.tf
@@ -1,0 +1,158 @@
+terraform {
+  required_providers {
+    azapi = {
+      source = "Azure/azapi"
+    }
+  }
+}
+
+provider "azapi" {
+  skip_provider_registration = false
+}
+
+variable "resource_name" {
+  type    = string
+  default = "acctest0001"
+}
+
+variable "location" {
+  type    = string
+  default = "eastus"
+}
+
+resource "azapi_resource" "resourceGroup" {
+  type     = "Microsoft.Resources/resourceGroups@2020-06-01"
+  name     = "${var.resource_name}-rg"
+  location = var.location
+}
+
+resource "azapi_resource" "virtualNetwork" {
+  type      = "Microsoft.Network/virtualNetworks@2022-07-01"
+  parent_id = azapi_resource.resourceGroup.id
+  name      = "${var.resource_name}-vnet"
+  location  = var.location
+  body = {
+    properties = {
+      addressSpace = {
+        addressPrefixes = [
+          "10.0.0.0/16",
+        ]
+      }
+      dhcpOptions = {
+        dnsServers = [
+        ]
+      }
+      subnets = [
+      ]
+    }
+  }
+  schema_validation_enabled = false
+  response_export_values    = ["*"]
+  lifecycle {
+    ignore_changes = [body.properties.subnets]
+  }
+}
+
+resource "azapi_resource" "subnet" {
+  type      = "Microsoft.Network/virtualNetworks/subnets@2022-07-01"
+  parent_id = azapi_resource.virtualNetwork.id
+  name      = "${var.resource_name}-subnet"
+  body = {
+    properties = {
+      addressPrefix = "10.0.2.0/24"
+      delegations = [
+      ]
+      privateEndpointNetworkPolicies    = "Enabled"
+      privateLinkServiceNetworkPolicies = "Enabled"
+      serviceEndpointPolicies = [
+      ]
+      serviceEndpoints = [
+      ]
+    }
+  }
+  schema_validation_enabled = false
+  response_export_values    = ["*"]
+}
+
+resource "azapi_resource" "containerGroupProfile" {
+  type      = "Microsoft.ContainerInstance/containerGroupProfiles@2024-05-01-preview"
+  parent_id = azapi_resource.resourceGroup.id
+  name      = "${var.resource_name}-contianerGroup"
+  location  = var.location
+
+  body = {
+    properties = {
+      "containers" : [
+        {
+          "name" : "mycontainergroupprofile",
+          "properties" : {
+            "command" : [],
+            "environmentVariables" : [],
+            "image" : "mcr.microsoft.com/azuredocs/aci-helloworld:latest",
+            "ports" : [
+              {
+                "port" : 8000
+              }
+            ],
+            "resources" : {
+              "requests" : {
+                "cpu" : 1,
+                "memoryInGB" : 1.5
+              }
+            }
+          }
+        }
+      ],
+      "imageRegistryCredentials" : [],
+      "ipAddress" : {
+        "ports" : [
+          {
+            "protocol" : "TCP",
+            "port" : 8000
+          }
+        ],
+        "type" : "Public"
+      },
+      "osType" : "Linux",
+      "sku" : "Standard"
+    }
+  }
+
+  schema_validation_enabled = false
+}
+
+
+
+resource "azapi_resource" "standbyContainerGroupPool" {
+  type      = "Microsoft.StandbyPool/standbyContainerGroupPools@2025-03-01"
+  parent_id = azapi_resource.resourceGroup.id
+  name      = "${var.resource_name}-CGPool"
+  body = {
+    properties = {
+      containerGroupProperties = {
+        containerGroupProfile = {
+          id       = azapi_resource.containerGroupProfile.id
+          revision = 1
+        }
+        subnetIds = [
+          {
+            id = azapi_resource.subnet.id
+          },
+        ]
+      }
+      elasticityProfile = {
+        maxReadyCapacity = 5
+        refillPolicy     = "always"
+      }
+      zones = [
+        "1",
+        "2",
+        "3",
+      ]
+    },
+    location = "${var.location}"
+  }
+  schema_validation_enabled = false
+  ignore_casing             = false
+  ignore_missing_property   = false
+}

--- a/examples/Microsoft.StandbyPool_standbyvirtualmachinepools@2025-03-01/basic/main.tf
+++ b/examples/Microsoft.StandbyPool_standbyvirtualmachinepools@2025-03-01/basic/main.tf
@@ -1,4 +1,3 @@
-
 terraform {
   required_providers {
     azapi = {

--- a/tools/generator-example-doc/resource_types.json
+++ b/tools/generator-example-doc/resource_types.json
@@ -2984,6 +2984,10 @@
     "friendlyName":"Microsoft Standby pools for Virtual Machine Scale Sets"
   },
   {
+    "resourceType":"Microsoft.StandbyPool/standbyContainerGroupPools",
+    "friendlyName":"Microsoft Standby pools for Container Groups"
+  },
+  {
     "resourceType": "Microsoft.Storage/storageAccounts",
     "friendlyName": "Azure Storage Account"
   },


### PR DESCRIPTION
I did not find example of `README.md` of examples... But this example needs set up permission in advance..
test:
```
❯ make example-test TARGET=Microsoft.StandbyPool_standbyContainerGroupPools@2025-03-01
TF_ACC=1 ARM_TEST_EXAMPLES=Microsoft.StandbyPool_standbyContainerGroupPools@2025-03-01 go test -v ./internal/services/... -run TestAccExamples_Selected -timeout 300m -ldflags="-X=github.com/Azure/terraform-provider-azapi/version.ProviderVersion=acc"
=== RUN   TestAccExamples_Selected
    azapi_resource_example_test.go:56: Found 1 testcases
=== RUN   TestAccExamples_Selected/../../examples/Microsoft.StandbyPool_standbyContainerGroupPools@2025-03-01/basic/main.tf
=== PAUSE TestAccExamples_Selected/../../examples/Microsoft.StandbyPool_standbyContainerGroupPools@2025-03-01/basic/main.tf
=== CONT  TestAccExamples_Selected/../../examples/Microsoft.StandbyPool_standbyContainerGroupPools@2025-03-01/basic/main.tf
--- PASS: TestAccExamples_Selected (0.00s)
    --- PASS: TestAccExamples_Selected/../../examples/Microsoft.StandbyPool_standbyContainerGroupPools@2025-03-01/basic/main.tf (1854.68s)
PASS
ok      github.com/Azure/terraform-provider-azapi/internal/services     1854.698s
?       github.com/Azure/terraform-provider-azapi/internal/services/common      [no test files]
?       github.com/Azure/terraform-provider-azapi/internal/services/defaults    [no test files]
testing: warning: no tests to run
PASS
ok      github.com/Azure/terraform-provider-azapi/internal/services/dynamic     (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/Azure/terraform-provider-azapi/internal/services/functions   (cached) [no tests to run]
?       github.com/Azure/terraform-provider-azapi/internal/services/migration   [no test files]
?       github.com/Azure/terraform-provider-azapi/internal/services/myplanmodifier      [no test files]
testing: warning: no tests to run
PASS
ok      github.com/Azure/terraform-provider-azapi/internal/services/myplanmodifier/planmodifierdynamic  (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/Azure/terraform-provider-azapi/internal/services/myvalidator (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/Azure/terraform-provider-azapi/internal/services/parse       (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/Azure/terraform-provider-azapi/internal/services/preflight   (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/Azure/terraform-provider-azapi/internal/services/validate    (cached) [no tests to run]
```