### PR TITLE
No recreate for `azapi_resource_action` resource on type change

### DIFF
--- a/internal/services/azapi_resource_action_resource.go
+++ b/internal/services/azapi_resource_action_resource.go
@@ -95,9 +95,6 @@ func (r *ActionResource) Schema(ctx context.Context, request resource.SchemaRequ
 				Validators: []validator.String{
 					myvalidator.StringIsResourceType(),
 				},
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
-				},
 				MarkdownDescription: docstrings.Type(),
 			},
 


### PR DESCRIPTION
The `azapi_resource_action` resource will force re-creation if the type field changes. This means that simply updating the api-version (for example, from 2022-05-01 to 2023-01-01) can cause the resource to be destroyed and recreated, which is problematic—especially if `when = "destroy"` is set. The resource should still be sufficiently re-created if any of the other marked arguments change. 