### PR TITLE
Print entrauth logs to the same redirected writer instead of stderr

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -743,7 +743,7 @@ func buildChainedTokenCredential(model providerData, clientOpt azcore.ClientOpti
 	}
 
 	cred, err := aztfauth.NewCredential(aztfauth.Option{
-		Logger:                     log.New(os.Stderr, "[DEBUG] ", log.LstdFlags|log.Lmsgprefix),
+		Logger:                     log.New(log.Default().Writer(), "[DEBUG] ", log.LstdFlags|log.Lmsgprefix),
 		TenantId:                   model.TenantID.ValueString(),
 		ClientId:                   model.ClientID.ValueString(),
 		ClientIdFile:               model.ClientIDFilePath.ValueString(),


### PR DESCRIPTION
The log's writer is redirected by the underlying go-plugin, hence we shall continue using that other than output to stderr, otherwise the log will be messy..