### PR TITLE
bugfix: provider crash if the `identity.type` returned is not a string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ ENHANCEMENTS:
 BUG FIXES:
 - Fix a bug that invalid resource ID containing `|` character is not detected when validating the configuration.
 - Fix a bug that schema validation fails to validate when the discriminator field is unknown.
+- Fix the crash that occurs when the `identity.type` returns a value that is not a string.
 
 ## v2.5.0
 

--- a/internal/azure/identity/identity.go
+++ b/internal/azure/identity/identity.go
@@ -97,7 +97,17 @@ func FlattenIdentity(identity interface{}) *Model {
 			}
 		}
 
-		identityType := identityMap["type"].(string)
+		// should not be nil, but check just in case
+		if identityMap["type"] == nil {
+			return nil
+		}
+
+		identityType, ok := identityMap["type"].(string)
+		if !ok {
+			// should not happen, but check just in case
+			return nil
+		}
+
 		switch {
 		case strings.Contains(identityType, ","):
 			identityType = string(SystemAssignedUserAssigned)


### PR DESCRIPTION
fixes https://github.com/Azure/terraform-provider-azapi/issues/942