### PR TITLE
preflight - fix name field

### DIFF
--- a/internal/services/azapi_resource_preflight_test.go
+++ b/internal/services/azapi_resource_preflight_test.go
@@ -126,6 +126,30 @@ func TestAccGenericResource_preflightManagementGroupScopedNestedResource(t *test
 	})
 }
 
+func TestAccGenericResource_preflightChildResource(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azapi_resource", "test")
+	r := GenericResource{}
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config:             r.preflightChildResouce(data),
+			PlanOnly:           true,
+			ExpectNonEmptyPlan: true,
+		},
+	})
+}
+
+func TestAccGenericResource_apiTest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azapi_resource", "test")
+	r := GenericResource{}
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config:             r.preflightChildResouce(data),
+			PlanOnly:           true,
+			ExpectNonEmptyPlan: true,
+		},
+	})
+}
+
 func TestAccGenericResource_preflightResourceGroupScopedTrackedResource(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azapi_resource", "test")
 	r := GenericResource{}
@@ -292,6 +316,38 @@ resource "azapi_resource" "managementGroup" {
   }
 }
 `
+}
+
+func (r GenericResource) preflightChildResouce(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azapi" {
+  enable_preflight = true
+}
+
+%s
+
+resource "azapi_resource" "managed_identity" {
+  type      = "Microsoft.ManagedIdentity/userAssignedIdentities@2025-01-31-preview"
+  name      = "test-managed-identity"
+  parent_id = azapi_resource.resourceGroup.id
+  location  = "westeurope"
+}
+
+resource "azapi_resource" "federated_credential" {
+  type      = "Microsoft.ManagedIdentity/userAssignedIdentities/federatedIdentityCredentials@2025-01-31-preview"
+  name      = "test-federated-credential"
+  parent_id = azapi_resource.managed_identity.id
+  body = {
+    properties = {
+      audiences = [
+        "api://AzureADTokenExchange"
+      ]
+      issuer  = "https://vstoken.dev.azure.com/11111111-1111-11111-1111"
+      subject = "sc://test"
+    }
+  }
+}
+`, r.template(data))
 }
 
 func (r GenericResource) preflightSubscriptionScopedResource(data acceptance.TestData) string {

--- a/internal/services/azapi_resource_preflight_test.go
+++ b/internal/services/azapi_resource_preflight_test.go
@@ -138,18 +138,6 @@ func TestAccGenericResource_preflightChildResource(t *testing.T) {
 	})
 }
 
-func TestAccGenericResource_apiTest(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azapi_resource", "test")
-	r := GenericResource{}
-	data.ResourceTest(t, r, []resource.TestStep{
-		{
-			Config:             r.preflightChildResouce(data),
-			PlanOnly:           true,
-			ExpectNonEmptyPlan: true,
-		},
-	})
-}
-
 func TestAccGenericResource_preflightResourceGroupScopedTrackedResource(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azapi_resource", "test")
 	r := GenericResource{}

--- a/internal/services/preflight/preflight_test.go
+++ b/internal/services/preflight/preflight_test.go
@@ -180,3 +180,52 @@ func Test_ScopeID(t *testing.T) {
 		}
 	}
 }
+
+func Test_ResourceAndParentName(t *testing.T) {
+	testcases := []struct {
+		ResourceId                    string
+		ScopeId                       string
+		ExpectedResourceAndParentName string
+	}{
+		{
+			ResourceId:                    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azapifakerg/providers/Microsoft.Network/virtualNetworks/vnet/subnets/mySubnet",
+			ScopeId:                       "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azapifakerg",
+			ExpectedResourceAndParentName: "vnet/mySubnet",
+		},
+		{
+			ResourceId:                    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azapifakerg/providers/Microsoft.Network/virtualNetworks/vnet",
+			ScopeId:                       "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azapifakerg",
+			ExpectedResourceAndParentName: "vnet",
+		},
+		{
+			ResourceId:                    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azapifakerg",
+			ScopeId:                       "/subscriptions/00000000-0000-0000-0000-000000000000",
+			ExpectedResourceAndParentName: "azapifakerg",
+		},
+		{
+			ResourceId:                    "/subscriptions/00000000-0000-0000-0000-000000000000",
+			ScopeId:                       "/",
+			ExpectedResourceAndParentName: "00000000-0000-0000-0000-000000000000",
+		},
+		{
+			ResourceId:                    "/providers/Microsoft.Management/managementGroups/azapifakemg",
+			ScopeId:                       "/",
+			ExpectedResourceAndParentName: "azapifakemg",
+		},
+		{
+			ResourceId:                    "/providers/Microsoft.Management/managementGroups/azapifakemg/providers/Microsoft.Network/virtualNetworks/vnet/subnets/mySubnet",
+			ScopeId:                       "/providers/Microsoft.Management/managementGroups/azapifakemg",
+			ExpectedResourceAndParentName: "vnet/mySubnet",
+		},
+	}
+
+	for _, testcase := range testcases {
+		actual, err := ResourceAndParentName(testcase.ResourceId, testcase.ScopeId)
+		if err != nil {
+			t.Errorf("Expected no error, but got %v", err)
+		}
+		if actual != testcase.ExpectedResourceAndParentName {
+			t.Errorf("Expected %s, but got %s", testcase.ExpectedResourceAndParentName, actual)
+		}
+	}
+}


### PR DESCRIPTION
Fixed the name field to align with the number of segments in the resource type field. For example, if the type is "virtualNetworks/subnets", the name will now be "vnetName/subnetName".