### PR TITLE
docs: replace deprecated AzAPI VSCode extension references with Microsoft Terraform extension (fix #958)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This provider compliments the AzureRM provider by enabling the management of Azu
 
 * [Learn how to use azapi_update_resource](https://docs.microsoft.com/en-us/azure/developer/terraform/get-started-azapi-update-resource)
 
-* [AzApi VSCode Extension](https://marketplace.visualstudio.com/items?itemName=azapi-vscode.azapi) provides a rich authoring experience to help you use the AzApi provider.
+* VS Code users: install the [Microsoft Terraform extension](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-azureterraform) for authoring assistance (the former AzAPI VS Code extension has been deprecated and its features were merged here).
 
 Also, there is a rich library of [examples](https://github.com/Azure/terraform-provider-azapi/tree/main/examples) to help you get started.
 

--- a/docs/guides/feature_convert_arm_template.md
+++ b/docs/guides/feature_convert_arm_template.md
@@ -2,17 +2,17 @@
 layout: "azapi"
 page_title: "Feature: Convert ARM Template/Resource JSON to AzAPI Configuration"
 description: |-
-  This guide will cover how to use AzAPI VSCode extension to convert ARM template/resource JSON to AzAPI configuration.
+  This guide will cover how to use the Microsoft Terraform VS Code extension to convert ARM template/resource JSON to AzAPI configuration.
 
 ---
 
-The AzAPI VSCode extension provides a feature to convert ARM template/resource JSON to AzAPI configuration. This feature is useful when you have an existing ARM template or resource JSON and want to convert it to AzAPI configuration.
+The Microsoft Terraform VS Code extension (which now includes the former AzAPI extension features) provides a capability to convert ARM template/resource JSON to AzAPI configuration. This is useful when you have an existing ARM template or resource JSON and want to convert it to AzAPI configuration.
 
 This article covers how to use the feature to convert ARM template/resource JSON to AzAPI configuration.
 
 ## Prerequisites
 
-- [AzAPI VSCode extension](https://marketplace.visualstudio.com/items?itemName=azapi-vscode.azapi) version 2.0.1 or later
+- [Microsoft Terraform VS Code extension](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-azureterraform) (includes AzAPI features)
 - [Terraform AzAPI provider](https://registry.terraform.io/providers/azure/azapi) version 2.0.1 or later
 
 ## Convert ARM template to AzAPI configuration
@@ -110,8 +110,8 @@ A step-by-step guide on how to export the ARM template from the Azure portal can
 }
 ```
 
-3. Paste the ARM template JSON in a `*.tf` file in the VSCode editor.  
-The AzAPI VSCode extension will automatically detect the ARM template JSON and convert it to AzAPI configuration.
+3. Paste the ARM template JSON in a `*.tf` file in the VS Code editor.  
+The Microsoft Terraform extension will automatically detect the ARM template JSON and convert it to AzAPI configuration.
 
 ```hcl
 variable "subscriptionId" {
@@ -260,7 +260,7 @@ For example, the following is a resource JSON:
 }
 ```
 
-Copy the resource JSON and paste it in a `*.tf` file in the VSCode editor. The AzAPI VSCode extension will automatically detect the resource JSON and convert it to AzAPI configuration, it will remove the read-only fields and only keep the fields that can be modified.
+Copy the resource JSON and paste it in a `*.tf` file in the VS Code editor. The Microsoft Terraform extension will automatically detect the resource JSON and convert it to AzAPI configuration; it will remove the read-only fields and only keep the fields that can be modified.
 
 Here is the converted AzAPI configuration:
 ```hcl

--- a/docs/guides/feature_migrate_from_azurerm.md
+++ b/docs/guides/feature_migrate_from_azurerm.md
@@ -14,7 +14,7 @@ This guide is intended to help you migrate your existing AzureRM resources to Az
 ## Prerequisites
 
 - [Terraform](https://www.terraform.io/downloads.html) version 1.8.0 or later
-- [AzAPI VSCode extension](https://marketplace.visualstudio.com/items?itemName=azapi-vscode.azapi) version 2.1.0 or later
+- [Microsoft Terraform VS Code extension](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-azureterraform) (includes AzAPI features)
 - [Terraform AzAPI provider](https://registry.terraform.io/providers/azure/azapi) version 2.1.0 or later
 
 ## Migration Steps

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,7 @@ Documentation regarding the [Data Sources](/docs/configuration/data-sources.html
 
 Interested in the provider's latest features, or want to make sure you're up to date? Check out the [changelog](https://github.com/Azure/terraform-provider-azapi/blob/main/CHANGELOG.md) for version information and release notes.
 
-Strongly recommended to install [AzApi VSCode Extension](https://marketplace.visualstudio.com/items?itemName=azapi-vscode.azapi), it provides a rich authoring experience to help you use the AzApi provider.
+For VS Code authoring, install the [Microsoft Terraform extension](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-azureterraform) which now contains the former AzAPI extension features (the standalone AzAPI extension has been deprecated).
 
 Also, there is a rich library of [examples](https://github.com/Azure/terraform-provider-azapi/tree/main/examples) to help you get started.
 

--- a/templates/guides/feature_convert_arm_template.md
+++ b/templates/guides/feature_convert_arm_template.md
@@ -2,17 +2,17 @@
 layout: "azapi"
 page_title: "Feature: Convert ARM Template/Resource JSON to AzAPI Configuration"
 description: |-
-  This guide will cover how to use AzAPI VSCode extension to convert ARM template/resource JSON to AzAPI configuration.
+  This guide will cover how to use the Microsoft Terraform VS Code extension to convert ARM template/resource JSON to AzAPI configuration.
 
 ---
 
-The AzAPI VSCode extension provides a feature to convert ARM template/resource JSON to AzAPI configuration. This feature is useful when you have an existing ARM template or resource JSON and want to convert it to AzAPI configuration.
+The Microsoft Terraform VS Code extension (which now includes the former AzAPI extension features) provides a capability to convert ARM template/resource JSON to AzAPI configuration. This is useful when you have an existing ARM template or resource JSON and want to convert it to AzAPI configuration.
 
 This article covers how to use the feature to convert ARM template/resource JSON to AzAPI configuration.
 
 ## Prerequisites
 
-- [AzAPI VSCode extension](https://marketplace.visualstudio.com/items?itemName=azapi-vscode.azapi) version 2.0.1 or later
+- [Microsoft Terraform VS Code extension](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-azureterraform) (includes AzAPI features)
 - [Terraform AzAPI provider](https://registry.terraform.io/providers/azure/azapi) version 2.0.1 or later
 
 ## Convert ARM template to AzAPI configuration
@@ -110,8 +110,8 @@ A step-by-step guide on how to export the ARM template from the Azure portal can
 }
 ```
 
-3. Paste the ARM template JSON in a `*.tf` file in the VSCode editor.  
-The AzAPI VSCode extension will automatically detect the ARM template JSON and convert it to AzAPI configuration.
+3. Paste the ARM template JSON in a `*.tf` file in the VS Code editor.  
+The Microsoft Terraform extension will automatically detect the ARM template JSON and convert it to AzAPI configuration.
 
 ```hcl
 variable "subscriptionId" {
@@ -260,7 +260,7 @@ For example, the following is a resource JSON:
 }
 ```
 
-Copy the resource JSON and paste it in a `*.tf` file in the VSCode editor. The AzAPI VSCode extension will automatically detect the resource JSON and convert it to AzAPI configuration, it will remove the read-only fields and only keep the fields that can be modified.
+Copy the resource JSON and paste it in a `*.tf` file in the VS Code editor. The Microsoft Terraform extension will automatically detect the resource JSON and convert it to AzAPI configuration; it will remove the read-only fields and only keep the fields that can be modified.
 
 Here is the converted AzAPI configuration:
 ```hcl

--- a/templates/guides/feature_migrate_from_azurerm.md
+++ b/templates/guides/feature_migrate_from_azurerm.md
@@ -14,7 +14,7 @@ This guide is intended to help you migrate your existing AzureRM resources to Az
 ## Prerequisites
 
 - [Terraform](https://www.terraform.io/downloads.html) version 1.8.0 or later
-- [AzAPI VSCode extension](https://marketplace.visualstudio.com/items?itemName=azapi-vscode.azapi) version 2.1.0 or later
+- [Microsoft Terraform VS Code extension](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-azureterraform) (includes AzAPI features)
 - [Terraform AzAPI provider](https://registry.terraform.io/providers/azure/azapi) version 2.1.0 or later
 
 ## Migration Steps

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -13,7 +13,7 @@ Documentation regarding the [Data Sources](/docs/configuration/data-sources.html
 
 Interested in the provider's latest features, or want to make sure you're up to date? Check out the [changelog](https://github.com/Azure/terraform-provider-azapi/blob/main/CHANGELOG.md) for version information and release notes.
 
-Strongly recommended to install [AzApi VSCode Extension](https://marketplace.visualstudio.com/items?itemName=azapi-vscode.azapi), it provides a rich authoring experience to help you use the AzApi provider.
+For VS Code authoring, install the [Microsoft Terraform extension](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-azureterraform) which now contains the former AzAPI extension features (the standalone AzAPI extension has been deprecated).
 
 Also, there is a rich library of [examples](https://github.com/Azure/terraform-provider-azapi/tree/main/examples) to help you get started.
 


### PR DESCRIPTION
fixes https://github.com/Azure/terraform-provider-azapi/issues/958