### PR TITLE
Fix a regression issue when auth via MI

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Azure/terraform-provider-azapi
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.18.1
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.10.1
-	github.com/Azure/entrauth v0.0.0-20250717031544-5435286359f8
+	github.com/Azure/entrauth v0.0.0-20250819004238-dc2a3f58cbb7
 	github.com/go-git/go-git/v5 v5.14.0
 	github.com/google/go-cmp v0.7.0
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/Azure/azure-sdk-for-go/sdk/azidentity/cache v0.3.2 h1:yz1bePFlP5Vws5+
 github.com/Azure/azure-sdk-for-go/sdk/azidentity/cache v0.3.2/go.mod h1:Pa9ZNPuoNu/GztvBSKk9J1cDJW6vk/n0zLtV4mgd8N8=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.1 h1:FPKJS1T+clwv+OLGt13a8UjqeRuh0O4SJ3lUriThc+4=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.1/go.mod h1:j2chePtV91HrC22tGoRX3sGY42uF13WzmmV80/OdVAA=
-github.com/Azure/entrauth v0.0.0-20250717031544-5435286359f8 h1:3JWS3gsHVxJEFAed32hdSPaI57KGsZRcJgb8nukkD6Q=
-github.com/Azure/entrauth v0.0.0-20250717031544-5435286359f8/go.mod h1:jIg7TADab0IH1ZNyn6t7vd2W0n8yPPNu9iZwLrYMgSc=
+github.com/Azure/entrauth v0.0.0-20250819004238-dc2a3f58cbb7 h1:leAO67xPIXNUVo5cdk+kYGyO800wRbvrEkxSGh7lqL8=
+github.com/Azure/entrauth v0.0.0-20250819004238-dc2a3f58cbb7/go.mod h1:jIg7TADab0IH1ZNyn6t7vd2W0n8yPPNu9iZwLrYMgSc=
 github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1 h1:WJTmL004Abzc5wDB5VtZG2PJk5ndYDgVacGqfirKxjM=
 github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1/go.mod h1:tCcJZ0uHAmvjsVYzEFivsRTN00oz5BEsRgQHu5JZ9WE=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.4.2 h1:oygO0locgZJe7PpYPXT5A29ZkwJaPqcva7BVeemZOZs=

--- a/vendor/github.com/Azure/entrauth/aztfauth/aztfauth.go
+++ b/vendor/github.com/Azure/entrauth/aztfauth/aztfauth.go
@@ -264,10 +264,13 @@ func (opt Option) buildMSICredOpt() (entrauth.CredentialOption, error) {
 	if err != nil {
 		return nil, err
 	}
-	return entrauth.ManagedIdentityCredentialOption{
-		ID:            azidentity.ClientID(*clientId),
+	out := entrauth.ManagedIdentityCredentialOption{
 		ClientOptions: opt.ClientOptions,
-	}, nil
+	}
+	if *clientId != "" {
+		out.ID = azidentity.ClientID(*clientId)
+	}
+	return out, nil
 }
 
 func (opt Option) buildAzureCLICredOpt() (entrauth.CredentialOption, error) {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -36,7 +36,7 @@ github.com/Azure/azure-sdk-for-go/sdk/internal/log
 github.com/Azure/azure-sdk-for-go/sdk/internal/poller
 github.com/Azure/azure-sdk-for-go/sdk/internal/temporal
 github.com/Azure/azure-sdk-for-go/sdk/internal/uuid
-# github.com/Azure/entrauth v0.0.0-20250717031544-5435286359f8
+# github.com/Azure/entrauth v0.0.0-20250819004238-dc2a3f58cbb7
 ## explicit; go 1.24.1
 github.com/Azure/entrauth
 github.com/Azure/entrauth/aztfauth


### PR DESCRIPTION
Fix #962

## Test

Using the following terraform config:

```hcl
provider "azapi" {
  use_msi = true
  skip_provider_registration = false
}

data "azapi_client_config" "current" {}

data "azapi_resource" "example" {
  name      = "magodo-test"
  parent_id = "/subscriptions/${data.azapi_client_config.current.subscription_id}"
  type      = "Microsoft.Resources/resourceGroups@2020-06-01"
}
```

Running in a VM with a system assigned identity enabled:

```shell
$ export ARM_SUBSCRIPTION_ID=****
$ TF_LOG_PROVIDER=DEBUG terraform plan

...
[DEBUG] Aug 19 00:47:24.834673 Authentication: ManagedIdentityCredential.GetToken() acquired a token for scope "https://management.core.windows.net/" 
...
No changes. Your infrastructure matches the configuration.                                                                                                                                       
Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.
```