### PR TITLE
fix: retry regression in 2.5.0

### DIFF
--- a/internal/clients/options.go
+++ b/internal/clients/options.go
@@ -108,6 +108,16 @@ func NewRetryOptionsForReadAfterCreate() *policy.RetryOptions {
 		// Set a very high max retries to make sure context deadline is respected.
 		MaxRetries:  math.MaxInt16,
 		StatusCodes: statusCodes,
+		ShouldRetry: func(resp *http.Response, err error) bool {
+			// We need to test for status codes here too. This covers the case that these options are combined with
+			// retry options from NewRetryOptions, because the ShouldRetry function takes precedence over StatusCodes.
+			for _, code := range statusCodes {
+				if resp.StatusCode == code {
+					return true
+				}
+			}
+			return false
+		},
 	}
 }
 

--- a/internal/clients/options.go
+++ b/internal/clients/options.go
@@ -99,6 +99,7 @@ func CombineRetryOptions(opts ...*policy.RetryOptions) *policy.RetryOptions {
 
 // NewRetryOptionsForReadAfterCreate creates a RetryOptions for read-after-create operations.
 func NewRetryOptionsForReadAfterCreate() *policy.RetryOptions {
+	log.Printf("[DEBUG] Using custom retry configuration for read after create")
 	statusCodes := make([]int, 0)
 	statusCodes = append(statusCodes, DefaultRetryableStatusCodes...)
 	// Add default read after create values for the default retry configuration.
@@ -124,6 +125,13 @@ func NewRetryOptions(rtry retry.RetryValue) *policy.RetryOptions {
 		MaxRetries:  math.MaxInt16,
 		StatusCodes: DefaultRetryableStatusCodes,
 		ShouldRetry: func(resp *http.Response, err error) bool {
+			// We need to test for DefaultRetryableStatusCodes here as using ShouldRetry overrides the use of StatusCodes.
+			for _, code := range DefaultRetryableStatusCodes {
+				if resp.StatusCode == code {
+					return true
+				}
+			}
+
 			// Get the error message to check against regex patterns,
 			// If use the err.Error() string first, else get the response error from the HTTP response.
 			var errorMsg string

--- a/internal/clients/resource_client.go
+++ b/internal/clients/resource_client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 	"net/http"
 	"strings"
 	"time"
@@ -48,7 +49,16 @@ func (client *ResourceClient) CreateOrUpdate(ctx context.Context, resourceID str
 	// override the default retry options with the ones provided in the options
 	if options.RetryOptions != nil {
 		ctx = policy.WithRetryOptions(ctx, *options.RetryOptions)
+
+		log.Printf("[DEBUG] Retry configuration is custom: MaxRetries %d, RetryDelay %v, MaxRetryDelay %v, StatusCodes %v, ShouldRetryFunc %t",
+			options.RetryOptions.MaxRetries,
+			options.RetryOptions.RetryDelay,
+			options.RetryOptions.MaxRetryDelay,
+			options.RetryOptions.StatusCodes,
+			options.RetryOptions.ShouldRetry != nil,
+		)
 	}
+
 	urlPath := resourceID
 	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.host, urlPath))
 	if err != nil {
@@ -103,7 +113,15 @@ func (client *ResourceClient) Get(ctx context.Context, resourceID string, apiVer
 	// override the default retry options with the ones provided in the options
 	if options.RetryOptions != nil {
 		ctx = policy.WithRetryOptions(ctx, *options.RetryOptions)
+		log.Printf("[DEBUG] Retry configuration is custom: MaxRetries %d, RetryDelay %v, MaxRetryDelay %v, StatusCodes %v, ShouldRetryFunc %t",
+			options.RetryOptions.MaxRetries,
+			options.RetryOptions.RetryDelay,
+			options.RetryOptions.MaxRetryDelay,
+			options.RetryOptions.StatusCodes,
+			options.RetryOptions.ShouldRetry != nil,
+		)
 	}
+
 	urlPath := resourceID
 	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
 	if err != nil {
@@ -142,7 +160,15 @@ func (client *ResourceClient) Delete(ctx context.Context, resourceID string, api
 	// override the default retry options with the ones provided in the options
 	if options.RetryOptions != nil {
 		ctx = policy.WithRetryOptions(ctx, *options.RetryOptions)
+		log.Printf("[DEBUG] Retry configuration is custom: MaxRetries %d, RetryDelay %v, MaxRetryDelay %v, StatusCodes %v, ShouldRetryFunc %t",
+			options.RetryOptions.MaxRetries,
+			options.RetryOptions.RetryDelay,
+			options.RetryOptions.MaxRetryDelay,
+			options.RetryOptions.StatusCodes,
+			options.RetryOptions.ShouldRetry != nil,
+		)
 	}
+
 	urlPath := resourceID
 	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.host, urlPath))
 	if err != nil {
@@ -193,6 +219,13 @@ func (client *ResourceClient) Action(ctx context.Context, resourceID string, act
 	// override the default retry options with the ones provided in the options
 	if options.RetryOptions != nil {
 		ctx = policy.WithRetryOptions(ctx, *options.RetryOptions)
+		log.Printf("[DEBUG] Retry configuration is custom: MaxRetries %d, RetryDelay %v, MaxRetryDelay %v, StatusCodes %v, ShouldRetryFunc %t",
+			options.RetryOptions.MaxRetries,
+			options.RetryOptions.RetryDelay,
+			options.RetryOptions.MaxRetryDelay,
+			options.RetryOptions.StatusCodes,
+			options.RetryOptions.ShouldRetry != nil,
+		)
 	}
 	urlPath := resourceID
 	if action != "" {
@@ -266,7 +299,15 @@ func (client *ResourceClient) List(ctx context.Context, url string, apiVersion s
 	// override the default retry options with the ones provided in the options
 	if options.RetryOptions != nil {
 		ctx = policy.WithRetryOptions(ctx, *options.RetryOptions)
+		log.Printf("[DEBUG] Retry configuration is custom: MaxRetries %d, RetryDelay %v, MaxRetryDelay %v, StatusCodes %v, ShouldRetryFunc %t",
+			options.RetryOptions.MaxRetries,
+			options.RetryOptions.RetryDelay,
+			options.RetryOptions.MaxRetryDelay,
+			options.RetryOptions.StatusCodes,
+			options.RetryOptions.ShouldRetry != nil,
+		)
 	}
+
 	pager := runtime.NewPager(runtime.PagingHandler[interface{}]{
 		More: func(current interface{}) bool {
 			if current == nil {


### PR DESCRIPTION
Fixes #968

Hi @ms-henglu

AzAPI v2.5.0 introduced a regression in the retry logic that is causing issues with Azure Landing Zones deployments (we rely heavily on this feature).

The reason for the regression was the move from dedicated retry logic to using the SDK's ShouldRetry func. The adoption of ShouldRetry overrides the use of StatusCodes as a retry test.

This PR moves the status code checks into the ShouldRetry funcs so that they are always checked.

## Other considerations

In #970 I propose that we deprecate the [maximum_busy_retry_attempts](https://registry.terraform.io/providers/Azure/azapi/latest/docs#maximum_busy_retry_attempts-1) provider configuration and set this to `math.MaxInt16`. This move will simplify the provider configuration for callers and also revert to the context deadline, as it should.

