### PR TITLE
examples: add memberType for network manager network group; add routeTableUsageMode for routing configuration

### DIFF
--- a/docs/resources/Microsoft.Network_networkManagers_networkGroups.md
+++ b/docs/resources/Microsoft.Network_networkManagers_networkGroups.md
@@ -60,7 +60,7 @@ resource "azapi_resource" "resourceGroup" {
 }
 
 resource "azapi_resource" "networkManager" {
-  type      = "Microsoft.Network/networkManagers@2022-09-01"
+  type      = "Microsoft.Network/networkManagers@2024-10-01"
   parent_id = azapi_resource.resourceGroup.id
   name      = var.resource_name
   location  = var.location
@@ -68,7 +68,7 @@ resource "azapi_resource" "networkManager" {
     properties = {
       description = ""
       networkManagerScopeAccesses = [
-        "SecurityAdmin",
+        "Routing",
       ]
       networkManagerScopes = {
         managementGroups = [
@@ -84,17 +84,18 @@ resource "azapi_resource" "networkManager" {
 }
 
 resource "azapi_resource" "networkGroup" {
-  type      = "Microsoft.Network/networkManagers/networkGroups@2022-09-01"
+  type      = "Microsoft.Network/networkManagers/networkGroups@2024-10-01"
   parent_id = azapi_resource.networkManager.id
   name      = var.resource_name
   body = {
     properties = {
+      description = "example network group"
+      memberType  = "VirtualNetwork"
     }
   }
   schema_validation_enabled = false
   response_export_values    = ["*"]
 }
-
 
 ```
 

--- a/docs/resources/Microsoft.Network_networkManagers_networkGroups_staticMembers.md
+++ b/docs/resources/Microsoft.Network_networkManagers_networkGroups_staticMembers.md
@@ -60,7 +60,7 @@ resource "azapi_resource" "resourceGroup" {
 }
 
 resource "azapi_resource" "networkManager" {
-  type      = "Microsoft.Network/networkManagers@2022-09-01"
+  type      = "Microsoft.Network/networkManagers@2024-10-01"
   parent_id = azapi_resource.resourceGroup.id
   name      = var.resource_name
   location  = var.location
@@ -68,7 +68,7 @@ resource "azapi_resource" "networkManager" {
     properties = {
       description = ""
       networkManagerScopeAccesses = [
-        "SecurityAdmin",
+        "Routing",
       ]
       networkManagerScopes = {
         managementGroups = [
@@ -84,7 +84,7 @@ resource "azapi_resource" "networkManager" {
 }
 
 resource "azapi_resource" "virtualNetwork" {
-  type      = "Microsoft.Network/virtualNetworks@2022-07-01"
+  type      = "Microsoft.Network/virtualNetworks@2024-10-01"
   parent_id = azapi_resource.resourceGroup.id
   name      = var.resource_name
   location  = var.location
@@ -111,7 +111,7 @@ resource "azapi_resource" "virtualNetwork" {
 }
 
 resource "azapi_resource" "networkGroup" {
-  type      = "Microsoft.Network/networkManagers/networkGroups@2022-09-01"
+  type      = "Microsoft.Network/networkManagers/networkGroups@2024-10-01"
   parent_id = azapi_resource.networkManager.id
   name      = var.resource_name
   body = {
@@ -123,7 +123,7 @@ resource "azapi_resource" "networkGroup" {
 }
 
 resource "azapi_resource" "staticMember" {
-  type      = "Microsoft.Network/networkManagers/networkGroups/staticMembers@2022-09-01"
+  type      = "Microsoft.Network/networkManagers/networkGroups/staticMembers@2024-10-01"
   parent_id = azapi_resource.networkGroup.id
   name      = var.resource_name
   body = {
@@ -135,6 +135,47 @@ resource "azapi_resource" "staticMember" {
   response_export_values    = ["*"]
 }
 
+resource "azapi_resource" "subnet" {
+  type      = "Microsoft.Network/virtualNetworks/subnets@2024-10-01"
+  parent_id = azapi_resource.virtualNetwork.id
+  name      = var.resource_name
+  body = {
+    properties = {
+      addressPrefixes = [
+        "10.0.0.0/24"
+      ]
+    }
+  }
+  schema_validation_enabled = false
+  response_export_values    = ["*"]
+}
+
+resource "azapi_resource" "networkGroupForSubnet" {
+  type      = "Microsoft.Network/networkManagers/networkGroups@2024-10-01"
+  parent_id = azapi_resource.networkManager.id
+  name      = "${var.resource_name}-subnet"
+  body = {
+    properties = {
+      description = "example network group"
+      memberType  = "Subnet"
+    }
+  }
+  schema_validation_enabled = false
+  response_export_values    = ["*"]
+}
+
+resource "azapi_resource" "staticMemberForSubnet" {
+  type      = "Microsoft.Network/networkManagers/networkGroups/staticMembers@2024-10-01"
+  parent_id = azapi_resource.networkGroupForSubnet.id
+  name      = "${var.resource_name}-subnet"
+  body = {
+    properties = {
+      resourceId = azapi_resource.subnet.id
+    }
+  }
+  schema_validation_enabled = false
+  response_export_values    = ["*"]
+}
 
 ```
 

--- a/docs/resources/Microsoft.Network_networkManagers_routingConfigurations_ruleCollections_rules.md
+++ b/docs/resources/Microsoft.Network_networkManagers_routingConfigurations_ruleCollections_rules.md
@@ -51,7 +51,7 @@ resource "azapi_resource" "resourceGroup" {
 }
 
 resource "azapi_resource" "networkManager" {
-  type      = "Microsoft.Network/networkManagers@2024-05-01"
+  type      = "Microsoft.Network/networkManagers@2024-10-01"
   parent_id = azapi_resource.resourceGroup.id
   name      = var.resource_name
   location  = var.location
@@ -75,7 +75,7 @@ resource "azapi_resource" "networkManager" {
 }
 
 resource "azapi_resource" "networkGroup" {
-  type      = "Microsoft.Network/networkManagers/networkGroups@2024-05-01"
+  type      = "Microsoft.Network/networkManagers/networkGroups@2024-10-01"
   parent_id = azapi_resource.networkManager.id
   name      = var.resource_name
   body = {
@@ -87,7 +87,7 @@ resource "azapi_resource" "networkGroup" {
 }
 
 resource "azapi_resource" "virtualNetwork" {
-  type      = "Microsoft.Network/virtualNetworks@2024-05-01"
+  type      = "Microsoft.Network/virtualNetworks@2024-10-01"
   parent_id = azapi_resource.resourceGroup.id
   name      = var.resource_name
   location  = var.location
@@ -114,7 +114,7 @@ resource "azapi_resource" "virtualNetwork" {
 }
 
 resource "azapi_resource" "staticMember" {
-  type      = "Microsoft.Network/networkManagers/networkGroups/staticMembers@2024-05-01"
+  type      = "Microsoft.Network/networkManagers/networkGroups/staticMembers@2024-10-01"
   parent_id = azapi_resource.networkGroup.id
   name      = var.resource_name
   body = {
@@ -127,12 +127,13 @@ resource "azapi_resource" "staticMember" {
 }
 
 resource "azapi_resource" "routingConfiguration" {
-  type      = "Microsoft.Network/networkManagers/routingConfigurations@2024-05-01"
+  type      = "Microsoft.Network/networkManagers/routingConfigurations@2024-10-01"
   parent_id = azapi_resource.networkManager.id
   name      = var.resource_name
   body = {
     properties = {
-      description = "example routing configuration"
+      description         = "example routing configuration"
+      routeTableUsageMode = "UseExisting"
     }
   }
   schema_validation_enabled = false
@@ -140,7 +141,7 @@ resource "azapi_resource" "routingConfiguration" {
 }
 
 resource "azapi_resource" "ruleCollection" {
-  type      = "Microsoft.Network/networkManagers/routingConfigurations/ruleCollections@2024-05-01"
+  type      = "Microsoft.Network/networkManagers/routingConfigurations/ruleCollections@2024-10-01"
   parent_id = azapi_resource.routingConfiguration.id
   name      = var.resource_name
   body = {
@@ -158,7 +159,7 @@ resource "azapi_resource" "ruleCollection" {
 }
 
 resource "azapi_resource" "rule" {
-  type      = "Microsoft.Network/networkManagers/routingConfigurations/ruleCollections/rules@2024-05-01"
+  type      = "Microsoft.Network/networkManagers/routingConfigurations/ruleCollections/rules@2024-10-01"
   parent_id = azapi_resource.ruleCollection.id
   name      = var.resource_name
   body = {
@@ -184,7 +185,7 @@ resource "azapi_resource" "rule" {
 }
 
 resource "azapi_resource_action" "deploy" {
-  type        = "Microsoft.Network/networkManagers@2024-05-01"
+  type        = "Microsoft.Network/networkManagers@2024-10-01"
   action      = "commit"
   when        = "apply"
   resource_id = azapi_resource.networkManager.id
@@ -202,7 +203,7 @@ resource "azapi_resource_action" "deploy" {
 
 # this one is to remove the deployment when `terraform destroy` is called
 resource "azapi_resource_action" "undeploy" {
-  type        = "Microsoft.Network/networkManagers@2024-05-01"
+  type        = "Microsoft.Network/networkManagers@2024-10-01"
   action      = "commit"
   when        = "destroy"
   resource_id = azapi_resource.networkManager.id

--- a/examples/Microsoft.Network_networkManagers_networkGroups@2024-10-01/main.tf
+++ b/examples/Microsoft.Network_networkManagers_networkGroups@2024-10-01/main.tf
@@ -44,7 +44,7 @@ resource "azapi_resource" "resourceGroup" {
 }
 
 resource "azapi_resource" "networkManager" {
-  type      = "Microsoft.Network/networkManagers@2022-09-01"
+  type      = "Microsoft.Network/networkManagers@2024-10-01"
   parent_id = azapi_resource.resourceGroup.id
   name      = var.resource_name
   location  = var.location
@@ -52,7 +52,7 @@ resource "azapi_resource" "networkManager" {
     properties = {
       description = ""
       networkManagerScopeAccesses = [
-        "SecurityAdmin",
+        "Routing",
       ]
       networkManagerScopes = {
         managementGroups = [
@@ -68,14 +68,15 @@ resource "azapi_resource" "networkManager" {
 }
 
 resource "azapi_resource" "networkGroup" {
-  type      = "Microsoft.Network/networkManagers/networkGroups@2022-09-01"
+  type      = "Microsoft.Network/networkManagers/networkGroups@2024-10-01"
   parent_id = azapi_resource.networkManager.id
   name      = var.resource_name
   body = {
     properties = {
+      description = "example network group"
+      memberType  = "VirtualNetwork"
     }
   }
   schema_validation_enabled = false
   response_export_values    = ["*"]
 }
-

--- a/examples/Microsoft.Network_networkManagers_networkGroups_staticMembers@2024-10-01/main.tf
+++ b/examples/Microsoft.Network_networkManagers_networkGroups_staticMembers@2024-10-01/main.tf
@@ -44,7 +44,7 @@ resource "azapi_resource" "resourceGroup" {
 }
 
 resource "azapi_resource" "networkManager" {
-  type      = "Microsoft.Network/networkManagers@2022-09-01"
+  type      = "Microsoft.Network/networkManagers@2024-10-01"
   parent_id = azapi_resource.resourceGroup.id
   name      = var.resource_name
   location  = var.location
@@ -52,7 +52,7 @@ resource "azapi_resource" "networkManager" {
     properties = {
       description = ""
       networkManagerScopeAccesses = [
-        "SecurityAdmin",
+        "Routing",
       ]
       networkManagerScopes = {
         managementGroups = [
@@ -68,7 +68,7 @@ resource "azapi_resource" "networkManager" {
 }
 
 resource "azapi_resource" "virtualNetwork" {
-  type      = "Microsoft.Network/virtualNetworks@2022-07-01"
+  type      = "Microsoft.Network/virtualNetworks@2024-10-01"
   parent_id = azapi_resource.resourceGroup.id
   name      = var.resource_name
   location  = var.location
@@ -95,7 +95,7 @@ resource "azapi_resource" "virtualNetwork" {
 }
 
 resource "azapi_resource" "networkGroup" {
-  type      = "Microsoft.Network/networkManagers/networkGroups@2022-09-01"
+  type      = "Microsoft.Network/networkManagers/networkGroups@2024-10-01"
   parent_id = azapi_resource.networkManager.id
   name      = var.resource_name
   body = {
@@ -107,7 +107,7 @@ resource "azapi_resource" "networkGroup" {
 }
 
 resource "azapi_resource" "staticMember" {
-  type      = "Microsoft.Network/networkManagers/networkGroups/staticMembers@2022-09-01"
+  type      = "Microsoft.Network/networkManagers/networkGroups/staticMembers@2024-10-01"
   parent_id = azapi_resource.networkGroup.id
   name      = var.resource_name
   body = {
@@ -119,3 +119,44 @@ resource "azapi_resource" "staticMember" {
   response_export_values    = ["*"]
 }
 
+resource "azapi_resource" "subnet" {
+  type      = "Microsoft.Network/virtualNetworks/subnets@2024-10-01"
+  parent_id = azapi_resource.virtualNetwork.id
+  name      = var.resource_name
+  body = {
+    properties = {
+      addressPrefixes = [
+        "10.0.0.0/24"
+      ]
+    }
+  }
+  schema_validation_enabled = false
+  response_export_values    = ["*"]
+}
+
+resource "azapi_resource" "networkGroupForSubnet" {
+  type      = "Microsoft.Network/networkManagers/networkGroups@2024-10-01"
+  parent_id = azapi_resource.networkManager.id
+  name      = "${var.resource_name}-subnet"
+  body = {
+    properties = {
+      description = "example network group"
+      memberType  = "Subnet"
+    }
+  }
+  schema_validation_enabled = false
+  response_export_values    = ["*"]
+}
+
+resource "azapi_resource" "staticMemberForSubnet" {
+  type      = "Microsoft.Network/networkManagers/networkGroups/staticMembers@2024-10-01"
+  parent_id = azapi_resource.networkGroupForSubnet.id
+  name      = "${var.resource_name}-subnet"
+  body = {
+    properties = {
+      resourceId = azapi_resource.subnet.id
+    }
+  }
+  schema_validation_enabled = false
+  response_export_values    = ["*"]
+}

--- a/examples/Microsoft.Network_networkManagers_routingConfigurations_ruleCollections_rules@2024-10-01/main.tf
+++ b/examples/Microsoft.Network_networkManagers_routingConfigurations_ruleCollections_rules@2024-10-01/main.tf
@@ -35,7 +35,7 @@ resource "azapi_resource" "resourceGroup" {
 }
 
 resource "azapi_resource" "networkManager" {
-  type      = "Microsoft.Network/networkManagers@2024-05-01"
+  type      = "Microsoft.Network/networkManagers@2024-10-01"
   parent_id = azapi_resource.resourceGroup.id
   name      = var.resource_name
   location  = var.location
@@ -59,7 +59,7 @@ resource "azapi_resource" "networkManager" {
 }
 
 resource "azapi_resource" "networkGroup" {
-  type      = "Microsoft.Network/networkManagers/networkGroups@2024-05-01"
+  type      = "Microsoft.Network/networkManagers/networkGroups@2024-10-01"
   parent_id = azapi_resource.networkManager.id
   name      = var.resource_name
   body = {
@@ -71,7 +71,7 @@ resource "azapi_resource" "networkGroup" {
 }
 
 resource "azapi_resource" "virtualNetwork" {
-  type      = "Microsoft.Network/virtualNetworks@2024-05-01"
+  type      = "Microsoft.Network/virtualNetworks@2024-10-01"
   parent_id = azapi_resource.resourceGroup.id
   name      = var.resource_name
   location  = var.location
@@ -98,7 +98,7 @@ resource "azapi_resource" "virtualNetwork" {
 }
 
 resource "azapi_resource" "staticMember" {
-  type      = "Microsoft.Network/networkManagers/networkGroups/staticMembers@2024-05-01"
+  type      = "Microsoft.Network/networkManagers/networkGroups/staticMembers@2024-10-01"
   parent_id = azapi_resource.networkGroup.id
   name      = var.resource_name
   body = {
@@ -111,12 +111,13 @@ resource "azapi_resource" "staticMember" {
 }
 
 resource "azapi_resource" "routingConfiguration" {
-  type      = "Microsoft.Network/networkManagers/routingConfigurations@2024-05-01"
+  type      = "Microsoft.Network/networkManagers/routingConfigurations@2024-10-01"
   parent_id = azapi_resource.networkManager.id
   name      = var.resource_name
   body = {
     properties = {
-      description = "example routing configuration"
+      description         = "example routing configuration"
+      routeTableUsageMode = "UseExisting"
     }
   }
   schema_validation_enabled = false
@@ -124,7 +125,7 @@ resource "azapi_resource" "routingConfiguration" {
 }
 
 resource "azapi_resource" "ruleCollection" {
-  type      = "Microsoft.Network/networkManagers/routingConfigurations/ruleCollections@2024-05-01"
+  type      = "Microsoft.Network/networkManagers/routingConfigurations/ruleCollections@2024-10-01"
   parent_id = azapi_resource.routingConfiguration.id
   name      = var.resource_name
   body = {
@@ -142,7 +143,7 @@ resource "azapi_resource" "ruleCollection" {
 }
 
 resource "azapi_resource" "rule" {
-  type      = "Microsoft.Network/networkManagers/routingConfigurations/ruleCollections/rules@2024-05-01"
+  type      = "Microsoft.Network/networkManagers/routingConfigurations/ruleCollections/rules@2024-10-01"
   parent_id = azapi_resource.ruleCollection.id
   name      = var.resource_name
   body = {
@@ -168,7 +169,7 @@ resource "azapi_resource" "rule" {
 }
 
 resource "azapi_resource_action" "deploy" {
-  type        = "Microsoft.Network/networkManagers@2024-05-01"
+  type        = "Microsoft.Network/networkManagers@2024-10-01"
   action      = "commit"
   when        = "apply"
   resource_id = azapi_resource.networkManager.id
@@ -186,7 +187,7 @@ resource "azapi_resource_action" "deploy" {
 
 # this one is to remove the deployment when `terraform destroy` is called
 resource "azapi_resource_action" "undeploy" {
-  type        = "Microsoft.Network/networkManagers@2024-05-01"
+  type        = "Microsoft.Network/networkManagers@2024-10-01"
   action      = "commit"
   when        = "destroy"
   resource_id = azapi_resource.networkManager.id


### PR DESCRIPTION
```sh
-> % make example-test TARGET=Microsoft.Network_networkManagers_networkGroups@2024-10-01,Microsoft.Network_networkManagers_networkGroups_staticMembers@2024-10-01,Microsoft.Network_networkManagers_routingConfigurations_ruleCollections_rules@2024-10-01
TF_ACC=1 ARM_TEST_EXAMPLES=Microsoft.Network_networkManagers_networkGroups@2024-10-01,Microsoft.Network_networkManagers_networkGroups_staticMembers@2024-10-01,Microsoft.Network_networkManagers_routingConfigurations_ruleCollections_rules@2024-10-01 go test -v ./internal/services/... -run TestAccExamples_Selected -timeout 300m -ldflags="-X=github.com/Azure/terraform-provider-azapi/version.ProviderVersion=acc"
=== RUN   TestAccExamples_Selected
    azapi_resource_example_test.go:56: Found 3 testcases
=== RUN   TestAccExamples_Selected/../../examples/Microsoft.Network_networkManagers_networkGroups@2024-10-01/main.tf
=== PAUSE TestAccExamples_Selected/../../examples/Microsoft.Network_networkManagers_networkGroups@2024-10-01/main.tf
=== RUN   TestAccExamples_Selected/../../examples/Microsoft.Network_networkManagers_networkGroups_staticMembers@2024-10-01/main.tf
=== PAUSE TestAccExamples_Selected/../../examples/Microsoft.Network_networkManagers_networkGroups_staticMembers@2024-10-01/main.tf
=== RUN   TestAccExamples_Selected/../../examples/Microsoft.Network_networkManagers_routingConfigurations_ruleCollections_rules@2024-10-01/main.tf
=== PAUSE TestAccExamples_Selected/../../examples/Microsoft.Network_networkManagers_routingConfigurations_ruleCollections_rules@2024-10-01/main.tf
=== CONT  TestAccExamples_Selected/../../examples/Microsoft.Network_networkManagers_networkGroups@2024-10-01/main.tf
=== CONT  TestAccExamples_Selected/../../examples/Microsoft.Network_networkManagers_routingConfigurations_ruleCollections_rules@2024-10-01/main.tf
=== CONT  TestAccExamples_Selected/../../examples/Microsoft.Network_networkManagers_networkGroups_staticMembers@2024-10-01/main.tf
--- PASS: TestAccExamples_Selected (0.01s)
    --- PASS: TestAccExamples_Selected/../../examples/Microsoft.Network_networkManagers_networkGroups@2024-10-01/main.tf (72.91s)
    --- PASS: TestAccExamples_Selected/../../examples/Microsoft.Network_networkManagers_routingConfigurations_ruleCollections_rules@2024-10-01/main.tf (74.36s)
    --- PASS: TestAccExamples_Selected/../../examples/Microsoft.Network_networkManagers_networkGroups_staticMembers@2024-10-01/main.tf (124.99s)
PASS
ok      github.com/Azure/terraform-provider-azapi/internal/services     125.032s
?       github.com/Azure/terraform-provider-azapi/internal/services/common      [no test files]
?       github.com/Azure/terraform-provider-azapi/internal/services/defaults    [no test files]
testing: warning: no tests to run
PASS
ok      github.com/Azure/terraform-provider-azapi/internal/services/dynamic     (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/Azure/terraform-provider-azapi/internal/services/functions   (cached) [no tests to run]
?       github.com/Azure/terraform-provider-azapi/internal/services/migration   [no test files]
?       github.com/Azure/terraform-provider-azapi/internal/services/myplanmodifier      [no test files]
testing: warning: no tests to run
PASS
ok      github.com/Azure/terraform-provider-azapi/internal/services/myplanmodifier/planmodifierdynamic  (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/Azure/terraform-provider-azapi/internal/services/myvalidator (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/Azure/terraform-provider-azapi/internal/services/parse       (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/Azure/terraform-provider-azapi/internal/services/preflight   (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/Azure/terraform-provider-azapi/internal/services/validate    (cached) [no tests to run]
```