### PR TITLE
bugfix: specified subscription ID should not be overridden by Azure CLI default subscription ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ ENHANCEMENTS:
 - Add documentation for choosing the resource type.
 
 BUG FIXES:
+- `azapi_client_config` data source: Fix a bug that specified subscription ID should not be overridden by Azure CLI default subscription ID.
 - `azapi_resource` resource: Support moving from `azurerm_storage_container` whose `id` is a data-plane URL by leveraging the `resource_manager_id` attribute (GH-955).
 - `azapi_resource` resource: Support moving from `azurerm_key_vault_secret` whose `id` is a data-plane URL by leveraging the `resource_versionless_id` attribute (GH-917).
 - `azapi_resource` resource: Support moving from `azurerm_key_vault_key` whose `id` is a data-plane URL by leveraging the `resource_versionless_id` attribute.

--- a/internal/clients/account.go
+++ b/internal/clients/account.go
@@ -138,8 +138,13 @@ func (account *ResourceManagerAccount) loadDefaultsFromAzCmd() error {
 		return fmt.Errorf("obtaining defaults from az cmd: %s", err)
 	}
 
-	account.tenantId = &accountModel.TenantId
-	account.subscriptionId = &accountModel.SubscriptionID
+	// Only set values that are currently nil (not already configured)
+	if account.tenantId == nil {
+		account.tenantId = &accountModel.TenantId
+	}
+	if account.subscriptionId == nil {
+		account.subscriptionId = &accountModel.SubscriptionID
+	}
 	return nil
 }
 


### PR DESCRIPTION
fixes https://github.com/Azure/terraform-provider-azapi/issues/963
fixes https://github.com/Azure/terraform-provider-azapi/issues/981

When use Azure CLI authentication and specify a subscription ID in the `azapi` provider block, the specified subscription ID will be overridden by the subscription ID read from azure cli.