### PR TITLE
Bump Go version to 1.24.6 to address CVEs

### DIFF
--- a/.azdo/ado-oidc-pipeline.yml
+++ b/.azdo/ado-oidc-pipeline.yml
@@ -5,7 +5,7 @@ steps:
   - task: GoTool@0
     displayName: "Install correct version of Go"
     inputs:
-      version: '1.24.2'
+      version: '1.24.6'
       GOPATH: "$(Pipeline.Workspace)/gopath"
       GOBIN: "$(GOPATH)/bin"
   

--- a/.azdo/build-pipeline.yml
+++ b/.azdo/build-pipeline.yml
@@ -17,7 +17,7 @@ jobs:
     name: pool-ubuntu-2404
 
   variables:
-    goVersion: 1.24.2
+    goVersion: 1.24.6
     GOBIN:  '$(GOPATH)/bin' # Go binaries path
     GOROOT: '/usr/local/go' # Go installation path
     GOPATH: '$(system.defaultWorkingDirectory)/gopath' # Go workspace path

--- a/.azdo/build-release-pipeline.yml
+++ b/.azdo/build-release-pipeline.yml
@@ -61,7 +61,7 @@ stages:
           - task: GoTool@0
             displayName: "Install Go"
             inputs:
-              version: 1.24.2
+              version: 1.24.6
           - script: |
               set -e
               mkdir build

--- a/.azdo/nightly-test-pipeline.yml
+++ b/.azdo/nightly-test-pipeline.yml
@@ -11,8 +11,8 @@ jobs:
       maxParallel: 1 # any more and we get throttled by AzDO!
       accTest: true
       goVersions:
-        - value: '1.24.2'
-          ymlSafeName: '1_24_2'
+        - value: '1.24.6'
+          ymlSafeName: '1_24_6'
 
       vmImages:
         - value: 'ubuntu-20.04'

--- a/go.mod
+++ b/go.mod
@@ -111,4 +111,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-go 1.24.2
+go 1.24.6


### PR DESCRIPTION
Fixes #991

This PR updates the Go version from 1.24.2 to 1.24.6 across all configuration files to address several security vulnerabilities:
- CVE-2025-22874
- CVE-2025-4674
- CVE-2025-47907

## Changes Made
- Updated `go.mod` to use Go 1.24.6
- Updated `.azdo/build-pipeline.yml` to use Go 1.24.6
- Updated `.azdo/build-release-pipeline.yml` to use Go 1.24.6
- Updated `.azdo/nightly-test-pipeline.yml` to use Go 1.24.6 (also updated ymlSafeName from 1_24_2 to 1_24_6)
- Updated `.azdo/ado-oidc-pipeline.yml` to use Go 1.24.6