### PR TITLE
Add Azure Government support for KeyVault endpoint

### DIFF
--- a/internal/provider/environments.go
+++ b/internal/provider/environments.go
@@ -33,6 +33,10 @@ func init() {
 		Audience: "https://vault.azure.net",
 		Endpoint: "https://vault.azure.net",
 	}
+	cloud.AzureGovernment.Services[KeyVault] = cloud.ServiceConfiguration{
+		Audience: "https://vault.usgovcloudapi.net",
+		Endpoint: "https://vault.usgovcloudapi.net",
+	}
 	cloud.AzurePublic.Services[Purview] = cloud.ServiceConfiguration{
 		Audience: "https://purview.azure.net",
 		Endpoint: "https://purview.azure.com",


### PR DESCRIPTION
azapi_data_plane_resource cannot hit the proper endpoint without a provider endpoint override. This adds support for Azure Government to hit the proper KeyVault endpoint without using a provider configuration. 


`provider "azapi" {
  endpoint = [{
    resource_manager_audience = "https://vault.usgovcloudapi.net" # Required to hit the data plane endpoints
   }]
}
`