### PR TITLE
fix(utils): incorrect JSON merge behavior when new value is nil

### DIFF
--- a/utils/json.go
+++ b/utils/json.go
@@ -26,7 +26,7 @@ func NormalizeJson(jsonString interface{}) string {
 // MergeObject is used to merge object old and new, if overlaps, use new value
 func MergeObject(old interface{}, new interface{}) interface{} {
 	if new == nil {
-		return new
+		return old
 	}
 	switch oldValue := old.(type) {
 	case map[string]interface{}:

--- a/utils/json_test.go
+++ b/utils/json_test.go
@@ -432,7 +432,7 @@ func Test_MergeObject(t *testing.T) {
 	}{
 		{
 			Name: "Merge simple objects",
-			OldJson: ` 
+			OldJson: `
 {
 	"a":1,
     "b": {
@@ -720,6 +720,20 @@ func Test_ExtractObject(t *testing.T) {
 	if result != nil {
 		resultJson, _ := json.Marshal(result)
 		t.Fatalf("Expected nil but got %s", resultJson)
+	}
+}
+
+func Test_MergeObjectWithNilNewValue(t *testing.T) {
+	var new any // has nil value
+	old := map[string]any{
+		"a": 1,
+		"b": map[string]any{
+			"b1": "b1",
+		},
+	}
+	got := utils.MergeObject(old, new)
+	if !reflect.DeepEqual(old, got) {
+		t.Fatalf("Expected %v but got %v", old, got)
 	}
 }
 


### PR DESCRIPTION
fixes #999

Hi @ms-henglu 

This bug was always present but masked when callers did not specify `sensitive_body`.

### Why was this not picked up before?

When sensitive body & sensitive body are not specified, the call to `unmarshalSensitiveBody()` returns an `any` value with an underlying concrete type of `map[string]any`. Critically this value does not pass a nil equality test.

https://github.com/Azure/terraform-provider-azapi/blob/ec2098dbb4a72e6e6ac8559f83cbb7f4aea52045/internal/services/azapi_resource.go#L737

When this value is passed into `MergeObject()`, this test is `false` and the function returns the old value unmodified (as the new value is not nil, but is empty).

https://github.com/Azure/terraform-provider-azapi/blob/ec2098dbb4a72e6e6ac8559f83cbb7f4aea52045/utils/json.go#L27-L30

#### Debug output

<img width="285" height="72" alt="image" src="https://github.com/user-attachments/assets/64d88bec-cd8a-4bc1-ba04-fcc9f0060fd2" />


### What happens when a caller specified `sensitive_body`

In the case of #999, the caller was calling the module with conditions in the sensitive body, meaning that the input was a dynamic object with null values for a password attribute.

This means that `unmarshalSebsitiveBody()` returned a true `nil` value, therefore in `MergeObject()`, the nil equality test passed and nil was returned.

#### Debug output

<img width="156" height="72" alt="image" src="https://github.com/user-attachments/assets/fee9e907-e9d3-4f6a-873c-932dcbdf6ffa" />

This then failed the interface conversion here and caused a panic:

https://github.com/Azure/terraform-provider-azapi/blob/ec2098dbb4a72e6e6ac8559f83cbb7f4aea52045/internal/services/azapi_resource.go#L742
