### PR TITLE
Update CHANGELOG for v2.8.0 and suppress G304 gosec warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## v2.8.0 (Unreleased)
 
+FEATURES:
+- **New Provider Function**: snake2camel
+
 ENHANCEMENTS:
 - `azapi_data_plane_resource` resource: Adds a customization layer which allows custom CRUD operations for resources that don't follow standard patterns. 
 - `azapi_data_plane_resource` resource: Support `Microsoft.KeyVault/vaults/keys` type.
@@ -8,7 +11,12 @@ ENHANCEMENTS:
 - `azapi_data_plane_resource` resource: Support `Microsoft.Search/searchServices/indexers` type.
 - `azapi_data_plane_resource` resource: Support `Microsoft.Search/searchServices/indexes` type.
 - `azapi_data_plane_resource` resource: Support `Microsoft.Search/searchServices/skillsets` type.
-- `azapi_data_plane_resource` resource: Support `Microsoft.Search/searchServices/synonymmaps` type. 
+- `azapi_data_plane_resource` resource: Support `Microsoft.Search/searchServices/synonymmaps` type.
+- Bump Go version to 1.24.6 to address CVEs (GH-992).
+- Add more verified `azapi` examples.
+
+BUG FIXES:
+- Fix panic when using `sensitive_body_version` with empty `sensitive_body` (GH-999). 
 
 ## v2.7.0
 

--- a/tools/generator-example-doc/main.go
+++ b/tools/generator-example-doc/main.go
@@ -221,6 +221,7 @@ func generateDocumentation(inputDir string) (string, error) {
 	// Read remarks.md if it exists (optional file)
 	remarksPath := path.Join(inputDir, "remarks.md")
 	remarks := ""
+	// #nosec G304 - remarksPath is constructed from controlled directory path
 	if remarksContent, err := os.ReadFile(remarksPath); err == nil {
 		remarks = strings.TrimSpace(string(remarksContent))
 	}

--- a/tools/sync-reference-doc/main.go
+++ b/tools/sync-reference-doc/main.go
@@ -148,6 +148,7 @@ func main() {
 		// Read optional remarks.md file from the resource folder
 		remarksPath := filepath.Join(resDir, "remarks.md")
 		remarksContent := ""
+		// #nosec G304 - remarksPath is constructed from controlled directory path
 		if remarksData, err := os.ReadFile(remarksPath); err == nil {
 			remarksContent = stripMarkdown(strings.TrimSpace(string(remarksData)))
 		}


### PR DESCRIPTION
## Description

This PR updates the CHANGELOG for the v2.8.0 release and suppresses gosec G304 warnings in the documentation generation tools.

## Changes

### CHANGELOG.md
- Added **FEATURES** section with new `snake2camel` provider function
- Added Go version bump to 1.24.6 (addresses CVEs) in **ENHANCEMENTS**
- Added more verified azapi examples in **ENHANCEMENTS**
- Added **BUG FIXES** section with fix for panic when using `sensitive_body_version` with empty `sensitive_body`

### Gosec Suppressions
- Suppressed G304 warnings in `tools/sync-reference-doc/main.go`
- Suppressed G304 warnings in `tools/generator-example-doc/main.go`
- Both suppressions are valid as the file paths are constructed from controlled directory paths

## Related Issues
- Fixes #999 (sensitive_body_version panic)
- Addresses CVE fixes with Go 1.24.6 bump (#992)