### PR TITLE
Update data plane resource tests to use azurerm provider

### DIFF
--- a/internal/services/azapi_data_plane_resource_test.go
+++ b/internal/services/azapi_data_plane_resource_test.go
@@ -22,7 +22,8 @@ func TestAccDataPlaneResource_appConfigKeyValues(t *testing.T) {
 
 	data.ResourceTest(t, r, []resource.TestStep{
 		{
-			Config: r.appConfigKeyValues(data),
+			Config:            r.appConfigKeyValues(data),
+			ExternalProviders: externalProvidersAzurerm(),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -64,7 +65,8 @@ func TestAccDataPlaneResource_keyVaultIssuer(t *testing.T) {
 
 	data.ResourceTest(t, r, []resource.TestStep{
 		{
-			Config: r.keyVaultIssuer(data),
+			Config:            r.keyVaultIssuer(data),
+			ExternalProviders: externalProvidersAzurerm(),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -112,7 +114,8 @@ func TestAccDataPlaneResource_timeouts(t *testing.T) {
 
 	data.ResourceTest(t, r, []resource.TestStep{
 		{
-			Config: r.timeouts(data),
+			Config:            r.timeouts(data),
+			ExternalProviders: externalProvidersAzurerm(),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),


### PR DESCRIPTION
- Migrated test configurations from azapi_resource to azurerm provider resources
- Updated app configuration tests to use azurerm_resource_group and azurerm_app_configuration
- Simplified role assignment setup using azurerm_role_assignment
- Updated Key Vault tests to use azurerm_client_config instead of azapi_client_config
- Fixed IoT Apps test to properly reference properties.subdomain
- Added ExternalProviders configuration for tests that require azurerm provider