### PR TITLE
Fix import state null identity handling

### DIFF
--- a/internal/services/azapi_resource.go
+++ b/internal/services/azapi_resource.go
@@ -1155,7 +1155,7 @@ func (r *AzapiResource) ImportState(ctx context.Context, request resource.Import
 	var err error
 
 	// Case 1: Traditional ID-based import using request.ID
-	if request.Identity == nil {
+	if request.Identity == nil || request.Identity.Raw.IsNull() {
 		tflog.Debug(ctx, fmt.Sprintf("Importing Resource - parsing %q", request.ID))
 		id, err = parse.ResourceID(request.ID)
 		if err != nil {


### PR DESCRIPTION
## Description

This PR fixes a bug in the  function where importing resources was failing with a "Value Conversion Error" when the Identity field was present but null.

## Problem

The test  was failing during the import step with:


## Root Cause

The check `request.Identity == nil` was insufficient because during standard imports, `request.Identity` could be a non-nil pointer with a null `Raw` value. When the code attempted to call `request.Identity.Get(ctx, &identityData)` on a null identity, it failed because `AzapiResourceIdentityModel` is a non-pointer struct type that cannot handle null values.

## Solution

Added an additional check `request.Identity.Raw.IsNull()` alongside the existing nil check. This properly handles both cases:
1. Traditional imports where `request.Identity` is nil
2. Identity-based imports where `request.Identity` is not nil but contains a null value

## Testing

- Fixes the failing `TestAccGenericResource_extensionScope` test
- No changes to existing functionality for identity-based imports

## Changes

- `internal/services/azapi_resource.go`: Updated the condition in `ImportState` method from `request.Identity == nil` to `request.Identity == nil || request.Identity.Raw.IsNull()`