### PR TITLE
bugfix: azapi_data_plane_resource doesn't support 204 status code

### DIFF
--- a/internal/clients/data_plane_client.go
+++ b/internal/clients/data_plane_client.go
@@ -104,7 +104,7 @@ func (client *DataPlaneClient) CreateOrUpdateThenPoll(ctx context.Context, id pa
 	if err != nil {
 		return nil, err
 	}
-	if !runtime.HasStatusCode(resp, http.StatusOK, http.StatusCreated, http.StatusAccepted) {
+	if !runtime.HasStatusCode(resp, http.StatusOK, http.StatusCreated, http.StatusAccepted, http.StatusNoContent) {
 		return nil, runtime.NewResponseError(resp)
 	}
 


### PR DESCRIPTION
fix https://github.com/Azure/terraform-provider-azapi/issues/1048

Fix the issue when UPSERTING a dataplane resource when the resource already exists. In this case the API answers with a 204 instead of a 200/201.

```
╷
│ Error: Failed to create/update resource
│ 
│   with azapi_data_plane_resource.works_council_index,
│   on rag.tf line 20, in resource "azapi_data_plane_resource" "rag_index":
│   20: resource "azapi_data_plane_resource" "rag_index" {
│ 
│ creating/updating "Resource: (ResourceId \"rag-westeurope.search.windows.net/indexes('rag-index')\" / Api Version \"2025-09-01\")": PUT
│ https://rag-westeurope.search.windows.net/indexes('rag-index')
│ --------------------------------------------------------------------------------
│ RESPONSE 204: 204 No Content
│ ERROR CODE UNAVAILABLE
│ --------------------------------------------------------------------------------
│ Response contained no body
│ --------------------------------------------------------------------------------
│
```

This implements the same bugfix as https://github.com/Azure/terraform-provider-azapi/pull/441