### PR TITLE
feat: add resource_group_id to parse_resource_id function

### DIFF
--- a/docs/functions/parse_resource_id.md
+++ b/docs/functions/parse_resource_id.md
@@ -30,6 +30,7 @@ locals {
 #     "virtualNetworks" = "myVNet"
 #   })
 #   "provider_namespace" = "Microsoft.Network"
+#   "resource_group_id" = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup"
 #   "resource_group_name" = "myResourceGroup"
 #   "subscription_id" = "00000000-0000-0000-0000-000000000000"
 #   "type" = "Microsoft.Network/virtualNetworks"

--- a/docs/guides/2.0-upgrade-guide.md
+++ b/docs/guides/2.0-upgrade-guide.md
@@ -150,6 +150,7 @@ output "resource_id" {
 #     "virtualNetworks" = "myVNet"
 #   })
 #   "provider_namespace" = "Microsoft.Network"
+#   "resource_group_id" = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup"
 #   "resource_group_name" = "myResourceGroup"
 #   "subscription_id" = "00000000-0000-0000-0000-000000000000"
 #   "type" = "Microsoft.Network/virtualNetworks"

--- a/examples/functions/parse_resource_id/function.tf
+++ b/examples/functions/parse_resource_id/function.tf
@@ -15,6 +15,7 @@ locals {
 #     "virtualNetworks" = "myVNet"
 #   })
 #   "provider_namespace" = "Microsoft.Network"
+#   "resource_group_id" = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup"
 #   "resource_group_name" = "myResourceGroup"
 #   "subscription_id" = "00000000-0000-0000-0000-000000000000"
 #   "type" = "Microsoft.Network/virtualNetworks"

--- a/internal/services/functions/parse_resource_id_function.go
+++ b/internal/services/functions/parse_resource_id_function.go
@@ -23,6 +23,7 @@ var ParseResourceIdResultAttrTypes = map[string]attr.Type{
 	"name":                types.StringType,
 	"parent_id":           types.StringType,
 	"resource_group_name": types.StringType,
+	"resource_group_id":   types.StringType,
 	"subscription_id":     types.StringType,
 	"provider_namespace":  types.StringType,
 	"parts": types.MapType{
@@ -98,12 +99,18 @@ func (p *ParseResourceIdFunction) Run(ctx context.Context, request function.RunR
 		parts[components[i]] = basetypes.NewStringValue(components[i+1])
 	}
 
+	resourceGroupId := ""
+	if armId.ResourceGroupName != "" {
+		resourceGroupId = fmt.Sprintf("/subscriptions/%s/resourceGroups/%s", armId.SubscriptionID, armId.ResourceGroupName)
+	}
+
 	result := map[string]attr.Value{
 		"id":                  types.StringValue(id.ID()),
 		"type":                types.StringValue(id.AzureResourceType),
 		"name":                types.StringValue(id.Name),
 		"parent_id":           types.StringValue(id.ParentId),
 		"resource_group_name": types.StringValue(armId.ResourceGroupName),
+		"resource_group_id":   types.StringValue(resourceGroupId),
 		"subscription_id":     types.StringValue(armId.SubscriptionID),
 		"provider_namespace":  types.StringValue(armId.ResourceType.Namespace),
 		"parts":               types.MapValueMust(types.StringType, parts),

--- a/internal/services/functions/parse_resource_id_function_test.go
+++ b/internal/services/functions/parse_resource_id_function_test.go
@@ -31,6 +31,7 @@ func TestParseResourceIdFunction(t *testing.T) {
 					"name":                types.StringValue("vnet1"),
 					"parent_id":           types.StringValue("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1"),
 					"resource_group_name": types.StringValue("rg1"),
+					"resource_group_id":   types.StringValue("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1"),
 					"subscription_id":     types.StringValue("00000000-0000-0000-0000-000000000000"),
 					"provider_namespace":  types.StringValue("Microsoft.Network"),
 					"parts": types.MapValueMust(types.StringType, map[string]attr.Value{
@@ -56,6 +57,7 @@ func TestParseResourceIdFunction(t *testing.T) {
 					"name":                types.StringValue("ba1"),
 					"parent_id":           types.StringValue("/"),
 					"resource_group_name": types.StringValue(""),
+					"resource_group_id":   types.StringValue(""),
 					"subscription_id":     types.StringValue(""),
 					"provider_namespace":  types.StringValue("Microsoft.Billing"),
 					"parts": types.MapValueMust(types.StringType, map[string]attr.Value{
@@ -79,6 +81,7 @@ func TestParseResourceIdFunction(t *testing.T) {
 					"name":                types.StringValue("00000000-0000-0000-0000-000000000000"),
 					"parent_id":           types.StringValue("/"),
 					"resource_group_name": types.StringValue(""),
+					"resource_group_id":   types.StringValue(""),
 					"subscription_id":     types.StringValue("00000000-0000-0000-0000-000000000000"),
 					"provider_namespace":  types.StringValue("Microsoft.Resources"),
 					"parts": types.MapValueMust(types.StringType, map[string]attr.Value{
@@ -101,6 +104,7 @@ func TestParseResourceIdFunction(t *testing.T) {
 					"name":                types.StringValue("mg1"),
 					"parent_id":           types.StringValue("/"),
 					"resource_group_name": types.StringValue(""),
+					"resource_group_id":   types.StringValue(""),
 					"subscription_id":     types.StringValue(""),
 					"provider_namespace":  types.StringValue("Microsoft.Management"),
 					"parts": types.MapValueMust(types.StringType, map[string]attr.Value{
@@ -124,6 +128,7 @@ func TestParseResourceIdFunction(t *testing.T) {
 					"name":                types.StringValue("mylock"),
 					"parent_id":           types.StringValue("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/vnet1"),
 					"resource_group_name": types.StringValue("rg1"),
+					"resource_group_id":   types.StringValue("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1"),
 					"subscription_id":     types.StringValue("00000000-0000-0000-0000-000000000000"),
 					"provider_namespace":  types.StringValue("Microsoft.Authorization"),
 					"parts": types.MapValueMust(types.StringType, map[string]attr.Value{

--- a/templates/guides/2.0-upgrade-guide.md
+++ b/templates/guides/2.0-upgrade-guide.md
@@ -150,6 +150,7 @@ output "resource_id" {
 #     "virtualNetworks" = "myVNet"
 #   })
 #   "provider_namespace" = "Microsoft.Network"
+#   "resource_group_id" = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup"
 #   "resource_group_name" = "myResourceGroup"
 #   "subscription_id" = "00000000-0000-0000-0000-000000000000"
 #   "type" = "Microsoft.Network/virtualNetworks"


### PR DESCRIPTION
## Summary

- Adds `resource_group_id` to the object returned by the `parse_resource_id` provider function
- Returns the full ARM resource group ID (`/subscriptions/{id}/resourceGroups/{name}`) when the resource has a resource group, and `""` otherwise (consistent with existing `resource_group_name` behavior)
- Updated all example output comments in docs, templates, and examples to include the new field
- All existing unit tests updated and passing

## Test plan

- [x] Unit tests pass: `go test ./internal/services/functions/... -run TestParseResourceIdFunction`
- [x] Verified locally with `terraform plan` using dev override — `resource_group_id` appears correctly for resource group-scoped resources and is empty for subscription/tenant-scoped resources

🤖 Generated with [Claude Code](https://claude.com/claude-code)