### PR TITLE
fix: RequiresReplaceIfNotNull handles typed null from HCL conditional expressions

### DIFF
--- a/internal/services/myplanmodifier/planmodifierdynamic/dynamic_requires_replace.go
+++ b/internal/services/myplanmodifier/planmodifierdynamic/dynamic_requires_replace.go
@@ -23,17 +23,21 @@ func RequiresReplace() planmodifier.Dynamic {
 
 // RequiresReplaceIfNotNull is a plan modifier that sets RequiresReplace
 // on the attribute if the planned value is different from the state value.
-// It will not trigger replacement when either the planned or state value is null.
+// It will not trigger replacement when either the planned or state value is effectively null.
+// A Dynamic attribute can be null in two ways:
+//  1. The outer Dynamic wrapper is null (e.g., types.DynamicNull())
+//  2. The outer Dynamic is "known" but wraps a null underlying value
+//     (e.g., types.DynamicValue(TupleNull())) — this happens when HCL evaluates
+//     a conditional like `condition ? [...] : null` for a DynamicAttribute.
+//
 // When this function is called, the equality of the planned and state values
 // has already been checked by the PlanModifyDynamic method, so we can assume they are different values.
 func RequiresReplaceIfNotNull() planmodifier.Dynamic {
 	return RequiresReplaceIf(
 		func(_ context.Context, req planmodifier.DynamicRequest, resp *RequiresReplaceIfFuncResponse) {
-			if req.PlanValue.IsNull() || req.StateValue.IsNull() {
-				resp.RequiresReplace = false
-				return
-			}
-			resp.RequiresReplace = true
+			planNull := req.PlanValue.IsNull() || req.PlanValue.UnderlyingValue().IsNull()
+			stateNull := req.StateValue.IsNull() || req.StateValue.UnderlyingValue().IsNull()
+			resp.RequiresReplace = !planNull && !stateNull
 		},
 		"If the planned value is different from the state value, Terraform will destroy and recreate the resource unless either the planned or state value is null.",
 		"If the planned value is different from the state value, Terraform will destroy and recreate the resource unless either the planned or state value is null.",

--- a/internal/services/myplanmodifier/planmodifierdynamic/dynamic_requires_replace_test.go
+++ b/internal/services/myplanmodifier/planmodifierdynamic/dynamic_requires_replace_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -48,6 +49,20 @@ func Test_RequiresReplaceIfNotNull(t *testing.T) {
 			planValue:      types.DynamicValue(types.StringValue("plan")),
 			stateValue:     types.DynamicValue(types.StringValue("state")),
 			expectedResult: true,
+		},
+		{
+			// When HCL evaluates `condition ? [...] : null` for a DynamicAttribute,
+			// it produces a DynamicValue wrapping a null tuple, not a DynamicNull.
+			name:           "plan value is dynamic wrapping null tuple",
+			planValue:      types.DynamicValue(types.TupleNull([]attr.Type{types.StringType})),
+			stateValue:     types.DynamicValue(types.StringValue("state")),
+			expectedResult: false,
+		},
+		{
+			name:           "state value is dynamic wrapping null tuple",
+			planValue:      types.DynamicValue(types.StringValue("plan")),
+			stateValue:     types.DynamicValue(types.TupleNull([]attr.Type{types.StringType})),
+			expectedResult: false,
 		},
 	}
 


### PR DESCRIPTION
## Bug

`RequiresReplaceIfNotNull` incorrectly triggers resource replacement when `replace_triggers_external_values` is set to `null` via a conditional expression like:

```hcl
replace_triggers_external_values = var.trigger_replace ? [var.sku] : null
```

This affects `azapi_resource`, `azapi_update_resource`, and `azapi_data_plane_resource`.

## Root Cause

When HCL evaluates `condition ? [...] : null` for a `DynamicAttribute`, the null branch produces a **typed null** (`DynamicValue(TupleNull([]))`) instead of `DynamicNull()`. The outer Dynamic wrapper reports `IsNull()=false`, so the plan modifier incorrectly treats it as a non-null value and triggers replacement.

The bug was not caught because existing tests and docs only use **literal `null`** (which produces `DynamicNull()`), never a conditional expression.

## Fix

Check both `IsNull()` on the Dynamic wrapper **and** `UnderlyingValue().IsNull()` on the inner value, to detect both forms of null.

## Tests

Added 2 new unit test cases for the wrapped-null-tuple scenario. All 7 tests pass.
