### PR TITLE
Fix azapi_update_resource migration missing replace_triggers_external_values field

### DIFF
--- a/internal/services/migration/azapi_update_resource_migration_v0_to_v2.go
+++ b/internal/services/migration/azapi_update_resource_migration_v0_to_v2.go
@@ -99,27 +99,28 @@ func AzapiUpdateResourceMigrationV0ToV2(ctx context.Context) resource.StateUpgra
 				Timeouts              timeouts.Value `tfsdk:"timeouts"`
 			}
 			type newModel struct {
-				ID                     types.String        `tfsdk:"id"`
-				Name                   types.String        `tfsdk:"name"`
-				ParentID               types.String        `tfsdk:"parent_id"`
-				ResourceID             types.String        `tfsdk:"resource_id"`
-				Type                   types.String        `tfsdk:"type"`
-				Body                   types.Dynamic       `tfsdk:"body"`
-				SensitiveBody          types.Dynamic       `tfsdk:"sensitive_body"`
-				SensitiveBodyVersion   types.Map           `tfsdk:"sensitive_body_version"`
-				IgnoreCasing           types.Bool          `tfsdk:"ignore_casing"`
-				IgnoreMissingProperty  types.Bool          `tfsdk:"ignore_missing_property"`
-				ListUniqueIdProperty   types.Map           `tfsdk:"list_unique_id_property"`
-				IgnoreOtherItemsInList types.List          `tfsdk:"ignore_other_items_in_list"`
-				ResponseExportValues   types.Dynamic       `tfsdk:"response_export_values"`
-				Locks                  types.List          `tfsdk:"locks"`
-				Output                 types.Dynamic       `tfsdk:"output"`
-				Timeouts               timeouts.Value      `tfsdk:"timeouts"`
-				Retry                  retry.RetryValue    `tfsdk:"retry"`
-				UpdateHeaders          map[string]string   `tfsdk:"update_headers"`
-				UpdateQueryParameters  map[string][]string `tfsdk:"update_query_parameters"`
-				ReadHeaders            map[string]string   `tfsdk:"read_headers"`
-				ReadQueryParameters    map[string][]string `tfsdk:"read_query_parameters"`
+				ID                            types.String        `tfsdk:"id"`
+				Name                          types.String        `tfsdk:"name"`
+				ParentID                      types.String        `tfsdk:"parent_id"`
+				ResourceID                    types.String        `tfsdk:"resource_id"`
+				Type                          types.String        `tfsdk:"type"`
+				Body                          types.Dynamic       `tfsdk:"body"`
+				SensitiveBody                 types.Dynamic       `tfsdk:"sensitive_body"`
+				SensitiveBodyVersion          types.Map           `tfsdk:"sensitive_body_version"`
+				IgnoreCasing                  types.Bool          `tfsdk:"ignore_casing"`
+				IgnoreMissingProperty         types.Bool          `tfsdk:"ignore_missing_property"`
+				ListUniqueIdProperty          types.Map           `tfsdk:"list_unique_id_property"`
+				IgnoreOtherItemsInList        types.List          `tfsdk:"ignore_other_items_in_list"`
+				ReplaceTriggersExternalValues types.Dynamic       `tfsdk:"replace_triggers_external_values"`
+				ResponseExportValues          types.Dynamic       `tfsdk:"response_export_values"`
+				Locks                         types.List          `tfsdk:"locks"`
+				Output                        types.Dynamic       `tfsdk:"output"`
+				Timeouts                      timeouts.Value      `tfsdk:"timeouts"`
+				Retry                         retry.RetryValue    `tfsdk:"retry"`
+				UpdateHeaders                 map[string]string   `tfsdk:"update_headers"`
+				UpdateQueryParameters         map[string][]string `tfsdk:"update_query_parameters"`
+				ReadHeaders                   map[string]string   `tfsdk:"read_headers"`
+				ReadQueryParameters           map[string][]string `tfsdk:"read_query_parameters"`
 			}
 
 			var oldState OldModel
@@ -147,22 +148,23 @@ func AzapiUpdateResourceMigrationV0ToV2(ctx context.Context) resource.StateUpgra
 			}
 
 			newState := newModel{
-				ID:                     oldState.ID,
-				Name:                   oldState.Name,
-				ParentID:               oldState.ParentID,
-				ResourceID:             oldState.ResourceID,
-				Type:                   oldState.Type,
-				Body:                   bodyVal,
-				Locks:                  oldState.Locks,
-				IgnoreCasing:           oldState.IgnoreCasing,
-				IgnoreMissingProperty:  oldState.IgnoreMissingProperty,
-				ListUniqueIdProperty:   types.MapNull(types.StringType),
-				IgnoreOtherItemsInList: types.ListNull(types.StringType),
-				ResponseExportValues:   responseExportValues,
-				Output:                 outputVal,
-				Timeouts:               oldState.Timeouts,
-				Retry:                  retry.NewRetryValueNull(),
-				SensitiveBodyVersion:   types.MapNull(types.StringType),
+				ID:                            oldState.ID,
+				Name:                          oldState.Name,
+				ParentID:                      oldState.ParentID,
+				ResourceID:                    oldState.ResourceID,
+				Type:                          oldState.Type,
+				Body:                          bodyVal,
+				Locks:                         oldState.Locks,
+				IgnoreCasing:                  oldState.IgnoreCasing,
+				IgnoreMissingProperty:         oldState.IgnoreMissingProperty,
+				ListUniqueIdProperty:          types.MapNull(types.StringType),
+				IgnoreOtherItemsInList:        types.ListNull(types.StringType),
+				ReplaceTriggersExternalValues: types.DynamicNull(),
+				ResponseExportValues:          responseExportValues,
+				Output:                        outputVal,
+				Timeouts:                      oldState.Timeouts,
+				Retry:                         retry.NewRetryValueNull(),
+				SensitiveBodyVersion:          types.MapNull(types.StringType),
 			}
 
 			response.Diagnostics.Append(response.State.Set(ctx, newState)...)

--- a/internal/services/migration/azapi_update_resource_migration_v1_to_v2.go
+++ b/internal/services/migration/azapi_update_resource_migration_v1_to_v2.go
@@ -99,27 +99,28 @@ func AzapiUpdateResourceMigrationV1ToV2(ctx context.Context) resource.StateUpgra
 				Timeouts              timeouts.Value `tfsdk:"timeouts"`
 			}
 			type newModel struct {
-				ID                     types.String        `tfsdk:"id"`
-				Name                   types.String        `tfsdk:"name"`
-				ParentID               types.String        `tfsdk:"parent_id"`
-				ResourceID             types.String        `tfsdk:"resource_id"`
-				Type                   types.String        `tfsdk:"type"`
-				Body                   types.Dynamic       `tfsdk:"body"`
-				SensitiveBody          types.Dynamic       `tfsdk:"sensitive_body"`
-				SensitiveBodyVersion   types.Map           `tfsdk:"sensitive_body_version"`
-				IgnoreCasing           types.Bool          `tfsdk:"ignore_casing"`
-				IgnoreMissingProperty  types.Bool          `tfsdk:"ignore_missing_property"`
-				ListUniqueIdProperty   types.Map           `tfsdk:"list_unique_id_property"`
-				IgnoreOtherItemsInList types.List          `tfsdk:"ignore_other_items_in_list"`
-				ResponseExportValues   types.Dynamic       `tfsdk:"response_export_values"`
-				Locks                  types.List          `tfsdk:"locks"`
-				Output                 types.Dynamic       `tfsdk:"output"`
-				Timeouts               timeouts.Value      `tfsdk:"timeouts"`
-				Retry                  retry.RetryValue    `tfsdk:"retry"`
-				UpdateHeaders          map[string]string   `tfsdk:"update_headers"`
-				UpdateQueryParameters  map[string][]string `tfsdk:"update_query_parameters"`
-				ReadHeaders            map[string]string   `tfsdk:"read_headers"`
-				ReadQueryParameters    map[string][]string `tfsdk:"read_query_parameters"`
+				ID                            types.String        `tfsdk:"id"`
+				Name                          types.String        `tfsdk:"name"`
+				ParentID                      types.String        `tfsdk:"parent_id"`
+				ResourceID                    types.String        `tfsdk:"resource_id"`
+				Type                          types.String        `tfsdk:"type"`
+				Body                          types.Dynamic       `tfsdk:"body"`
+				SensitiveBody                 types.Dynamic       `tfsdk:"sensitive_body"`
+				SensitiveBodyVersion          types.Map           `tfsdk:"sensitive_body_version"`
+				IgnoreCasing                  types.Bool          `tfsdk:"ignore_casing"`
+				IgnoreMissingProperty         types.Bool          `tfsdk:"ignore_missing_property"`
+				ListUniqueIdProperty          types.Map           `tfsdk:"list_unique_id_property"`
+				IgnoreOtherItemsInList        types.List          `tfsdk:"ignore_other_items_in_list"`
+				ReplaceTriggersExternalValues types.Dynamic       `tfsdk:"replace_triggers_external_values"`
+				ResponseExportValues          types.Dynamic       `tfsdk:"response_export_values"`
+				Locks                         types.List          `tfsdk:"locks"`
+				Output                        types.Dynamic       `tfsdk:"output"`
+				Timeouts                      timeouts.Value      `tfsdk:"timeouts"`
+				Retry                         retry.RetryValue    `tfsdk:"retry"`
+				UpdateHeaders                 map[string]string   `tfsdk:"update_headers"`
+				UpdateQueryParameters         map[string][]string `tfsdk:"update_query_parameters"`
+				ReadHeaders                   map[string]string   `tfsdk:"read_headers"`
+				ReadQueryParameters           map[string][]string `tfsdk:"read_query_parameters"`
 			}
 
 			var oldState OldModel
@@ -145,22 +146,23 @@ func AzapiUpdateResourceMigrationV1ToV2(ctx context.Context) resource.StateUpgra
 			}
 
 			newState := newModel{
-				ID:                     oldState.ID,
-				Name:                   oldState.Name,
-				ParentID:               oldState.ParentID,
-				ResourceID:             oldState.ResourceID,
-				Type:                   oldState.Type,
-				Body:                   bodyVal,
-				Locks:                  oldState.Locks,
-				IgnoreCasing:           oldState.IgnoreCasing,
-				IgnoreMissingProperty:  oldState.IgnoreMissingProperty,
-				ListUniqueIdProperty:   types.MapNull(types.StringType),
-				IgnoreOtherItemsInList: types.ListNull(types.StringType),
-				ResponseExportValues:   responseExportValues,
-				Output:                 outputVal,
-				Timeouts:               oldState.Timeouts,
-				Retry:                  retry.NewRetryValueNull(),
-				SensitiveBodyVersion:   types.MapNull(types.StringType),
+				ID:                            oldState.ID,
+				Name:                          oldState.Name,
+				ParentID:                      oldState.ParentID,
+				ResourceID:                    oldState.ResourceID,
+				Type:                          oldState.Type,
+				Body:                          bodyVal,
+				Locks:                         oldState.Locks,
+				IgnoreCasing:                  oldState.IgnoreCasing,
+				IgnoreMissingProperty:         oldState.IgnoreMissingProperty,
+				ListUniqueIdProperty:          types.MapNull(types.StringType),
+				IgnoreOtherItemsInList:        types.ListNull(types.StringType),
+				ReplaceTriggersExternalValues: types.DynamicNull(),
+				ResponseExportValues:          responseExportValues,
+				Output:                        outputVal,
+				Timeouts:                      oldState.Timeouts,
+				Retry:                         retry.NewRetryValueNull(),
+				SensitiveBodyVersion:          types.MapNull(types.StringType),
 			}
 
 			response.Diagnostics.Append(response.State.Set(ctx, newState)...)


### PR DESCRIPTION
## Problem

The `newModel` struct in both v0-to-v2 and v1-to-v2 state migrations for `azapi_update_resource` was missing the `replace_triggers_external_values` field that exists in the current schema (version 2). This caused a `Value Conversion Error` during state upgrade:

```
Mismatch between struct and object type: Object defines fields not found in struct: replace_triggers_external_values.
Struct: migration.newModel
```

This affected all `TestAccAzapiUpdateResourceUpgrade_*` tests.

## Fix

Added the missing `ReplaceTriggersExternalValues types.Dynamic` field to the `newModel` struct in both migration files and initialized it to `types.DynamicNull()` in the migrated state.
