### PR TITLE
test: add upgrade test to reproduce missing resource identity after read (#1077)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-## v2.9.0 (Unreleased)
+## Unreleased
+
+BUG FIXES:
+- Fix `Missing Resource Identity After Read` error when a resource is deleted outside of Terraform and a subsequent plan is run (GH-1077).
+
+## v2.9.0
 
 ENHANCEMENTS:
 - `azapi_update_resource` resource: Support `replace_triggers_external_values` argument to trigger resource replacement based on external values.

--- a/internal/services/azapi_resource.go
+++ b/internal/services/azapi_resource.go
@@ -1032,6 +1032,11 @@ func (r *AzapiResource) Read(ctx context.Context, request resource.ReadRequest, 
 	if err != nil {
 		if utils.ResponseErrorWasNotFound(err) {
 			tflog.Info(ctx, fmt.Sprintf("Error reading %q - removing from state", id.ID()))
+			resourceIdentity := AzapiResourceIdentityModel{
+				ID:   model.ID,
+				Type: model.Type,
+			}
+			response.Diagnostics.Append(response.Identity.Set(ctx, resourceIdentity)...)
 			response.State.RemoveResource(ctx)
 			return
 		}

--- a/internal/services/azapi_resource_upgrade_test.go
+++ b/internal/services/azapi_resource_upgrade_test.go
@@ -3,6 +3,7 @@ package services_test
 import (
 	"fmt"
 	"os"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -595,4 +596,45 @@ func TestAccAzapiResourceUpgrade_basic_from_schema_v0(t *testing.T) {
 			Config: updatedConfig,
 		}),
 	})
+}
+
+// TestAccAzapiResourceUpgrade_missingResourceIdentityAfterRead reproduces issue #1077:
+// When upgrading from v2.7 to v2.8+, if the resource was deleted outside of Terraform,
+// the Read function encounters a 404 and calls RemoveResource but doesn't set
+// response.Identity, causing a "Missing Resource Identity After Read" error.
+func TestAccAzapiResourceUpgrade_missingResourceIdentityAfterRead(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azapi_resource", "test")
+	r := GenericResource{}
+
+	data.UpgradeTest(t, r, []resource.TestStep{
+		// Step 1: Deploy with azapi v2.7.0 — creates a resource group and deletes it via resource action
+		data.UpgradeTestDeployStep(resource.TestStep{
+			Config: r.resourceGroupWithDelete(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("id").Exists(),
+			),
+			ExpectError: regexp.MustCompile(`ResourceGroupNotFound`),
+		}, "2.7.0"),
+		{
+			RefreshState:             true,
+			ExpectNonEmptyPlan:       true,
+			ProtoV6ProviderFactories: data.Providers(),
+		},
+	})
+}
+
+func (r GenericResource) resourceGroupWithDelete(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+resource "azapi_resource" "test" {
+  type     = "Microsoft.Resources/resourceGroups@2023-07-01"
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azapi_resource_action" "delete" {
+  type        = "Microsoft.Resources/resourceGroups@2023-07-01"
+  resource_id = azapi_resource.test.id
+  method      = "DELETE"
+}
+`, data.RandomInteger, data.LocationPrimary)
 }

--- a/internal/services/azapi_resource_upgrade_test.go
+++ b/internal/services/azapi_resource_upgrade_test.go
@@ -1,14 +1,15 @@
 package services_test
 
 import (
+	"context"
 	"fmt"
 	"os"
-	"regexp"
 	"strings"
 	"testing"
 
 	"github.com/Azure/terraform-provider-azapi/internal/acceptance"
 	"github.com/Azure/terraform-provider-azapi/internal/acceptance/check"
+	"github.com/Azure/terraform-provider-azapi/internal/clients"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
@@ -607,34 +608,43 @@ func TestAccAzapiResourceUpgrade_missingResourceIdentityAfterRead(t *testing.T) 
 	r := GenericResource{}
 
 	data.UpgradeTest(t, r, []resource.TestStep{
-		// Step 1: Deploy with azapi v2.7.0 — creates a resource group and deletes it via resource action
+		// Step 1: Deploy with azapi v2.7.0 — creates a resource group
 		data.UpgradeTestDeployStep(resource.TestStep{
-			Config: r.resourceGroupWithDelete(data),
+			Config: r.resourceGroup(data),
 			Check: resource.ComposeTestCheckFunc(
-				check.That(data.ResourceName).Key("id").Exists(),
+				check.That(data.ResourceName).ExistsInAzure(r),
 			),
-			ExpectError: regexp.MustCompile(`ResourceGroupNotFound`),
 		}, "2.7.0"),
-		{
-			RefreshState:             true,
-			ExpectNonEmptyPlan:       true,
-			ProtoV6ProviderFactories: data.Providers(),
-		},
+		// Step 2: Refresh state with dev provider — delete the resource externally first via PreConfig,
+		// then the Read on azapi_resource.test will get a 404.
+		// This should remove the resource from state gracefully, but with the bug
+		// it fails with "Missing Resource Identity After Read"
+		data.UpgradeTestPlanStep(
+			resource.TestStep{
+				Config:             r.resourceGroup(data),
+				ExpectNonEmptyPlan: true,
+				PreConfig: func() {
+					client, err := acceptance.BuildTestClient()
+					if err != nil {
+						t.Fatalf("building test client: %+v", err)
+					}
+					resourceId := fmt.Sprintf("/subscriptions/%s/resourceGroups/acctestRG-%d", os.Getenv("ARM_SUBSCRIPTION_ID"), data.RandomInteger)
+					_, err = client.ResourceClient.Delete(context.Background(), resourceId, "2023-07-01", clients.DefaultRequestOptions())
+					if err != nil {
+						t.Fatalf("deleting resource group: %+v", err)
+					}
+				},
+			}),
 	})
 }
 
-func (r GenericResource) resourceGroupWithDelete(data acceptance.TestData) string {
+func (r GenericResource) resourceGroup(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 resource "azapi_resource" "test" {
   type     = "Microsoft.Resources/resourceGroups@2023-07-01"
   name     = "acctestRG-%[1]d"
   location = "%[2]s"
-}
-
-resource "azapi_resource_action" "delete" {
-  type        = "Microsoft.Resources/resourceGroups@2023-07-01"
-  resource_id = azapi_resource.test.id
-  method      = "DELETE"
+  body     = {}
 }
 `, data.RandomInteger, data.LocationPrimary)
 }


### PR DESCRIPTION
## Description

Adds `TestAccAzapiResourceUpgrade_missingResourceIdentityAfterRead` to reproduce issue #1077.

## Reproduction

When upgrading from v2.7 to v2.8+, if a resource was deleted outside of Terraform, the Read function encounters a 404 and calls `RemoveResource` but doesn't set `response.Identity`, causing a `Missing Resource Identity After Read` error.

### Test Evidence

```
=== RUN   TestAccAzapiResourceUpgrade_identityExternallyDeleted
=== PAUSE TestAccAzapiResourceUpgrade_identityExternallyDeleted
=== CONT  TestAccAzapiResourceUpgrade_identityExternallyDeleted
    testcase.go:119: Step 2/2 error running refresh: exit status 1

        Error: Missing Resource Identity After Read

        The Terraform Provider unexpectedly returned no resource identity data after
        having no errors in the resource read. This is always an issue in the
        Terraform Provider and should be reported to the provider developers.
--- FAIL: TestAccAzapiResourceUpgrade_identityExternallyDeleted (57.84s)
```

Fixes #1077
