### PR TITLE
Fix dependabot.yml syntax error

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,4 +15,3 @@ updates:
       - dependency-name: "*"
         update-types:
           - "version-update:semver-major"
-    vendor: true


### PR DESCRIPTION
The dependabot.yml contains syntax error which causes automatic update to not trigger.

https://github.com/Azure/terraform-provider-azapi/network/updates

<img width="927" height="296" alt="image" src="https://github.com/user-attachments/assets/3a448b8e-a590-4d1c-8d82-5fcdb585804b" />

Refer to https://www.schemastore.org/dependabot-2.0.json: the doc on `vendor` says:

> Don't use this option if you're using 'gomod'.

## Testing

Have checked local validator pass. Will check the dependency setting section above again after merging to main.