### PR TITLE
fix(utils/json): guard empty newArr in updateObjectAtPath

### DIFF
--- a/utils/json.go
+++ b/utils/json.go
@@ -154,6 +154,13 @@ func updateObjectAtPath(old interface{}, new interface{}, option UpdateJsonOptio
 			if len(oldValue) == 0 {
 				return new
 			}
+			if len(newArr) == 0 {
+				// oldValue is non-empty (checked above) but newArr is
+				// empty — a newArr[0] identifier lookup would
+				// otherwise panic with 'index out of range [0] with
+				// length 0'. Treat as an intentional clear.
+				return newArr
+			}
 
 			identifierKey := listIdentifierKeyForPath(path, option)
 			hasIdentifier := identifierOfArrayItemByKey(oldValue[0], identifierKey) != "" && identifierOfArrayItemByKey(newArr[0], identifierKey) != ""

--- a/utils/json.go
+++ b/utils/json.go
@@ -156,7 +156,7 @@ func updateObjectAtPath(old interface{}, new interface{}, option UpdateJsonOptio
 			}
 			if len(newArr) == 0 {
 				// oldValue is non-empty (checked above) but newArr is
-				// empty — a newArr[0] identifier lookup would
+				// empty, a newArr[0] identifier lookup would
 				// otherwise panic with 'index out of range [0] with
 				// length 0'. Treat as an intentional clear.
 				return newArr


### PR DESCRIPTION
Fixes Azure/terraform-provider-azapi#1106.

`updateObjectAtPath`'s `[]interface{}` branch returned early when `oldValue` was empty but then dereferenced `newArr[0]` for the identifier lookup without checking `newArr`'s length. A Landing-Zone-sized plan that clears an existing array property (old has entries, new is empty) panicked the provider with `index out of range [0] with length 0` in `ReadResource` / `PlanResourceChange`, surfacing as the "Plugin did not respond" Terraform errors in the linked issue.

## Fix

Treat an empty `newArr` against a non-empty `oldValue` as an intentional clear and return `newArr`. The `hasIdentifier` path (both sides non-empty) is unchanged.

`go test ./utils/...` clean.