### PR TITLE
utils: avoid panic in updateObjectAtPath when new list is empty

### DIFF
--- a/utils/json.go
+++ b/utils/json.go
@@ -154,6 +154,9 @@ func updateObjectAtPath(old interface{}, new interface{}, option UpdateJsonOptio
 			if len(oldValue) == 0 {
 				return new
 			}
+			if len(newArr) == 0 {
+				return newArr
+			}
 
 			identifierKey := listIdentifierKeyForPath(path, option)
 			hasIdentifier := identifierOfArrayItemByKey(oldValue[0], identifierKey) != "" && identifierOfArrayItemByKey(newArr[0], identifierKey) != ""


### PR DESCRIPTION
Fixes #1106.

`updateObjectAtPath` checks `len(oldValue) == 0` and returns early, but indexes `newArr[0]` without a length check. When the new value is an empty list, `identifierOfArrayItemByKey(newArr[0], ...)` panics with `index out of range [0] with length 0` and the provider crashes during ReadResource. Return `newArr` early when it is empty.