### PR TITLE
acctest & nightly pipeline improvement and simplification

### DIFF
--- a/.azdo/acctest-pipeline.yml
+++ b/.azdo/acctest-pipeline.yml
@@ -13,5 +13,5 @@ jobs:
       maxParallel: 1
       accTest: true
       vmImages:
-        - value: 'ubuntu-20.04'
-          ymlSafeName: ubuntu_20_04
+        - value: 'ubuntu-24.04'
+          ymlSafeName: ubuntu_24_04

--- a/.azdo/acctest-pipeline.yml
+++ b/.azdo/acctest-pipeline.yml
@@ -13,5 +13,4 @@ jobs:
       maxParallel: 1
       accTest: true
       vmImages:
-        - value: 'ubuntu-24.04'
-          ymlSafeName: ubuntu_24_04
+        - ymlSafeName: ubuntu_24_04

--- a/.azdo/acctest-pipeline.yml
+++ b/.azdo/acctest-pipeline.yml
@@ -10,7 +10,4 @@ pr: none
 jobs:
   - template: ./ci.yml
     parameters:
-      maxParallel: 1
       accTest: true
-      vmImages:
-        - ymlSafeName: ubuntu_24_04

--- a/.azdo/ci.yml
+++ b/.azdo/ci.yml
@@ -1,21 +1,11 @@
-# This template will generate a list of jobs that will run. The
-# jobs created will correspond to the vmImages specified by the parameters.
-
 parameters:
-  vmImages: []
-  maxParallel: 1
+  unitTest: false
+  accTest: false
 
 jobs:
   - job: build
     timeoutInMinutes: 300
-    displayName: "Build: "
-
-    # Build on each supported OS using the Go version declared in go.mod
-    strategy:
-      maxParallel: ${{ parameters.maxParallel }}
-      matrix:
-        ${{ each vmImage in parameters.vmImages }}:
-          OS_${{ vmImage.ymlSafeName }}: {}
+    displayName: "Build"
 
     pool:
       name: pool-ubuntu-2404

--- a/.azdo/ci.yml
+++ b/.azdo/ci.yml
@@ -15,8 +15,7 @@ jobs:
       maxParallel: ${{ parameters.maxParallel }}
       matrix:
         ${{ each vmImage in parameters.vmImages }}:
-          OS_${{ vmImage.ymlSafeName }}:
-            vmImage: ${{ vmImage.value }}
+          OS_${{ vmImage.ymlSafeName }}: {}
 
     pool:
       name: pool-ubuntu-2404

--- a/.azdo/nightly-test-pipeline.yml
+++ b/.azdo/nightly-test-pipeline.yml
@@ -11,5 +11,4 @@ jobs:
       maxParallel: 1 # any more and we get throttled by AzDO!
       accTest: true
       vmImages:
-        - value: 'ubuntu-24.04'
-          ymlSafeName: ubuntu_24_04
+        - ymlSafeName: ubuntu_24_04

--- a/.azdo/nightly-test-pipeline.yml
+++ b/.azdo/nightly-test-pipeline.yml
@@ -8,7 +8,4 @@ schedules:
 jobs:
   - template: ./ci.yml
     parameters:
-      maxParallel: 1 # any more and we get throttled by AzDO!
       accTest: true
-      vmImages:
-        - ymlSafeName: ubuntu_24_04

--- a/.azdo/nightly-test-pipeline.yml
+++ b/.azdo/nightly-test-pipeline.yml
@@ -11,5 +11,5 @@ jobs:
       maxParallel: 1 # any more and we get throttled by AzDO!
       accTest: true
       vmImages:
-        - value: 'ubuntu-20.04'
-          ymlSafeName: ubuntu_20_04
+        - value: 'ubuntu-24.04'
+          ymlSafeName: ubuntu_24_04

--- a/docs/resources/Microsoft.ContainerInstance_containerGroups.md
+++ b/docs/resources/Microsoft.ContainerInstance_containerGroups.md
@@ -59,7 +59,7 @@ resource "azapi_resource" "containerGroup" {
             ]
             environmentVariables = [
             ]
-            image = "ubuntu:20.04"
+            image = "ubuntu:24.04"
             ports = [
               {
                 port     = 80

--- a/examples/Microsoft.ContainerInstance_containerGroups@2023-05-01/main.tf
+++ b/examples/Microsoft.ContainerInstance_containerGroups@2023-05-01/main.tf
@@ -41,7 +41,7 @@ resource "azapi_resource" "containerGroup" {
             ]
             environmentVariables = [
             ]
-            image = "ubuntu:20.04"
+            image = "ubuntu:24.04"
             ports = [
               {
                 port     = 80


### PR DESCRIPTION
1. Removed matrix pipeline build which is redundant: there was only 1 OS, and the pool is hardcoded to ubuntu 2404
2. Removed misleading ubuntu_20.04 label which is not used
3. Updates references to ubuntu 20.04 found in acctest configs to ubuntu 24.04.

## Testing

Ensure acctest pipeline passes