### PR TITLE
Add `preserve_resource_id_casing` provider feature flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ ENHANCEMENTS:
 - Bump Go version to 1.25.8 (GH-1082).
 - Bump `terraform-plugin-framework` from v1.16.1 to v1.19.0 (GH-1081).
 - Add example for `Microsoft.RedHatOpenShift/openShiftClusters` (GH-1083).
+- `azapi` provider: Support `preserve_resource_id_casing` feature flag (default `false`). When enabled, if the resource ID the provider would write back to state differs from the existing state value only by casing, the existing casing is preserved. This avoids spurious `Unexpected Identity Change` errors and diffs when consumers (or upstream modules) rely on a specific casing the Azure API may not preserve. Only the `id` and `resource_id` attributes are affected. Can also be sourced from the `ARM_PRESERVE_RESOURCE_ID_CASING` environment variable (GH-1122).
 
 BUG FIXES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ ENHANCEMENTS:
 - Acquire a policy token when a request is blocked by an invoke policy (GH-1145).
 - Update bicep types to Azure/azure-rest-api-specs revision 51d53915b5f31b10e6645c136807b9d95f9f09d1 (GH-1159).
 - Improve the bicep types update process (GH-1155).
+- `azapi` provider: Support `preserve_resource_id_casing` feature flag (default `false`). When enabled, if the resource ID the provider would write back to state differs from the existing state value only by casing, the existing casing is preserved. This avoids spurious `Unexpected Identity Change` errors and diffs when consumers (or upstream modules) rely on a specific casing the Azure API may not preserve. Only the `id` and `resource_id` attributes are affected. Can also be sourced from the `ARM_PRESERVE_RESOURCE_ID_CASING` environment variable (GH-1122).
 
 BUG FIXES:
 
@@ -26,7 +27,6 @@ ENHANCEMENTS:
 - Bump Go version to 1.25.8 (GH-1082).
 - Bump `terraform-plugin-framework` from v1.16.1 to v1.19.0 (GH-1081).
 - Add example for `Microsoft.RedHatOpenShift/openShiftClusters` (GH-1083).
-- `azapi` provider: Support `preserve_resource_id_casing` feature flag (default `false`). When enabled, if the resource ID the provider would write back to state differs from the existing state value only by casing, the existing casing is preserved. This avoids spurious `Unexpected Identity Change` errors and diffs when consumers (or upstream modules) rely on a specific casing the Azure API may not preserve. Only the `id` and `resource_id` attributes are affected. Can also be sourced from the `ARM_PRESERVE_RESOURCE_ID_CASING` environment variable (GH-1122).
 
 BUG FIXES:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -119,6 +119,7 @@ provider "azapi" {
 - `partner_id` (String) A GUID/UUID that is [registered](https://docs.microsoft.com/azure/marketplace/azure-partner-customer-usage-attribution#register-guids-and-offers) with Microsoft to facilitate partner resource usage attribution. This can also be sourced from the `ARM_PARTNER_ID` Environment Variable.
 
 	-> Value must satisfy at least one of the validations: ensure this in UUID format + string length must be at most 0.
+- `preserve_resource_id_casing` (Boolean) Preserve the existing casing of the resource ID in state. The default is false. When set to true, if the resource ID the provider would write back to state differs from the value already in state only by casing, the existing casing is kept. This is useful when consumers of the resource ID (or the `azapi_resource` identity) require a specific casing that the Azure API may not preserve. This only affects the `id` (and `resource_id`) attributes; other properties are unaffected. This can also be sourced from the `ARM_PRESERVE_RESOURCE_ID_CASING` Environment Variable.
 - `skip_provider_registration` (Boolean) Should the Provider skip registering the Resource Providers it supports? This can also be sourced from the `ARM_SKIP_PROVIDER_REGISTRATION` Environment Variable. Defaults to `false`.
 - `subscription_id` (String) The Subscription ID which should be used. This can also be sourced from the `ARM_SUBSCRIPTION_ID` Environment Variable.
 - `tenant_id` (String) The Tenant ID should be used. This can also be sourced from the `ARM_TENANT_ID` Environment Variable.

--- a/internal/features/user_flags.go
+++ b/internal/features/user_flags.go
@@ -1,21 +1,23 @@
 package features
 
 type UserFeatures struct {
-	DefaultTags          map[string]string
-	DefaultLocation      string
-	DefaultNaming        string
-	EnablePreflight      bool
-	IgnoreNoOpChanges    bool
-	DisableDefaultOutput bool
+	DefaultTags              map[string]string
+	DefaultLocation          string
+	DefaultNaming            string
+	EnablePreflight          bool
+	IgnoreNoOpChanges        bool
+	DisableDefaultOutput     bool
+	PreserveResourceIDCasing bool
 }
 
 func Default() UserFeatures {
 	return UserFeatures{
-		DefaultTags:          nil,
-		DefaultLocation:      "",
-		DefaultNaming:        "",
-		EnablePreflight:      false,
-		IgnoreNoOpChanges:    true,
-		DisableDefaultOutput: false,
+		DefaultTags:              nil,
+		DefaultLocation:          "",
+		DefaultNaming:            "",
+		EnablePreflight:          false,
+		IgnoreNoOpChanges:        true,
+		DisableDefaultOutput:     false,
+		PreserveResourceIDCasing: false,
 	}
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -87,6 +87,7 @@ type providerData struct {
 	IgnoreNoOpChanges            types.Bool   `tfsdk:"ignore_no_op_changes"`
 	DisableDefaultOutput         types.Bool   `tfsdk:"disable_default_output"`
 	AlwaysAcquirePolicyToken     types.Bool   `tfsdk:"always_acquire_policy_token"`
+	PreserveResourceIDCasing     types.Bool   `tfsdk:"preserve_resource_id_casing"`
 	MaximumBusyRetryAttempts     types.Int32  `tfsdk:"maximum_busy_retry_attempts"`
 }
 
@@ -336,6 +337,10 @@ func (p Provider) Schema(ctx context.Context, request provider.SchemaRequest, re
 			"always_acquire_policy_token": schema.BoolAttribute{
 				Optional:            true,
 				MarkdownDescription: "Always acquire a policy token for write requests, regardless of whether one is required. The default is `false`. The default behaviour is to wait for a qualifying `403` response indicating that a policy token is required, and then retry the request with an acquired policy token. When this attribute is set to `true`, the provider proactively acquires a policy token and attaches it to every write request, avoiding the extra round-trip per request. Performance will be improved if the number of changed resources is known to be large beforehand. This can also be sourced from the `ARM_ALWAYS_ACQUIRE_POLICY_TOKEN` Environment Variable. See [Feature: Acquire Policy Token](guides/feature_acquire_policy_token.html) to learn more.",
+			},
+			"preserve_resource_id_casing": schema.BoolAttribute{
+				Optional:    true,
+				Description: "Preserve the existing casing of the resource ID in state. The default is false. When set to true, if the resource ID the provider would write back to state differs from the value already in state only by casing, the existing casing is kept. This is useful when consumers of the resource ID (or the `azapi_resource` identity) require a specific casing that the Azure API may not preserve. This only affects the `id` (and `resource_id`) attributes; other properties are unaffected. This can also be sourced from the `ARM_PRESERVE_RESOURCE_ID_CASING` Environment Variable.",
 			},
 			"maximum_busy_retry_attempts": schema.Int32Attribute{
 				Optional:            true,
@@ -606,6 +611,14 @@ func (p Provider) Configure(ctx context.Context, request provider.ConfigureReque
 		}
 	}
 
+	if model.PreserveResourceIDCasing.IsNull() {
+		if v := os.Getenv("ARM_PRESERVE_RESOURCE_ID_CASING"); v != "" {
+			model.PreserveResourceIDCasing = types.BoolValue(v == "true")
+		} else {
+			model.PreserveResourceIDCasing = types.BoolValue(false)
+		}
+	}
+
 	var cloudConfig cloud.Configuration
 	env := model.Environment.ValueString()
 	switch strings.ToLower(env) {
@@ -699,12 +712,13 @@ func (p Provider) Configure(ctx context.Context, request provider.ConfigureReque
 		ApplicationUserAgent: buildUserAgent(request.TerraformVersion, model.PartnerID.ValueString(), model.DisableTerraformPartnerID.ValueBool()),
 		MaxGoSdkRetries:      maxGoSdkRetryAttempts,
 		Features: features.UserFeatures{
-			DefaultTags:          tags.ExpandTags(model.DefaultTags),
-			DefaultLocation:      location.Normalize(model.DefaultLocation.ValueString()),
-			DefaultNaming:        model.DefaultName.ValueString(),
-			EnablePreflight:      model.EnablePreflight.ValueBool(),
-			IgnoreNoOpChanges:    model.IgnoreNoOpChanges.ValueBool(),
-			DisableDefaultOutput: model.DisableDefaultOutput.ValueBool(),
+			DefaultTags:              tags.ExpandTags(model.DefaultTags),
+			DefaultLocation:          location.Normalize(model.DefaultLocation.ValueString()),
+			DefaultNaming:            model.DefaultName.ValueString(),
+			EnablePreflight:          model.EnablePreflight.ValueBool(),
+			IgnoreNoOpChanges:        model.IgnoreNoOpChanges.ValueBool(),
+			DisableDefaultOutput:     model.DisableDefaultOutput.ValueBool(),
+			PreserveResourceIDCasing: model.PreserveResourceIDCasing.ValueBool(),
 		},
 		SkipProviderRegistration:    model.SkipProviderRegistration.ValueBool(),
 		DisableCorrelationRequestID: model.DisableCorrelationRequestID.ValueBool(),

--- a/internal/services/azapi_resource.go
+++ b/internal/services/azapi_resource.go
@@ -920,7 +920,11 @@ func (r *AzapiResource) CreateUpdate(ctx context.Context, requestConfig tfsdk.Co
 			requestOptions.RetryOptions, requestOptions.LastRetryError = clients.NewRetryOptions(plan.Retry)
 			if responseBody, err := client.Get(recoveryCtx, id.AzureResourceId, id.ApiVersion, requestOptions); err == nil {
 				// generate the computed fields
-				plan.ID = types.StringValue(id.ID())
+				stateID := ""
+				if state != nil {
+					stateID = state.ID.ValueString()
+				}
+				plan.ID = types.StringValue(preserveCasing(stateID, id.ID(), r.ProviderData.Features.PreserveResourceIDCasing))
 
 				var defaultOutput interface{}
 				if !r.ProviderData.Features.DisableDefaultOutput {
@@ -976,7 +980,11 @@ func (r *AzapiResource) CreateUpdate(ctx context.Context, requestConfig tfsdk.Co
 	}
 
 	// generate the computed fields
-	plan.ID = types.StringValue(id.ID())
+	stateID := ""
+	if state != nil {
+		stateID = state.ID.ValueString()
+	}
+	plan.ID = types.StringValue(preserveCasing(stateID, id.ID(), r.ProviderData.Features.PreserveResourceIDCasing))
 
 	var defaultOutput interface{}
 	if !r.ProviderData.Features.DisableDefaultOutput {

--- a/internal/services/azapi_resource_preserve_resource_id_casing_test.go
+++ b/internal/services/azapi_resource_preserve_resource_id_casing_test.go
@@ -1,0 +1,138 @@
+package services_test
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/Azure/terraform-provider-azapi/internal/acceptance"
+	"github.com/Azure/terraform-provider-azapi/internal/acceptance/check"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+// serverFarmsCasing matches the casing azurerm writes into state for an App Service Plan.
+var serverFarmsCasing = regexp.MustCompile(`/Microsoft\.Web/serverFarms/`)
+
+// TestAccGenericResource_preserveResourceIDCasingAzurermMigration covers the migration
+// reported in GH-1120: azurerm_service_plan stores its id as `.../Microsoft.Web/serverFarms/...`,
+// the resource is then adopted by azapi_resource whose type is `Microsoft.Web/serverfarms`,
+// and a later update rebuilds the id from the type, flipping the casing in state and identity.
+func TestAccGenericResource_preserveResourceIDCasingAzurermMigration(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azapi_resource", "test")
+	r := GenericResource{}
+
+	const servicePlan = "azapi_resource.servicePlan"
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			ExternalProviders: externalProvidersAzurerm(),
+			Config:            r.azurermServicePlan(data),
+			Check: resource.ComposeTestCheckFunc(
+				resource.TestMatchResourceAttr("azurerm_service_plan.test", "id", serverFarmsCasing),
+			),
+		},
+		{
+			ExternalProviders: externalProvidersAzurerm(),
+			Config:            r.azurermServicePlanAdoptedByAzapi(data, ""),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(servicePlan).ExistsInAzure(r),
+				resource.TestMatchResourceAttr(servicePlan, "id", serverFarmsCasing),
+			),
+		},
+		{
+			// Forces an update so CreateUpdate recomputes the id from the type.
+			ExternalProviders: externalProvidersAzurerm(),
+			Config:            r.azurermServicePlanAdoptedByAzapi(data, "acctest"),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(servicePlan).ExistsInAzure(r),
+				resource.TestMatchResourceAttr(servicePlan, "id", serverFarmsCasing),
+			),
+		},
+	})
+}
+
+func (r GenericResource) azurermServicePlan(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestrg%[1]s"
+  location = "%[2]s"
+}
+
+resource "azurerm_service_plan" "test" {
+  name                = "acctestsp%[1]s"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  os_type             = "Windows"
+  sku_name            = "P1v3"
+}
+`, data.RandomString, data.LocationPrimary)
+}
+
+func (r GenericResource) azurermServicePlanAdoptedByAzapi(data acceptance.TestData, tag string) string {
+	tags := ""
+	if tag != "" {
+		tags = fmt.Sprintf(`
+  tags = {
+    environment = %[1]q
+  }
+`, tag)
+	}
+
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+provider "azapi" {
+  preserve_resource_id_casing = true
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestrg%[1]s"
+  location = "%[2]s"
+}
+
+removed {
+  from = azurerm_service_plan.test
+  lifecycle {
+    destroy = false
+  }
+}
+
+locals {
+  // Matches the id azurerm wrote to state for azurerm_service_plan.test.
+  service_plan_id = "${azurerm_resource_group.test.id}/providers/Microsoft.Web/serverFarms/acctestsp%[1]s"
+}
+
+import {
+  to = azapi_resource.servicePlan
+  identity = {
+    id = local.service_plan_id
+  }
+}
+
+resource "azapi_resource" "servicePlan" {
+  type      = "Microsoft.Web/serverfarms@2023-12-01"
+  name      = "acctestsp%[1]s"
+  parent_id = azurerm_resource_group.test.id
+  location  = azurerm_resource_group.test.location
+
+  body = {
+    properties = {
+      hyperV         = false
+      perSiteScaling = false
+      reserved       = false
+      zoneRedundant  = false
+    }
+    sku = {
+      name = "P1v3"
+    }
+  }
+%[3]s
+}
+`, data.RandomString, data.LocationPrimary, tags)
+}

--- a/internal/services/azapi_update_resource.go
+++ b/internal/services/azapi_update_resource.go
@@ -534,10 +534,16 @@ func (r *AzapiUpdateResource) CreateUpdate(ctx context.Context, requestConfig tf
 		return
 	}
 
-	model.ID = basetypes.NewStringValue(id.ID())
+	priorID := ""
+	priorResourceID := ""
+	if stateModel != nil {
+		priorID = stateModel.ID.ValueString()
+		priorResourceID = stateModel.ResourceID.ValueString()
+	}
+	model.ID = basetypes.NewStringValue(preserveCasing(priorID, id.ID(), r.ProviderData.Features.PreserveResourceIDCasing))
 	model.Name = basetypes.NewStringValue(id.Name)
 	model.ParentID = basetypes.NewStringValue(id.ParentId)
-	model.ResourceID = basetypes.NewStringValue(id.AzureResourceId)
+	model.ResourceID = basetypes.NewStringValue(preserveCasing(priorResourceID, id.AzureResourceId, r.ProviderData.Features.PreserveResourceIDCasing))
 
 	var defaultOutput interface{}
 	if !r.ProviderData.Features.DisableDefaultOutput {
@@ -605,10 +611,10 @@ func (r *AzapiUpdateResource) Read(ctx context.Context, request resource.ReadReq
 	}
 
 	state := model
-	state.ID = basetypes.NewStringValue(id.ID())
+	state.ID = basetypes.NewStringValue(preserveCasing(model.ID.ValueString(), id.ID(), r.ProviderData.Features.PreserveResourceIDCasing))
 	state.Name = basetypes.NewStringValue(id.Name)
 	state.ParentID = basetypes.NewStringValue(id.ParentId)
-	state.ResourceID = basetypes.NewStringValue(id.AzureResourceId)
+	state.ResourceID = basetypes.NewStringValue(preserveCasing(model.ResourceID.ValueString(), id.AzureResourceId, r.ProviderData.Features.PreserveResourceIDCasing))
 	state.Type = basetypes.NewStringValue(fmt.Sprintf("%s@%s", id.AzureResourceType, id.ApiVersion))
 
 	requestBody := make(map[string]interface{})

--- a/internal/services/azapi_update_resource_preserve_resource_id_casing_test.go
+++ b/internal/services/azapi_update_resource_preserve_resource_id_casing_test.go
@@ -1,0 +1,102 @@
+package services_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/Azure/terraform-provider-azapi/internal/acceptance"
+	"github.com/Azure/terraform-provider-azapi/internal/acceptance/check"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+// TestAccGenericUpdateResource_preserveResourceIDCasing exercises the
+// preserve_resource_id_casing provider feature flag end-to-end through
+// azapi_update_resource. The source resource is declared with a lower-case
+// leading character (webPubSub) while the azapi_update_resource type uses the
+// canonical casing (WebPubSub), so the flag governs how the id / resource_id
+// attributes are stored. Applying with the flag enabled must succeed and leave
+// no perpetual diff (the implicit post-apply plan is asserted empty by the
+// testing framework).
+func TestAccGenericUpdateResource_preserveResourceIDCasing(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azapi_update_resource", "test")
+	r := GenericUpdateResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.preserveResourceIDCasing(data, true),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("resource_id").Exists(),
+			),
+		},
+	})
+}
+
+// TestAccAzapiUpdateResourceUpgrade_preserveResourceIDCasing reproduces the
+// state-migration scenario from issue #1120. The resource is first deployed with
+// an older provider version (which stores the resource_id with whatever casing it
+// computed), then the provider is upgraded to the local build with
+// preserve_resource_id_casing enabled. The plan step asserts that no perpetual
+// diff is produced after the upgrade: the flag keeps the previously stored casing
+// rather than re-normalising it, which is exactly the behaviour the flag adds for
+// azapi_update_resource.resource_id.
+func TestAccAzapiUpdateResourceUpgrade_preserveResourceIDCasing(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azapi_update_resource", "test")
+	r := GenericUpdateResource{}
+
+	data.UpgradeTest(t, r, []resource.TestStep{
+		data.UpgradeTestDeployStep(resource.TestStep{
+			Config: r.preserveResourceIDCasing(data, false),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		}, PreviousVersion),
+		data.UpgradeTestPlanStep(resource.TestStep{
+			Config: r.preserveResourceIDCasing(data, true),
+		}),
+		data.UpgradeTestApplyStep(resource.TestStep{
+			Config: r.preserveResourceIDCasing(data, true),
+		}),
+	})
+}
+
+// preserveResourceIDCasing builds a config where an azapi_update_resource targets
+// a resource whose id casing differs from the canonical type casing. When enabled
+// is true an explicit provider block turns on preserve_resource_id_casing; when
+// false the config omits the block so it can be deployed by older provider
+// versions that do not know the attribute.
+func (r GenericUpdateResource) preserveResourceIDCasing(data acceptance.TestData, enabled bool) string {
+	providerBlock := ""
+	if enabled {
+		providerBlock = `
+provider "azapi" {
+  preserve_resource_id_casing = true
+}
+`
+	}
+
+	return fmt.Sprintf(`
+%[1]s
+%[2]s
+
+resource "azapi_update_resource" "test" {
+  type        = "Microsoft.SignalRService/WebPubSub@2024-04-01-preview"
+  resource_id = azapi_resource.webPubSub.id
+
+  body = {
+    properties = {
+      networkACLs = {
+        defaultAction = "Deny"
+        publicNetwork = {
+          allow = ["ClientConnection"]
+        }
+        ipRules = [{
+          value  = "0.0.0.0/0"
+          action = "Allow"
+        }]
+      }
+    }
+  }
+}
+`, providerBlock, r.templateForIDCasing(data))
+}

--- a/internal/services/common.go
+++ b/internal/services/common.go
@@ -3,11 +3,23 @@ package services
 import (
 	"encoding/json"
 	"errors"
+	"strings"
 
 	"github.com/Azure/terraform-provider-azapi/internal/services/dynamic"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
+
+// preserveCasing returns existing when enabled and case-insensitively equal to candidate; otherwise candidate.
+func preserveCasing(existing, candidate string, enabled bool) string {
+	if !enabled || existing == "" {
+		return candidate
+	}
+	if strings.EqualFold(existing, candidate) {
+		return existing
+	}
+	return candidate
+}
 
 func buildOutputFromBody(responseBody interface{}, modelResponseExportValues types.Dynamic, defaultResult interface{}) (types.Dynamic, error) {
 	if modelResponseExportValues.IsNull() {

--- a/internal/services/common_test.go
+++ b/internal/services/common_test.go
@@ -1,0 +1,93 @@
+package services
+
+import "testing"
+
+func TestPreserveCasing(t *testing.T) {
+	const (
+		serverFarmsID = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Web/serverFarms/plan1"
+		serverfarmsID = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Web/serverfarms/plan1"
+	)
+
+	testCases := []struct {
+		name      string
+		existing  string
+		candidate string
+		enabled   bool
+		expected  string
+	}{
+		{
+			name:      "disabled returns candidate",
+			existing:  "/foo/Bar",
+			candidate: "/foo/bar",
+			enabled:   false,
+			expected:  "/foo/bar",
+		},
+		{
+			name:      "enabled with empty existing returns candidate",
+			existing:  "",
+			candidate: "/foo/bar",
+			enabled:   true,
+			expected:  "/foo/bar",
+		},
+		{
+			name:      "enabled with case-insensitive match keeps existing",
+			existing:  "/foo/Bar",
+			candidate: "/foo/bar",
+			enabled:   true,
+			expected:  "/foo/Bar",
+		},
+		{
+			name:      "enabled with identical values keeps existing",
+			existing:  "/foo/bar",
+			candidate: "/foo/bar",
+			enabled:   true,
+			expected:  "/foo/bar",
+		},
+		{
+			name:      "enabled with genuinely different values returns candidate",
+			existing:  "/foo/bar",
+			candidate: "/foo/baz",
+			enabled:   true,
+			expected:  "/foo/baz",
+		},
+		{
+			// Regression test for #1120: after a state migration the resource id
+			// may have been normalised to lower case (serverfarms) while the value
+			// the provider recomputes preserves the original casing (serverFarms).
+			// With the feature enabled the state casing must be preserved so the
+			// azapi_resource identity does not report a spurious change.
+			name:      "enabled preserves migrated serverFarms casing (#1120)",
+			existing:  serverFarmsID,
+			candidate: serverfarmsID,
+			enabled:   true,
+			expected:  serverFarmsID,
+		},
+		{
+			// Same scenario but with the feature disabled (the default): the
+			// recomputed candidate wins so behaviour is unchanged for existing users.
+			name:      "disabled does not preserve migrated serverFarms casing (default)",
+			existing:  serverFarmsID,
+			candidate: serverfarmsID,
+			enabled:   false,
+			expected:  serverfarmsID,
+		},
+		{
+			// azapi_update_resource.resource_id path: the bare Azure resource id
+			// (without the api-version suffix) must also keep its state casing.
+			name:      "enabled preserves resource_id path casing",
+			existing:  "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/RG1/providers/Microsoft.Web/serverFarms/plan1",
+			candidate: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Web/serverfarms/plan1",
+			enabled:   true,
+			expected:  "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/RG1/providers/Microsoft.Web/serverFarms/plan1",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := preserveCasing(tc.existing, tc.candidate, tc.enabled)
+			if actual != tc.expected {
+				t.Fatalf("preserveCasing(%q, %q, %t) = %q, expected %q", tc.existing, tc.candidate, tc.enabled, actual, tc.expected)
+			}
+		})
+	}
+}

--- a/internal/services/preserve_resource_id_casing_test.go
+++ b/internal/services/preserve_resource_id_casing_test.go
@@ -1,0 +1,93 @@
+package services
+
+import (
+	"testing"
+
+	"github.com/Azure/terraform-provider-azapi/internal/services/parse"
+)
+
+const (
+	casingTestName     = "plan1"
+	casingTestParentID = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1"
+	casingTestType     = "Microsoft.Web/serverfarms@2025-03-01"
+
+	// State migrated from azurerm carries the casing Azure returns ("serverFarms"),
+	// while the provider rebuilds the id from the configured type ("serverfarms").
+	casingTestMigratedID   = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Web/serverFarms/plan1"
+	casingTestRecomputedID = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Web/serverfarms/plan1"
+)
+
+// TestPreserveResourceIDCasingAzapiResource covers the azapi_resource create/update
+// path, where the id is rebuilt with parse.NewResourceID and assigned to plan.ID.
+func TestPreserveResourceIDCasingAzapiResource(t *testing.T) {
+	id, err := parse.NewResourceID(casingTestName, casingTestParentID, casingTestType)
+	if err != nil {
+		t.Fatalf("building resource id: %+v", err)
+	}
+
+	// Without this the assertions below would pass vacuously.
+	if id.ID() != casingTestRecomputedID {
+		t.Fatalf("parse.NewResourceID() = %q, expected %q", id.ID(), casingTestRecomputedID)
+	}
+
+	if got := preserveCasing(casingTestMigratedID, id.ID(), false); got != casingTestRecomputedID {
+		t.Errorf("feature disabled: got %q, expected %q", got, casingTestRecomputedID)
+	}
+
+	if got := preserveCasing(casingTestMigratedID, id.ID(), true); got != casingTestMigratedID {
+		t.Errorf("feature enabled: got %q, expected %q", got, casingTestMigratedID)
+	}
+}
+
+// TestPreserveResourceIDCasingAzapiUpdateResourceNameParentID covers the
+// azapi_update_resource create/update path when name and parent_id are configured.
+// The last type segment comes from type, so both id and resource_id are rebuilt.
+func TestPreserveResourceIDCasingAzapiUpdateResourceNameParentID(t *testing.T) {
+	id, err := parse.NewResourceID(casingTestName, casingTestParentID, casingTestType)
+	if err != nil {
+		t.Fatalf("building resource id: %+v", err)
+	}
+
+	if id.ID() != casingTestRecomputedID || id.AzureResourceId != casingTestRecomputedID {
+		t.Fatalf("parse.NewResourceID() = (%q, %q), expected both to be %q", id.ID(), id.AzureResourceId, casingTestRecomputedID)
+	}
+
+	testCases := []struct {
+		name      string
+		candidate string
+		enabled   bool
+		expected  string
+	}{
+		{"id disabled", id.ID(), false, casingTestRecomputedID},
+		{"id enabled", id.ID(), true, casingTestMigratedID},
+		{"resource_id disabled", id.AzureResourceId, false, casingTestRecomputedID},
+		{"resource_id enabled", id.AzureResourceId, true, casingTestMigratedID},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := preserveCasing(casingTestMigratedID, tc.candidate, tc.enabled); got != tc.expected {
+				t.Fatalf("got %q, expected %q", got, tc.expected)
+			}
+		})
+	}
+}
+
+// TestPreserveResourceIDCasingAzapiUpdateResourceResourceID covers the
+// azapi_update_resource path when resource_id is configured. parse.ResourceIDWithResourceType
+// currently echoes the supplied casing, so this asserts the guarantee the feature
+// makes rather than that behaviour, and fails if a future parser change reintroduces #1120.
+func TestPreserveResourceIDCasingAzapiUpdateResourceResourceID(t *testing.T) {
+	id, err := parse.ResourceIDWithResourceType(casingTestMigratedID, casingTestType)
+	if err != nil {
+		t.Fatalf("parsing resource id: %+v", err)
+	}
+
+	if got := preserveCasing(casingTestMigratedID, id.ID(), true); got != casingTestMigratedID {
+		t.Errorf("feature enabled: got %q, expected %q", got, casingTestMigratedID)
+	}
+
+	if got := preserveCasing(casingTestMigratedID, id.AzureResourceId, true); got != casingTestMigratedID {
+		t.Errorf("feature enabled: got %q, expected %q", got, casingTestMigratedID)
+	}
+}


### PR DESCRIPTION
## Summary

Adds an opt-in provider feature flag `preserve_resource_id_casing` (default `false`) that preserves the existing casing of `id` and `resource_id` in state when the value the provider would otherwise write back differs only by casing.

Fixes #1120 (which references the original report at Azure/terraform-azurerm-avm-res-web-serverfarm#122).

## Why

One example of the issue: The Azure Verified Module `terraform-azurerm-avm-res-web-serverfarm` v2.0.0 switched from `azurerm_service_plan` to `azapi_resource`. Users upgrading from v1.0.0 hit `Unexpected Identity Change` errors because `azurerm` had written `serverFarms` (capital `F`) into state, while `azapi_resource` recomputes the ID with the casing from the user's `type` attribute, which the AVM module sets to `Microsoft.Web/serverfarms@2025-03-01` (lowercase `f`). Both spellings reference the same Azure resource, but Terraform's identity comparison is case-sensitive.

## Behaviour

- **Default (`false`)**: identical to today; the provider writes `id` / `resource_id` as computed.
- **`true`**: in Read and CreateUpdate, if `strings.EqualFold(state.id, computed.id)` and they differ, the existing casing in state is kept. Same for `resource_id`.
- Genuinely different values (not just casing) always pass through unchanged.
- Scope is limited to the `id` and `resource_id` attributes (and the framework identity derived from them). The user's HCL `type` value is never silently overridden.

## Configuration

```hcl
provider "azapi" {
  preserve_resource_id_casing = true
}
```

or via env: `ARM_PRESERVE_RESOURCE_ID_CASING=true`.

## Tests

- Added unit test `TestPreserveCasing` in `internal/services/common_test.go` covering: disabled, empty existing, case-only difference, identical, genuinely different.
- I did not add an acceptance test: the casing scenario is hard to provoke from a fresh `terraform apply` (state ID matches user's `type` casing on first write); reproducing it requires a state migrated/imported from another source. Happy to add one (e.g. via `terraform import` with a re-cased URL) if reviewers prefer.