### PR TITLE
Fix UpdateObject empty array handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ ENHANCEMENTS:
 - Bump `terraform-plugin-framework` from v1.16.1 to v1.19.0 (GH-1081).
 - Add example for `Microsoft.RedHatOpenShift/openShiftClusters` (GH-1083).
 
+BUG FIXES:
+
+- Fix a panic when comparing a non-empty configured list with an empty remote list during no-op change detection (GH-1125).
+
 ## v2.9.0
 
 ENHANCEMENTS:

--- a/utils/json.go
+++ b/utils/json.go
@@ -151,8 +151,8 @@ func updateObjectAtPath(old interface{}, new interface{}, option UpdateJsonOptio
 		}
 	case []interface{}:
 		if newArr, ok := new.([]interface{}); ok {
-			if len(oldValue) == 0 {
-				return new
+			if len(oldValue) == 0 || len(newArr) == 0 {
+				return newArr
 			}
 
 			identifierKey := listIdentifierKeyForPath(path, option)

--- a/utils/json_test.go
+++ b/utils/json_test.go
@@ -1075,6 +1075,49 @@ func Test_UpdateObjectDuplicateIdentifiersWithInconsistentOrdering(t *testing.T)
 	}
 }
 
+func Test_UpdateObjectNonEmptyOldArrayWithEmptyNewArray(t *testing.T) {
+	OldJson := `
+{
+  "properties": {
+    "subnets": [
+      {
+        "name": "default",
+        "properties": {
+          "addressPrefix": "10.0.3.0/24"
+        }
+      }
+    ]
+  }
+}
+`
+	NewJson := `
+{
+  "properties": {
+    "subnets": []
+  }
+}
+`
+	ExpectJson := `
+{
+  "properties": {
+    "subnets": []
+  }
+}
+`
+
+	var old, new, expected any
+	_ = json.Unmarshal([]byte(OldJson), &old)
+	_ = json.Unmarshal([]byte(NewJson), &new)
+	_ = json.Unmarshal([]byte(ExpectJson), &expected)
+
+	got := utils.UpdateObject(old, new, utils.UpdateJsonOption{})
+	if !reflect.DeepEqual(got, expected) {
+		expectedJson, _ := json.MarshalIndent(expected, "", "  ")
+		gotJson, _ := json.MarshalIndent(got, "", "  ")
+		t.Fatalf("Expected:\n%s\n\n but got\n%s", expectedJson, gotJson)
+	}
+}
+
 func Test_UpdateObject_ListUniqueIdProperty_IgnoreOtherItemsInList(t *testing.T) {
 	testcases := []struct {
 		Name                   string


### PR DESCRIPTION
## Summary
- Fix a panic in `UpdateObject` when no-op change detection compares a non-empty configured list with an empty remote list.
- The crash happened because `updateObjectAtPath` checked only the old array length before reading `newArr[0]` for list item identifier matching.
- Return the empty new array before identifier lookup, matching the existing empty-array handling in merge logic.
- Add a regression test that covers the non-empty old array plus empty new array case.

Fixes #1106
Fixes #1087 

## Tests
- go test ./utils -run Test_UpdateObjectNonEmptyOldArrayWithEmptyNewArray -count=1
- go test ./utils -count=1