### PR TITLE
feat: add sensitive_body support to azapi_resource_action variants

### DIFF
--- a/docs/actions/resource_action.md
+++ b/docs/actions/resource_action.md
@@ -148,3 +148,4 @@ action "azapi_resource_action" "power_on" {
 
 	-> Value must be one of: ["POST" "PATCH" "PUT" "DELETE" "GET" "HEAD"].
 - `query_parameters` (Map of List of String) Query parameters to include in the request.
+- `sensitive_body` (Dynamic, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) A dynamic attribute that contains the write-only properties of the request body. This will be merge-patched to the body to construct the actual request body.

--- a/docs/ephemeral-resources/resource_action.md
+++ b/docs/ephemeral-resources/resource_action.md
@@ -109,6 +109,7 @@ ephemeral "azapi_resource_action" "listKeys" {
 	To learn more about JMESPath, visit [JMESPath](https://jmespath.org/).
 
 - `retry` (Object) The retry object supports the following attributes: See [below for nested schema](#nested--retry).
+- `sensitive_body` (Dynamic) A dynamic attribute that contains the write-only properties of the request body. This will be merge-patched to the body to construct the actual request body.
 - `timeouts` (Block) See [below for nested schema](#nested--timeouts).
 
 ### Read-Only

--- a/docs/resources/resource_action.md
+++ b/docs/resources/resource_action.md
@@ -130,6 +130,8 @@ resource "azapi_resource_action" "stop" {
 
 	~> Use the state value when new value is functionally equivalent to the old and thus no change is required.
 - `retry` (Object) The retry object supports the following attributes: See [below for nested schema](#nested--retry).
+- `sensitive_body` (Dynamic, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) A dynamic attribute that contains the write-only properties of the request body. This will be merge-patched to the body to construct the actual request body.
+- `sensitive_body_version` (Map of String) A map where the key is the path to the property in `sensitive_body` and the value is the version of the property. The key is a string in the format of `path.to.property[index].subproperty`, where `index` is the index of the item in an array. When the version is changed, the property will be included in the request body, otherwise it will be omitted from the request body.
 - `sensitive_response_export_values` (Dynamic) The attribute can accept either a list or a map.
 
 	- **List**: A list of paths that need to be exported from the response body. Setting it to `["*"]` will export the full response body. Here's an example. If it sets to `["properties.loginServer", "properties.policies.quarantinePolicy.status"]`, it will set the following HCL object to the computed property output.

--- a/internal/services/azapi_resource_action.go
+++ b/internal/services/azapi_resource_action.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/terraform-provider-azapi/internal/services/common"
 	"github.com/Azure/terraform-provider-azapi/internal/services/myvalidator"
 	"github.com/Azure/terraform-provider-azapi/internal/services/parse"
+	"github.com/Azure/terraform-provider-azapi/utils"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/action"
@@ -29,6 +30,7 @@ type AzapiResourceActionModel struct {
 	Action          types.String  `tfsdk:"action"`
 	Method          types.String  `tfsdk:"method"`
 	Body            types.Dynamic `tfsdk:"body"`
+	SensitiveBody   types.Dynamic `tfsdk:"sensitive_body"`
 	Locks           types.List    `tfsdk:"locks"`
 	Headers         types.Map     `tfsdk:"headers"`
 	QueryParameters types.Map     `tfsdk:"query_parameters"`
@@ -94,6 +96,12 @@ func (a *AzapiResourceAction) Schema(ctx context.Context, req action.SchemaReque
 				},
 			},
 
+			"sensitive_body": actionschema.DynamicAttribute{
+				Optional:            true,
+				WriteOnly:           true,
+				MarkdownDescription: docstrings.SensitiveBody(),
+			},
+
 			"locks": actionschema.ListAttribute{
 				Optional:            true,
 				ElementType:         types.StringType,
@@ -142,6 +150,22 @@ func (a *AzapiResourceAction) Invoke(ctx context.Context, req action.InvokeReque
 	if err := unmarshalBody(config.Body, &requestBody); err != nil {
 		resp.Diagnostics.AddError("Invalid body", fmt.Sprintf("The argument \"body\" is invalid: %s", err.Error()))
 		return
+	}
+
+	// Merge sensitive_body into the request body
+	if !config.SensitiveBody.IsNull() {
+		sensitiveBody, err := unmarshalSensitiveBody(config.SensitiveBody, types.MapNull(types.StringType), types.MapNull(types.StringType))
+		if err != nil {
+			resp.Diagnostics.AddError("Invalid sensitive_body", fmt.Sprintf("The argument \"sensitive_body\" is invalid: %s", err.Error()))
+			return
+		}
+		if sensitiveBody != nil {
+			if requestBody == nil {
+				requestBody = sensitiveBody
+			} else {
+				requestBody = utils.MergeObject(requestBody, sensitiveBody)
+			}
+		}
 	}
 
 	lockIds := common.AsStringList(config.Locks)

--- a/internal/services/azapi_resource_action_ephemeral.go
+++ b/internal/services/azapi_resource_action_ephemeral.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Azure/terraform-provider-azapi/internal/services/common"
 	"github.com/Azure/terraform-provider-azapi/internal/services/myvalidator"
 	"github.com/Azure/terraform-provider-azapi/internal/services/parse"
+	"github.com/Azure/terraform-provider-azapi/utils"
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/ephemeral/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -32,6 +33,7 @@ type ActionEphemeralModel struct {
 	Action               types.String     `tfsdk:"action"`
 	Method               types.String     `tfsdk:"method"`
 	Body                 types.Dynamic    `tfsdk:"body"`
+	SensitiveBody        types.Dynamic    `tfsdk:"sensitive_body"`
 	Locks                types.List       `tfsdk:"locks"`
 	ResponseExportValues types.Dynamic    `tfsdk:"response_export_values"`
 	Output               types.Dynamic    `tfsdk:"output"`
@@ -107,6 +109,11 @@ func (r *ActionEphemeral) Schema(ctx context.Context, request ephemeral.SchemaRe
 				},
 			},
 
+			"sensitive_body": schema.DynamicAttribute{
+				Optional:            true,
+				MarkdownDescription: docstrings.SensitiveBody(),
+			},
+
 			"locks": schema.ListAttribute{
 				ElementType: types.StringType,
 				Optional:    true,
@@ -175,6 +182,22 @@ func (r *ActionEphemeral) Open(ctx context.Context, request ephemeral.OpenReques
 	if err := unmarshalBody(model.Body, &requestBody); err != nil {
 		response.Diagnostics.AddError("Invalid body", fmt.Sprintf(`The argument "body" is invalid: %s`, err.Error()))
 		return
+	}
+
+	// Merge sensitive_body into the request body
+	if !model.SensitiveBody.IsNull() {
+		sensitiveBody, err := unmarshalSensitiveBody(model.SensitiveBody, types.MapNull(types.StringType), types.MapNull(types.StringType))
+		if err != nil {
+			response.Diagnostics.AddError("Invalid sensitive_body", fmt.Sprintf(`The argument "sensitive_body" is invalid: %s`, err.Error()))
+			return
+		}
+		if sensitiveBody != nil {
+			if requestBody == nil {
+				requestBody = sensitiveBody
+			} else {
+				requestBody = utils.MergeObject(requestBody, sensitiveBody)
+			}
+		}
 	}
 
 	method := model.Method.ValueString()

--- a/internal/services/azapi_resource_action_resource.go
+++ b/internal/services/azapi_resource_action_resource.go
@@ -44,6 +44,8 @@ type ActionResourceModel struct {
 	Action                        types.String     `tfsdk:"action"`
 	Method                        types.String     `tfsdk:"method"`
 	Body                          types.Dynamic    `tfsdk:"body"`
+	SensitiveBody                 types.Dynamic    `tfsdk:"sensitive_body"`
+	SensitiveBodyVersion          types.Map        `tfsdk:"sensitive_body_version"`
 	When                          types.String     `tfsdk:"when"`
 	Locks                         types.List       `tfsdk:"locks"`
 	IgnoreNotFound                types.Bool       `tfsdk:"ignore_not_found"`
@@ -171,6 +173,18 @@ func (r *ActionResource) Schema(ctx context.Context, request resource.SchemaRequ
 				},
 			},
 
+			"sensitive_body": schema.DynamicAttribute{
+				Optional:            true,
+				WriteOnly:           true,
+				MarkdownDescription: docstrings.SensitiveBody(),
+			},
+
+			"sensitive_body_version": schema.MapAttribute{
+				ElementType:         types.StringType,
+				Optional:            true,
+				MarkdownDescription: docstrings.SensitiveBodyVersion(),
+			},
+
 			"when": schema.StringAttribute{
 				Optional: true,
 				Computed: true,
@@ -273,6 +287,15 @@ func (r *ActionResource) ModifyPlan(ctx context.Context, request resource.Modify
 		return
 	}
 
+	// Validate: when=destroy is incompatible with sensitive_body (Config unavailable in DeleteRequest)
+	if !config.SensitiveBody.IsNull() && config.When.ValueString() == "destroy" {
+		response.Diagnostics.AddError(
+			"Invalid configuration",
+			`"sensitive_body" is not supported when "when" is set to "destroy", because the configuration is not available during the destroy phase.`,
+		)
+		return
+	}
+
 	if state == nil || !dynamic.SemanticallyEqual(config.Body, state.Body) {
 		plan.Output = basetypes.NewDynamicUnknown()
 		plan.SensitiveOutput = basetypes.NewDynamicUnknown()
@@ -285,14 +308,28 @@ func (r *ActionResource) ModifyPlan(ctx context.Context, request resource.Modify
 		if !plan.SensitiveResponseExportValues.Equal(state.SensitiveResponseExportValues) {
 			plan.SensitiveOutput = basetypes.NewDynamicUnknown()
 		}
+
+		// Set output as unknown to trigger a plan diff, if sensitive_body has changed
+		diff, diags := ephemeralBodyChangeInPlan(ctx, request.Private, config.SensitiveBody, config.SensitiveBodyVersion, state.SensitiveBodyVersion)
+		if response.Diagnostics = append(response.Diagnostics, diags...); response.Diagnostics.HasError() {
+			return
+		}
+		if diff {
+			tflog.Info(ctx, `"sensitive_body" has changed`)
+			plan.Output = types.DynamicUnknown()
+			plan.SensitiveOutput = types.DynamicUnknown()
+		}
 	}
 
 	response.Diagnostics.Append(response.Plan.Set(ctx, plan)...)
 }
 
 func (r *ActionResource) Create(ctx context.Context, request resource.CreateRequest, response *resource.CreateResponse) {
-	var model ActionResourceModel
+	var model, config ActionResourceModel
 	if response.Diagnostics.Append(request.Plan.Get(ctx, &model)...); response.Diagnostics.HasError() {
+		return
+	}
+	if response.Diagnostics.Append(request.Config.Get(ctx, &config)...); response.Diagnostics.HasError() {
 		return
 	}
 
@@ -304,7 +341,7 @@ func (r *ActionResource) Create(ctx context.Context, request resource.CreateRequ
 	defer cancel()
 
 	if model.When.ValueString() == "apply" {
-		r.Action(ctx, model, &response.State, &response.Diagnostics)
+		r.Action(ctx, model, config, &response.State, &response.Diagnostics, response.Private, types.MapNull(types.StringType))
 	} else {
 		id, err := parse.ResourceIDWithResourceType(model.ResourceId.ValueString(), model.Type.ValueString())
 		if err != nil {
@@ -324,11 +361,14 @@ func (r *ActionResource) Create(ctx context.Context, request resource.CreateRequ
 }
 
 func (r *ActionResource) Update(ctx context.Context, request resource.UpdateRequest, response *resource.UpdateResponse) {
-	var state, plan ActionResourceModel
+	var state, plan, config ActionResourceModel
 	if response.Diagnostics.Append(request.Plan.Get(ctx, &plan)...); response.Diagnostics.HasError() {
 		return
 	}
 	if response.Diagnostics.Append(request.State.Get(ctx, &state)...); response.Diagnostics.HasError() {
+		return
+	}
+	if response.Diagnostics.Append(request.Config.Get(ctx, &config)...); response.Diagnostics.HasError() {
 		return
 	}
 
@@ -348,7 +388,7 @@ func (r *ActionResource) Update(ctx context.Context, request resource.UpdateRequ
 	tflog.Debug(ctx, "azapi_resource.CreateUpdate proceeding with external request as no skippable changes were detected")
 
 	if plan.When.ValueString() == "apply" {
-		r.Action(ctx, plan, &response.State, &response.Diagnostics)
+		r.Action(ctx, plan, config, &response.State, &response.Diagnostics, response.Private, state.SensitiveBodyVersion)
 	} else {
 		response.Diagnostics.Append(response.State.Set(ctx, plan)...)
 	}
@@ -361,7 +401,7 @@ func (r *ActionResource) Delete(ctx context.Context, request resource.DeleteRequ
 	}
 
 	if model.When.ValueString() == "destroy" {
-		r.Action(ctx, model, &response.State, &response.Diagnostics)
+		r.Action(ctx, model, ActionResourceModel{}, &response.State, &response.Diagnostics, nil, types.MapNull(types.StringType))
 	}
 }
 
@@ -378,7 +418,7 @@ func (r *ActionResource) Read(ctx context.Context, request resource.ReadRequest,
 	response.Diagnostics.Append(response.State.Set(ctx, state)...)
 }
 
-func (r *ActionResource) Action(ctx context.Context, model ActionResourceModel, state *tfsdk.State, diagnostics *diag.Diagnostics) {
+func (r *ActionResource) Action(ctx context.Context, model ActionResourceModel, config ActionResourceModel, state *tfsdk.State, diagnostics *diag.Diagnostics, privateData PrivateData, priorSensitiveBodyVersion types.Map) {
 	actionTimeout, diags := model.Timeouts.Create(ctx, 30*time.Minute)
 	diagnostics.Append(diags...)
 	if diagnostics.HasError() {
@@ -400,6 +440,22 @@ func (r *ActionResource) Action(ctx context.Context, model ActionResourceModel, 
 	if err := unmarshalBody(model.Body, &requestBody); err != nil {
 		diagnostics.AddError("Invalid body", fmt.Sprintf(`The argument "body" is invalid: %s`, err.Error()))
 		return
+	}
+
+	// Merge sensitive_body into the request body
+	if !config.SensitiveBody.IsNull() {
+		sensitiveBody, err := unmarshalSensitiveBody(config.SensitiveBody, model.SensitiveBodyVersion, priorSensitiveBodyVersion)
+		if err != nil {
+			diagnostics.AddError("Invalid sensitive_body", fmt.Sprintf(`The argument "sensitive_body" is invalid: %s`, err.Error()))
+			return
+		}
+		if sensitiveBody != nil {
+			if requestBody == nil {
+				requestBody = sensitiveBody
+			} else {
+				requestBody = utils.MergeObject(requestBody, sensitiveBody)
+			}
+		}
 	}
 
 	lockIds := common.AsStringList(model.Locks)
@@ -449,6 +505,20 @@ func (r *ActionResource) Action(ctx context.Context, model ActionResourceModel, 
 	model.SensitiveOutput = sensitiveOutput
 
 	diagnostics.Append(state.Set(ctx, model)...)
+
+	// Store sensitive_body hash in private state for change detection
+	if privateData != nil {
+		if model.SensitiveBodyVersion.IsNull() {
+			writeOnlyBytes, err := dynamic.ToJSON(config.SensitiveBody)
+			if err != nil {
+				diagnostics.AddError("Invalid sensitive_body", err.Error())
+				return
+			}
+			diagnostics.Append(ephemeralBodyPrivateMgr.Set(ctx, privateData, writeOnlyBytes)...)
+		} else {
+			diagnostics.Append(ephemeralBodyPrivateMgr.Set(ctx, privateData, nil)...)
+		}
+	}
 }
 
 func (r *ActionResource) RenderOption() tffwdocs.ResourceRenderOption {


### PR DESCRIPTION
## Summary

Adds sensitive_body support to the three azapi_resource_action variants, closing #1039.

### Changes

**azapi_resource_action (stateful resource)**
- Added sensitive_body (WriteOnly) and sensitive_body_version schema attributes
- Bumped schema version 2 -> 3 with v2-to-v3 state migration
- ModifyPlan: validates that when=destroy + sensitive_body is an error (Config unavailable in DeleteRequest)
- ModifyPlan: detects sensitive_body changes via ephemeralBodyChangeInPlan
- Create/Update: reads sensitive_body from Config, merges into request body
- Action(): accepts explicit prior SensitiveBodyVersion to avoid reading from the new (empty) response state
- Stores sensitive_body hash in private state for change detection

**azapi_resource_action (stateless action)**
- Added sensitive_body (WriteOnly) to model and schema
- Merges into request body in Invoke() with null guard

**azapi_resource_action (ephemeral resource)**
- Added sensitive_body (Optional) to model and schema -- WriteOnly is a no-op on ephemeral schemas by framework design
- Merges into request body in Open() with null guard

**State migration**
- New azapi_resource_action_migration_v2_to_v3.go sets sensitive_body_version to null map

### Design decisions
- when=destroy + sensitive_body -> hard error in ModifyPlan (Config is not available in DeleteRequest)
- No sensitive_body_version on stateless/ephemeral variants (no state to track)
- Null guard on unmarshalSensitiveBody prevents turning nil body into empty object
- Matches existing pattern from azapi_update_resource exactly

Fixes #1039
