### PR TITLE
feat: complete Azure AI Search data plane surface (aliases, skillsets, indexers)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ENHANCEMENTS:
 
+- `azapi_data_plane_resource` resource: Register `Microsoft.Search/searchServices/aliases` and add examples and acceptance test coverage for Azure AI Search `aliases`, `skillsets`, and `indexers` data plane resources.
 - `azapi` provider: Preflight validation is now enabled on resource update operations (previously only on create) (GH-1112).
 - `azapi` provider: Preflight validation now requires only read permission instead of write permission (GH-1112).
 - Bump Go version to 1.25.8 (GH-1082).

--- a/docs/resources/data_plane_resource.md
+++ b/docs/resources/data_plane_resource.md
@@ -284,6 +284,7 @@ Optional:
 | Microsoft.Purview/accounts/Scanning/managedvirtualnetworks | /managedvirtualnetworks/{managedVirtualNetworkName} | {accountName}.purview.azure.com/scan                                                        |
 | Microsoft.Purview/accounts/Scanning/managedvirtualnetworks/managedprivateendpoints | /managedvirtualnetworks/{managedVirtualNetworkName}/managedprivateendpoints/{managedPrivateEndpointName} | {accountName}.purview.azure.com/scan/managedvirtualnetworks/{managedVirtualNetworkName}     |
 | Microsoft.Purview/accounts/Workflow/workflows | /workflows/{workflowId} | {accountName}.purview.azure.com                                                             |
+| Microsoft.Search/searchServices/aliases | /aliases('{aliasName}') | {searchServiceName}.search.windows.net                                                      |
 | Microsoft.Search/searchServices/datasources | /datasources('{dataSourceName}') | {searchServiceName}.search.windows.net                                                      |
 | Microsoft.Search/searchServices/indexers | /indexers('{indexerName}') | {searchServiceName}.search.windows.net                                                      |
 | Microsoft.Search/searchServices/indexes | /indexes('{indexName}') | {searchServiceName}.search.windows.net                                                      |
@@ -918,6 +919,114 @@ resource "azapi_data_plane_resource" "example" {
 }
 ```
 
+### Microsoft.Search/searchServices/aliases
+
+```terraform
+terraform {
+  required_providers {
+    azapi = {
+      source = "Azure/azapi"
+    }
+  }
+}
+
+provider "azapi" {
+}
+
+resource "azapi_resource" "resourceGroup" {
+  type     = "Microsoft.Resources/resourceGroups@2021-04-01"
+  name     = "example-resources"
+  location = "westeurope"
+}
+
+resource "azapi_resource" "searchService" {
+  type      = "Microsoft.Search/searchServices@2023-11-01"
+  parent_id = azapi_resource.resourceGroup.id
+  name      = "examplesearch"
+  location  = azapi_resource.resourceGroup.location
+  body = {
+    properties = {
+      replicaCount   = 1
+      partitionCount = 1
+      hostingMode    = "default"
+      authOptions = {
+        aadOrApiKey = {
+          aadAuthFailureMode = "http401WithBearerChallenge"
+        }
+      }
+    }
+    sku = {
+      name = "basic"
+    }
+  }
+}
+
+data "azapi_client_config" "current" {}
+
+data "azapi_resource_list" "roleDefinitions" {
+  type      = "Microsoft.Authorization/roleDefinitions@2022-04-01"
+  parent_id = "/subscriptions/${data.azapi_client_config.current.subscription_id}"
+  response_export_values = {
+    searchIndexDataContributorRoleId = "value[?properties.roleName == 'Search Index Data Contributor'].id | [0]"
+  }
+}
+
+resource "azapi_resource" "roleAssignment" {
+  type      = "Microsoft.Authorization/roleAssignments@2022-04-01"
+  parent_id = azapi_resource.searchService.id
+  name      = uuid()
+  body = {
+    properties = {
+      principalId      = data.azapi_client_config.current.object_id
+      roleDefinitionId = data.azapi_resource_list.roleDefinitions.output.searchIndexDataContributorRoleId
+    }
+  }
+  lifecycle {
+    ignore_changes = [name]
+  }
+}
+
+resource "azapi_data_plane_resource" "index" {
+  type      = "Microsoft.Search/searchServices/indexes@2024-07-01"
+  parent_id = "${azapi_resource.searchService.name}.search.windows.net"
+  name      = "hotels-index"
+  body = {
+    fields = [
+      {
+        name       = "hotelId"
+        type       = "Edm.String"
+        key        = true
+        searchable = false
+      },
+      {
+        name       = "hotelName"
+        type       = "Edm.String"
+        searchable = true
+      }
+    ]
+  }
+
+  depends_on = [
+    azapi_resource.roleAssignment,
+  ]
+}
+
+resource "azapi_data_plane_resource" "example" {
+  type      = "Microsoft.Search/searchServices/aliases@2026-04-01"
+  parent_id = "${azapi_resource.searchService.name}.search.windows.net"
+  name      = "myalias"
+  body = {
+    name    = "myalias"
+    indexes = [azapi_data_plane_resource.index.name]
+  }
+
+  depends_on = [
+    azapi_resource.roleAssignment,
+    azapi_data_plane_resource.index,
+  ]
+}
+```
+
 ### Microsoft.Search/searchServices/datasources
 
 ```terraform
@@ -1038,6 +1147,169 @@ resource "azapi_data_plane_resource" "example" {
 }
 ```
 
+### Microsoft.Search/searchServices/indexers
+
+```terraform
+terraform {
+  required_providers {
+    azapi = {
+      source = "Azure/azapi"
+    }
+  }
+}
+
+provider "azapi" {
+}
+
+resource "azapi_resource" "resourceGroup" {
+  type     = "Microsoft.Resources/resourceGroups@2021-04-01"
+  name     = "example-resources"
+  location = "westeurope"
+}
+
+resource "azapi_resource" "searchService" {
+  type      = "Microsoft.Search/searchServices@2023-11-01"
+  parent_id = azapi_resource.resourceGroup.id
+  name      = "examplesearch"
+  location  = azapi_resource.resourceGroup.location
+  body = {
+    properties = {
+      replicaCount   = 1
+      partitionCount = 1
+      hostingMode    = "default"
+      authOptions = {
+        aadOrApiKey = {
+          aadAuthFailureMode = "http401WithBearerChallenge"
+        }
+      }
+    }
+    sku = {
+      name = "basic"
+    }
+  }
+}
+
+data "azapi_client_config" "current" {}
+
+data "azapi_resource_list" "roleDefinitions" {
+  type      = "Microsoft.Authorization/roleDefinitions@2022-04-01"
+  parent_id = "/subscriptions/${data.azapi_client_config.current.subscription_id}"
+  response_export_values = {
+    searchIndexDataContributorRoleId = "value[?properties.roleName == 'Search Index Data Contributor'].id | [0]"
+  }
+}
+
+resource "azapi_resource" "roleAssignment" {
+  type      = "Microsoft.Authorization/roleAssignments@2022-04-01"
+  parent_id = azapi_resource.searchService.id
+  name      = uuid()
+  body = {
+    properties = {
+      principalId      = data.azapi_client_config.current.object_id
+      roleDefinitionId = data.azapi_resource_list.roleDefinitions.output.searchIndexDataContributorRoleId
+    }
+  }
+  lifecycle {
+    ignore_changes = [name]
+  }
+}
+
+resource "azapi_resource" "storageAccount" {
+  type      = "Microsoft.Storage/storageAccounts@2023-01-01"
+  parent_id = azapi_resource.resourceGroup.id
+  name      = "examplestorageacct"
+  location  = azapi_resource.resourceGroup.location
+  body = {
+    kind = "StorageV2"
+    properties = {
+      accessTier = "Hot"
+    }
+    sku = {
+      name = "Standard_LRS"
+    }
+  }
+}
+
+data "azapi_resource_action" "listKeys" {
+  type                   = "Microsoft.Storage/storageAccounts@2023-01-01"
+  resource_id            = azapi_resource.storageAccount.id
+  action                 = "listKeys"
+  response_export_values = ["*"]
+}
+
+resource "azapi_resource" "storageContainer" {
+  type      = "Microsoft.Storage/storageAccounts/blobServices/containers@2023-01-01"
+  parent_id = "${azapi_resource.storageAccount.id}/blobServices/default"
+  name      = "content"
+  body = {
+    properties = {}
+  }
+}
+
+resource "azapi_data_plane_resource" "index" {
+  type      = "Microsoft.Search/searchServices/indexes@2024-07-01"
+  parent_id = "${azapi_resource.searchService.name}.search.windows.net"
+  name      = "hotels-index"
+  body = {
+    fields = [
+      {
+        name       = "hotelId"
+        type       = "Edm.String"
+        key        = true
+        searchable = false
+      },
+      {
+        name       = "hotelName"
+        type       = "Edm.String"
+        searchable = true
+      }
+    ]
+  }
+
+  depends_on = [
+    azapi_resource.roleAssignment,
+  ]
+}
+
+resource "azapi_data_plane_resource" "datasource" {
+  type      = "Microsoft.Search/searchServices/datasources@2024-07-01"
+  parent_id = "${azapi_resource.searchService.name}.search.windows.net"
+  name      = "mydatasource"
+  body = {
+    type = "azureblob"
+    credentials = {
+      connectionString = "DefaultEndpointsProtocol=https;AccountName=${azapi_resource.storageAccount.name};AccountKey=${data.azapi_resource_action.listKeys.output.keys[0].value};EndpointSuffix=core.windows.net"
+    }
+    container = {
+      name = azapi_resource.storageContainer.name
+    }
+  }
+
+  depends_on = [
+    azapi_resource.roleAssignment,
+  ]
+}
+
+resource "azapi_data_plane_resource" "example" {
+  type      = "Microsoft.Search/searchServices/indexers@2024-07-01"
+  parent_id = "${azapi_resource.searchService.name}.search.windows.net"
+  name      = "myindexer"
+  body = {
+    dataSourceName  = azapi_data_plane_resource.datasource.name
+    targetIndexName = azapi_data_plane_resource.index.name
+    schedule = {
+      interval = "PT2H"
+    }
+  }
+
+  depends_on = [
+    azapi_resource.roleAssignment,
+    azapi_data_plane_resource.datasource,
+    azapi_data_plane_resource.index,
+  ]
+}
+```
+
 ### Microsoft.Search/searchServices/indexes
 
 ```terraform
@@ -1133,6 +1405,107 @@ resource "azapi_data_plane_resource" "example" {
         type       = "Edm.String"
         searchable = true
         filterable = true
+      }
+    ]
+  }
+
+  depends_on = [
+    azapi_resource.roleAssignment,
+  ]
+}
+```
+
+### Microsoft.Search/searchServices/skillsets
+
+```terraform
+terraform {
+  required_providers {
+    azapi = {
+      source = "Azure/azapi"
+    }
+  }
+}
+
+provider "azapi" {
+}
+
+resource "azapi_resource" "resourceGroup" {
+  type     = "Microsoft.Resources/resourceGroups@2021-04-01"
+  name     = "example-resources"
+  location = "westeurope"
+}
+
+resource "azapi_resource" "searchService" {
+  type      = "Microsoft.Search/searchServices@2023-11-01"
+  parent_id = azapi_resource.resourceGroup.id
+  name      = "examplesearch"
+  location  = azapi_resource.resourceGroup.location
+  body = {
+    properties = {
+      replicaCount   = 1
+      partitionCount = 1
+      hostingMode    = "default"
+      authOptions = {
+        aadOrApiKey = {
+          aadAuthFailureMode = "http401WithBearerChallenge"
+        }
+      }
+    }
+    sku = {
+      name = "basic"
+    }
+  }
+}
+
+data "azapi_client_config" "current" {}
+
+data "azapi_resource_list" "roleDefinitions" {
+  type      = "Microsoft.Authorization/roleDefinitions@2022-04-01"
+  parent_id = "/subscriptions/${data.azapi_client_config.current.subscription_id}"
+  response_export_values = {
+    searchIndexDataContributorRoleId = "value[?properties.roleName == 'Search Index Data Contributor'].id | [0]"
+  }
+}
+
+resource "azapi_resource" "roleAssignment" {
+  type      = "Microsoft.Authorization/roleAssignments@2022-04-01"
+  parent_id = azapi_resource.searchService.id
+  name      = uuid()
+  body = {
+    properties = {
+      principalId      = data.azapi_client_config.current.object_id
+      roleDefinitionId = data.azapi_resource_list.roleDefinitions.output.searchIndexDataContributorRoleId
+    }
+  }
+  lifecycle {
+    ignore_changes = [name]
+  }
+}
+
+resource "azapi_data_plane_resource" "example" {
+  type      = "Microsoft.Search/searchServices/skillsets@2024-07-01"
+  parent_id = "${azapi_resource.searchService.name}.search.windows.net"
+  name      = "myskillset"
+  body = {
+    description = "Example skillset that splits document content into pages"
+    skills = [
+      {
+        "@odata.type"     = "#Microsoft.Skills.Text.SplitSkill"
+        name              = "split-into-pages"
+        textSplitMode     = "pages"
+        maximumPageLength = 1000
+        inputs = [
+          {
+            name   = "text"
+            source = "/document/content"
+          }
+        ]
+        outputs = [
+          {
+            name       = "textItems"
+            targetName = "pages"
+          }
+        ]
       }
     ]
   }

--- a/examples/resources/azapi_data_plane_resource/Microsoft.Search_searchServices_aliases/main.tf
+++ b/examples/resources/azapi_data_plane_resource/Microsoft.Search_searchServices_aliases/main.tf
@@ -1,0 +1,103 @@
+terraform {
+  required_providers {
+    azapi = {
+      source = "Azure/azapi"
+    }
+  }
+}
+
+provider "azapi" {
+}
+
+resource "azapi_resource" "resourceGroup" {
+  type     = "Microsoft.Resources/resourceGroups@2021-04-01"
+  name     = "example-resources"
+  location = "westeurope"
+}
+
+resource "azapi_resource" "searchService" {
+  type      = "Microsoft.Search/searchServices@2023-11-01"
+  parent_id = azapi_resource.resourceGroup.id
+  name      = "examplesearch"
+  location  = azapi_resource.resourceGroup.location
+  body = {
+    properties = {
+      replicaCount   = 1
+      partitionCount = 1
+      hostingMode    = "default"
+      authOptions = {
+        aadOrApiKey = {
+          aadAuthFailureMode = "http401WithBearerChallenge"
+        }
+      }
+    }
+    sku = {
+      name = "basic"
+    }
+  }
+}
+
+data "azapi_client_config" "current" {}
+
+data "azapi_resource_list" "roleDefinitions" {
+  type      = "Microsoft.Authorization/roleDefinitions@2022-04-01"
+  parent_id = "/subscriptions/${data.azapi_client_config.current.subscription_id}"
+  response_export_values = {
+    searchIndexDataContributorRoleId = "value[?properties.roleName == 'Search Index Data Contributor'].id | [0]"
+  }
+}
+
+resource "azapi_resource" "roleAssignment" {
+  type      = "Microsoft.Authorization/roleAssignments@2022-04-01"
+  parent_id = azapi_resource.searchService.id
+  name      = uuid()
+  body = {
+    properties = {
+      principalId      = data.azapi_client_config.current.object_id
+      roleDefinitionId = data.azapi_resource_list.roleDefinitions.output.searchIndexDataContributorRoleId
+    }
+  }
+  lifecycle {
+    ignore_changes = [name]
+  }
+}
+
+resource "azapi_data_plane_resource" "index" {
+  type      = "Microsoft.Search/searchServices/indexes@2024-07-01"
+  parent_id = "${azapi_resource.searchService.name}.search.windows.net"
+  name      = "hotels-index"
+  body = {
+    fields = [
+      {
+        name       = "hotelId"
+        type       = "Edm.String"
+        key        = true
+        searchable = false
+      },
+      {
+        name       = "hotelName"
+        type       = "Edm.String"
+        searchable = true
+      }
+    ]
+  }
+
+  depends_on = [
+    azapi_resource.roleAssignment,
+  ]
+}
+
+resource "azapi_data_plane_resource" "example" {
+  type      = "Microsoft.Search/searchServices/aliases@2026-04-01"
+  parent_id = "${azapi_resource.searchService.name}.search.windows.net"
+  name      = "myalias"
+  body = {
+    name    = "myalias"
+    indexes = [azapi_data_plane_resource.index.name]
+  }
+
+  depends_on = [
+    azapi_resource.roleAssignment,
+    azapi_data_plane_resource.index,
+  ]
+}

--- a/examples/resources/azapi_data_plane_resource/Microsoft.Search_searchServices_indexers/main.tf
+++ b/examples/resources/azapi_data_plane_resource/Microsoft.Search_searchServices_indexers/main.tf
@@ -1,0 +1,158 @@
+terraform {
+  required_providers {
+    azapi = {
+      source = "Azure/azapi"
+    }
+  }
+}
+
+provider "azapi" {
+}
+
+resource "azapi_resource" "resourceGroup" {
+  type     = "Microsoft.Resources/resourceGroups@2021-04-01"
+  name     = "example-resources"
+  location = "westeurope"
+}
+
+resource "azapi_resource" "searchService" {
+  type      = "Microsoft.Search/searchServices@2023-11-01"
+  parent_id = azapi_resource.resourceGroup.id
+  name      = "examplesearch"
+  location  = azapi_resource.resourceGroup.location
+  body = {
+    properties = {
+      replicaCount   = 1
+      partitionCount = 1
+      hostingMode    = "default"
+      authOptions = {
+        aadOrApiKey = {
+          aadAuthFailureMode = "http401WithBearerChallenge"
+        }
+      }
+    }
+    sku = {
+      name = "basic"
+    }
+  }
+}
+
+data "azapi_client_config" "current" {}
+
+data "azapi_resource_list" "roleDefinitions" {
+  type      = "Microsoft.Authorization/roleDefinitions@2022-04-01"
+  parent_id = "/subscriptions/${data.azapi_client_config.current.subscription_id}"
+  response_export_values = {
+    searchIndexDataContributorRoleId = "value[?properties.roleName == 'Search Index Data Contributor'].id | [0]"
+  }
+}
+
+resource "azapi_resource" "roleAssignment" {
+  type      = "Microsoft.Authorization/roleAssignments@2022-04-01"
+  parent_id = azapi_resource.searchService.id
+  name      = uuid()
+  body = {
+    properties = {
+      principalId      = data.azapi_client_config.current.object_id
+      roleDefinitionId = data.azapi_resource_list.roleDefinitions.output.searchIndexDataContributorRoleId
+    }
+  }
+  lifecycle {
+    ignore_changes = [name]
+  }
+}
+
+resource "azapi_resource" "storageAccount" {
+  type      = "Microsoft.Storage/storageAccounts@2023-01-01"
+  parent_id = azapi_resource.resourceGroup.id
+  name      = "examplestorageacct"
+  location  = azapi_resource.resourceGroup.location
+  body = {
+    kind = "StorageV2"
+    properties = {
+      accessTier = "Hot"
+    }
+    sku = {
+      name = "Standard_LRS"
+    }
+  }
+}
+
+data "azapi_resource_action" "listKeys" {
+  type                   = "Microsoft.Storage/storageAccounts@2023-01-01"
+  resource_id            = azapi_resource.storageAccount.id
+  action                 = "listKeys"
+  response_export_values = ["*"]
+}
+
+resource "azapi_resource" "storageContainer" {
+  type      = "Microsoft.Storage/storageAccounts/blobServices/containers@2023-01-01"
+  parent_id = "${azapi_resource.storageAccount.id}/blobServices/default"
+  name      = "content"
+  body = {
+    properties = {}
+  }
+}
+
+resource "azapi_data_plane_resource" "index" {
+  type      = "Microsoft.Search/searchServices/indexes@2024-07-01"
+  parent_id = "${azapi_resource.searchService.name}.search.windows.net"
+  name      = "hotels-index"
+  body = {
+    fields = [
+      {
+        name       = "hotelId"
+        type       = "Edm.String"
+        key        = true
+        searchable = false
+      },
+      {
+        name       = "hotelName"
+        type       = "Edm.String"
+        searchable = true
+      }
+    ]
+  }
+
+  depends_on = [
+    azapi_resource.roleAssignment,
+  ]
+}
+
+resource "azapi_data_plane_resource" "datasource" {
+  type      = "Microsoft.Search/searchServices/datasources@2024-07-01"
+  parent_id = "${azapi_resource.searchService.name}.search.windows.net"
+  name      = "mydatasource"
+  body = {
+    type = "azureblob"
+    credentials = {
+      connectionString = "DefaultEndpointsProtocol=https;AccountName=${azapi_resource.storageAccount.name};AccountKey=${data.azapi_resource_action.listKeys.output.keys[0].value};EndpointSuffix=core.windows.net"
+    }
+    container = {
+      name = azapi_resource.storageContainer.name
+    }
+  }
+
+  depends_on = [
+    azapi_resource.roleAssignment,
+  ]
+}
+
+resource "azapi_data_plane_resource" "example" {
+  type      = "Microsoft.Search/searchServices/indexers@2024-07-01"
+  parent_id = "${azapi_resource.searchService.name}.search.windows.net"
+  name      = "myindexer"
+  body = {
+    dataSourceName  = azapi_data_plane_resource.datasource.name
+    targetIndexName = azapi_data_plane_resource.index.name
+    schedule = {
+      interval = "PT2H"
+    }
+  }
+
+  depends_on = [
+    azapi_resource.roleAssignment,
+    azapi_data_plane_resource.datasource,
+    azapi_data_plane_resource.index,
+  ]
+}

--- a/examples/resources/azapi_data_plane_resource/Microsoft.Search_searchServices_skillsets/main.tf
+++ b/examples/resources/azapi_data_plane_resource/Microsoft.Search_searchServices_skillsets/main.tf
@@ -1,0 +1,96 @@
+terraform {
+  required_providers {
+    azapi = {
+      source = "Azure/azapi"
+    }
+  }
+}
+
+provider "azapi" {
+}
+
+resource "azapi_resource" "resourceGroup" {
+  type     = "Microsoft.Resources/resourceGroups@2021-04-01"
+  name     = "example-resources"
+  location = "westeurope"
+}
+
+resource "azapi_resource" "searchService" {
+  type      = "Microsoft.Search/searchServices@2023-11-01"
+  parent_id = azapi_resource.resourceGroup.id
+  name      = "examplesearch"
+  location  = azapi_resource.resourceGroup.location
+  body = {
+    properties = {
+      replicaCount   = 1
+      partitionCount = 1
+      hostingMode    = "default"
+      authOptions = {
+        aadOrApiKey = {
+          aadAuthFailureMode = "http401WithBearerChallenge"
+        }
+      }
+    }
+    sku = {
+      name = "basic"
+    }
+  }
+}
+
+data "azapi_client_config" "current" {}
+
+data "azapi_resource_list" "roleDefinitions" {
+  type      = "Microsoft.Authorization/roleDefinitions@2022-04-01"
+  parent_id = "/subscriptions/${data.azapi_client_config.current.subscription_id}"
+  response_export_values = {
+    searchIndexDataContributorRoleId = "value[?properties.roleName == 'Search Index Data Contributor'].id | [0]"
+  }
+}
+
+resource "azapi_resource" "roleAssignment" {
+  type      = "Microsoft.Authorization/roleAssignments@2022-04-01"
+  parent_id = azapi_resource.searchService.id
+  name      = uuid()
+  body = {
+    properties = {
+      principalId      = data.azapi_client_config.current.object_id
+      roleDefinitionId = data.azapi_resource_list.roleDefinitions.output.searchIndexDataContributorRoleId
+    }
+  }
+  lifecycle {
+    ignore_changes = [name]
+  }
+}
+
+resource "azapi_data_plane_resource" "example" {
+  type      = "Microsoft.Search/searchServices/skillsets@2024-07-01"
+  parent_id = "${azapi_resource.searchService.name}.search.windows.net"
+  name      = "myskillset"
+  body = {
+    description = "Example skillset that splits document content into pages"
+    skills = [
+      {
+        "@odata.type"     = "#Microsoft.Skills.Text.SplitSkill"
+        name              = "split-into-pages"
+        textSplitMode     = "pages"
+        maximumPageLength = 1000
+        inputs = [
+          {
+            name   = "text"
+            source = "/document/content"
+          }
+        ]
+        outputs = [
+          {
+            name       = "textItems"
+            targetName = "pages"
+          }
+        ]
+      }
+    ]
+  }
+
+  depends_on = [
+    azapi_resource.roleAssignment,
+  ]
+}

--- a/internal/services/azapi_data_plane_resource_test.go
+++ b/internal/services/azapi_data_plane_resource_test.go
@@ -182,6 +182,34 @@ func TestAccDataPlaneResource_searchServiceSynonymMap(t *testing.T) {
 	})
 }
 
+func TestAccDataPlaneResource_searchServiceSkillset(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azapi_data_plane_resource", "test")
+	r := DataPlaneResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.searchServiceSkillset(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+	})
+}
+
+func TestAccDataPlaneResource_searchServiceAlias(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azapi_data_plane_resource", "test")
+	r := DataPlaneResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.searchServiceAlias(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+	})
+}
+
 func TestAccDataPlaneResource_headers(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azapi_data_plane_resource", "test")
 	r := DataPlaneResource{}
@@ -1317,6 +1345,193 @@ resource "azapi_data_plane_resource" "test" {
 
   depends_on = [
     azapi_resource.roleAssignment,
+  ]
+}
+`, data.LocationPrimary, data.RandomString)
+}
+
+func (r DataPlaneResource) searchServiceSkillset(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+resource "azapi_resource" "resourceGroup" {
+  type     = "Microsoft.Resources/resourceGroups@2021-04-01"
+  name     = "acctest%[2]s"
+  location = "%[1]s"
+}
+
+resource "azapi_resource" "searchService" {
+  type      = "Microsoft.Search/searchServices@2023-11-01"
+  parent_id = azapi_resource.resourceGroup.id
+  name      = "acctest%[2]s"
+  location  = azapi_resource.resourceGroup.location
+  body = {
+    properties = {
+      replicaCount   = 1
+      partitionCount = 1
+      hostingMode    = "default"
+      authOptions = {
+        aadOrApiKey = {
+          aadAuthFailureMode = "http401WithBearerChallenge"
+        }
+      }
+    }
+    sku = {
+      name = "standard"
+    }
+  }
+}
+
+data "azapi_client_config" "current" {}
+
+data "azapi_resource_list" "roleDefinitions" {
+  type      = "Microsoft.Authorization/roleDefinitions@2022-04-01"
+  parent_id = "/subscriptions/${data.azapi_client_config.current.subscription_id}"
+  response_export_values = {
+    searchIndexDataContributorRoleId = "value[?properties.roleName == 'Search Index Data Contributor'].id | [0]"
+  }
+}
+
+resource "azapi_resource" "roleAssignment" {
+  type      = "Microsoft.Authorization/roleAssignments@2022-04-01"
+  parent_id = azapi_resource.searchService.id
+  name      = uuid()
+  body = {
+    properties = {
+      principalId      = data.azapi_client_config.current.object_id
+      roleDefinitionId = data.azapi_resource_list.roleDefinitions.output.searchIndexDataContributorRoleId
+    }
+  }
+  lifecycle {
+    ignore_changes = [name]
+  }
+}
+
+resource "azapi_data_plane_resource" "test" {
+  type      = "Microsoft.Search/searchServices/skillsets@2024-07-01"
+  parent_id = "${azapi_resource.searchService.name}.search.windows.net"
+  name      = "myskillset"
+  body = {
+    description = "Split document content into pages"
+    skills = [
+      {
+        "@odata.type"     = "#Microsoft.Skills.Text.SplitSkill"
+        name              = "split-into-pages"
+        textSplitMode     = "pages"
+        maximumPageLength = 1000
+        inputs = [
+          {
+            name   = "text"
+            source = "/document/content"
+          }
+        ]
+        outputs = [
+          {
+            name       = "textItems"
+            targetName = "pages"
+          }
+        ]
+      }
+    ]
+  }
+
+  depends_on = [
+    azapi_resource.roleAssignment,
+  ]
+}
+`, data.LocationPrimary, data.RandomString)
+}
+
+func (r DataPlaneResource) searchServiceAlias(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+resource "azapi_resource" "resourceGroup" {
+  type     = "Microsoft.Resources/resourceGroups@2021-04-01"
+  name     = "acctest%[2]s"
+  location = "%[1]s"
+}
+
+resource "azapi_resource" "searchService" {
+  type      = "Microsoft.Search/searchServices@2023-11-01"
+  parent_id = azapi_resource.resourceGroup.id
+  name      = "acctest%[2]s"
+  location  = azapi_resource.resourceGroup.location
+  body = {
+    properties = {
+      replicaCount   = 1
+      partitionCount = 1
+      hostingMode    = "default"
+      authOptions = {
+        aadOrApiKey = {
+          aadAuthFailureMode = "http401WithBearerChallenge"
+        }
+      }
+    }
+    sku = {
+      name = "standard"
+    }
+  }
+}
+
+data "azapi_client_config" "current" {}
+
+data "azapi_resource_list" "roleDefinitions" {
+  type      = "Microsoft.Authorization/roleDefinitions@2022-04-01"
+  parent_id = "/subscriptions/${data.azapi_client_config.current.subscription_id}"
+  response_export_values = {
+    searchIndexDataContributorRoleId = "value[?properties.roleName == 'Search Index Data Contributor'].id | [0]"
+  }
+}
+
+resource "azapi_resource" "roleAssignment" {
+  type      = "Microsoft.Authorization/roleAssignments@2022-04-01"
+  parent_id = azapi_resource.searchService.id
+  name      = uuid()
+  body = {
+    properties = {
+      principalId      = data.azapi_client_config.current.object_id
+      roleDefinitionId = data.azapi_resource_list.roleDefinitions.output.searchIndexDataContributorRoleId
+    }
+  }
+  lifecycle {
+    ignore_changes = [name]
+  }
+}
+
+resource "azapi_data_plane_resource" "index" {
+  type      = "Microsoft.Search/searchServices/indexes@2024-07-01"
+  parent_id = "${azapi_resource.searchService.name}.search.windows.net"
+  name      = "hotels-index"
+  body = {
+    fields = [
+      {
+        name       = "hotelId"
+        type       = "Edm.String"
+        key        = true
+        searchable = false
+      },
+      {
+        name       = "hotelName"
+        type       = "Edm.String"
+        searchable = true
+      }
+    ]
+  }
+
+  depends_on = [
+    azapi_resource.roleAssignment,
+  ]
+}
+
+resource "azapi_data_plane_resource" "test" {
+  type      = "Microsoft.Search/searchServices/aliases@2026-04-01"
+  parent_id = "${azapi_resource.searchService.name}.search.windows.net"
+  name      = "myalias"
+  body = {
+    name    = "myalias"
+    indexes = [azapi_data_plane_resource.index.name]
+  }
+
+  depends_on = [
+    azapi_resource.roleAssignment,
+    azapi_data_plane_resource.index,
   ]
 }
 `, data.LocationPrimary, data.RandomString)

--- a/internal/services/parse/data_plane_resources.json
+++ b/internal/services/parse/data_plane_resources.json
@@ -371,13 +371,15 @@
     "UrlFormat": "{parentId}/indexers('{name}')",
     "ResourceType": "Microsoft.Search/searchServices/indexers",
     "ParentIDExample": "{searchServiceName}.search.windows.net",
-    "Url": "/indexers('{indexerName}')"
+    "Url": "/indexers('{indexerName}')",
+    "ExamplePath": "examples/resources/azapi_data_plane_resource/Microsoft.Search_searchServices_indexers/main.tf"
   },
   {
     "UrlFormat": "{parentId}/skillsets('{name}')",
     "ResourceType": "Microsoft.Search/searchServices/skillsets",
     "ParentIDExample": "{searchServiceName}.search.windows.net",
-    "Url": "/skillsets('{skillsetName}')"
+    "Url": "/skillsets('{skillsetName}')",
+    "ExamplePath": "examples/resources/azapi_data_plane_resource/Microsoft.Search_searchServices_skillsets/main.tf"
   },
   {
     "UrlFormat": "{parentId}/synonymmaps('{name}')",
@@ -385,6 +387,13 @@
     "ParentIDExample": "{searchServiceName}.search.windows.net",
     "Url": "/synonymmaps('{synonymMapName}')",
     "ExamplePath": "examples/resources/azapi_data_plane_resource/Microsoft.Search_searchServices_synonymmaps/main.tf"
+  },
+  {
+    "UrlFormat": "{parentId}/aliases('{name}')",
+    "ResourceType": "Microsoft.Search/searchServices/aliases",
+    "ParentIDExample": "{searchServiceName}.search.windows.net",
+    "Url": "/aliases('{aliasName}')",
+    "ExamplePath": "examples/resources/azapi_data_plane_resource/Microsoft.Search_searchServices_aliases/main.tf"
   },
   {
     "UrlFormat": "{parentId}/agents/{name}",


### PR DESCRIPTION
### Summary

Completes the Azure AI Search data plane surface for `azapi_data_plane_resource`.

Most of the AI Search data plane is already supported (`indexes`, `datasources`, `indexers`, `skillsets`, `synonymmaps` are registered). This PR fills the remaining gaps:

- **Registers `Microsoft.Search/searchServices/aliases`** — the only AI Search data plane resource that was not registered.
- **Adds example coverage** for `aliases`, `skillsets`, and `indexers` (and wires `ExamplePath` for indexers/skillsets in the registry).
- **Adds acceptance tests** `TestAccDataPlaneResource_searchServiceSkillset` and `TestAccDataPlaneResource_searchServiceAlias`.

### API version note

Index `aliases` use api-version **`2026-04-01`**, which is the first **stable** Search data plane version that defines the `/aliases` endpoint (verified against `azure-rest-api-specs`; `2024-07-01` and `2025-09-01` do not include it). All other Search types remain on `2024-07-01`.

### Testing

All six AI Search data plane acceptance tests pass against live Azure:

| Test | Result |
| --- | --- |
| `TestAccDataPlaneResource_searchServiceIndex` | PASS |
| `TestAccDataPlaneResource_searchServiceDataSource` | PASS |
| `TestAccDataPlaneResource_searchServiceIndexer` | PASS |
| `TestAccDataPlaneResource_searchServiceSynonymMap` | PASS |
| `TestAccDataPlaneResource_searchServiceSkillset` (new) | PASS |
| `TestAccDataPlaneResource_searchServiceAlias` (new) | PASS |

This is an additive, low-risk change (registry entry + examples + tests + generated docs).