### PR TITLE
Support sensitive body in resource action

### DIFF
--- a/docs/actions/resource_action.md
+++ b/docs/actions/resource_action.md
@@ -148,4 +148,4 @@ action "azapi_resource_action" "power_on" {
 
 	-> Value must be one of: ["POST" "PATCH" "PUT" "DELETE" "GET" "HEAD"].
 - `query_parameters` (Map of List of String) Query parameters to include in the request.
-- `sensitive_body` (Dynamic, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) A dynamic attribute that contains the write-only properties of the request body. This will be merge-patched to the body to construct the actual request body.
+- `sensitive_body` (Dynamic, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) A dynamic attribute that contains the write-only properties of the request body. This will be merge-patched to the body to construct the actual request body. If a property is defined in both `body` and `sensitive_body`, the `sensitive_body` value takes precedence.

--- a/docs/actions/resource_action.md
+++ b/docs/actions/resource_action.md
@@ -148,3 +148,4 @@ action "azapi_resource_action" "power_on" {
 
 	-> Value must be one of: ["POST" "PATCH" "PUT" "DELETE" "GET" "HEAD"].
 - `query_parameters` (Map of List of String) Query parameters to include in the request.
+- `sensitive_body` (Dynamic, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) A dynamic attribute that contains the write-only properties of the request body. This will be merge-patched to the body to construct the actual request body.

--- a/docs/ephemeral-resources/resource_action.md
+++ b/docs/ephemeral-resources/resource_action.md
@@ -109,7 +109,7 @@ ephemeral "azapi_resource_action" "listKeys" {
 	To learn more about JMESPath, visit [JMESPath](https://jmespath.org/).
 
 - `retry` (Object) The retry object supports the following attributes: See [below for nested schema](#nested--retry).
-- `sensitive_body` (Dynamic) A dynamic attribute that contains the write-only properties of the request body. This will be merge-patched to the body to construct the actual request body.
+- `sensitive_body` (Dynamic) A dynamic attribute that contains the write-only properties of the request body. This will be merge-patched to the body to construct the actual request body. If a property is defined in both `body` and `sensitive_body`, the `sensitive_body` value takes precedence.
 - `timeouts` (Block) See [below for nested schema](#nested--timeouts).
 
 ### Read-Only

--- a/docs/ephemeral-resources/resource_action.md
+++ b/docs/ephemeral-resources/resource_action.md
@@ -109,6 +109,7 @@ ephemeral "azapi_resource_action" "listKeys" {
 	To learn more about JMESPath, visit [JMESPath](https://jmespath.org/).
 
 - `retry` (Object) The retry object supports the following attributes: See [below for nested schema](#nested--retry).
+- `sensitive_body` (Dynamic) A dynamic attribute that contains the write-only properties of the request body. This will be merge-patched to the body to construct the actual request body.
 - `timeouts` (Block) See [below for nested schema](#nested--timeouts).
 
 ### Read-Only

--- a/docs/guides/feature_ephemeral_resource.md
+++ b/docs/guides/feature_ephemeral_resource.md
@@ -54,7 +54,7 @@ The below example demonstrates how to use the `sensitive_body` attribute to crea
 
 The `properties.storageAccount.key` acceptes the storage account key, which is sensitive information. To avoid storing this key in the state file, it was retrieved using the `azapi_resource_action` ephemeral resource, and passed to the `sensitive_body` attribute.
 
-The `sensitive_body` and `body` attributes will be merged into the request body.
+The `sensitive_body` and `body` attributes will be merged into the request body. If a property is defined in both `body` and `sensitive_body`, the `sensitive_body` value takes precedence.
 
 
 ```hcl

--- a/docs/resources/data_plane_resource.md
+++ b/docs/resources/data_plane_resource.md
@@ -161,7 +161,7 @@ resource "azapi_data_plane_resource" "dataset" {
 
 	~> Use the state value when new value is functionally equivalent to the old and thus no change is required.
 - `retry` (Object) The retry object supports the following attributes: See [below for nested schema](#nested--retry).
-- `sensitive_body` (Dynamic, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) A dynamic attribute that contains the write-only properties of the request body. This will be merge-patched to the body to construct the actual request body.
+- `sensitive_body` (Dynamic, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) A dynamic attribute that contains the write-only properties of the request body. This will be merge-patched to the body to construct the actual request body. If a property is defined in both `body` and `sensitive_body`, the `sensitive_body` value takes precedence.
 - `sensitive_body_version` (Map of String) A map where the key is the path to the property in `sensitive_body` and the value is the version of the property. The key is a string in the format of `path.to.property[index].subproperty`, where `index` is the index of the item in an array. When the version is changed, the property will be included in the request body, otherwise it will be omitted from the request body.
 - `timeouts` (Block) See [below for nested schema](#nested--timeouts).
 - `update_headers` (Map of String) A mapping of headers to be sent with the update request.

--- a/docs/resources/resource.md
+++ b/docs/resources/resource.md
@@ -191,7 +191,7 @@ output "quarantine_policy" {
 	~> Use the state value when new value is functionally equivalent to the old and thus no change is required.
 - `retry` (Object) The retry object supports the following attributes: See [below for nested schema](#nested--retry).
 - `schema_validation_enabled` (Boolean) Whether enabled the validation on `type` and `body` with embedded schema. Defaults to `true`.
-- `sensitive_body` (Dynamic, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) A dynamic attribute that contains the write-only properties of the request body. This will be merge-patched to the body to construct the actual request body.
+- `sensitive_body` (Dynamic, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) A dynamic attribute that contains the write-only properties of the request body. This will be merge-patched to the body to construct the actual request body. If a property is defined in both `body` and `sensitive_body`, the `sensitive_body` value takes precedence.
 - `sensitive_body_version` (Map of String) A map where the key is the path to the property in `sensitive_body` and the value is the version of the property. The key is a string in the format of `path.to.property[index].subproperty`, where `index` is the index of the item in an array. When the version is changed, the property will be included in the request body, otherwise it will be omitted from the request body.
 - `tags` (Map of String) A mapping of tags which should be assigned to the Azure resource.
 

--- a/docs/resources/resource_action.md
+++ b/docs/resources/resource_action.md
@@ -130,6 +130,8 @@ resource "azapi_resource_action" "stop" {
 
 	~> Use the state value when new value is functionally equivalent to the old and thus no change is required.
 - `retry` (Object) The retry object supports the following attributes: See [below for nested schema](#nested--retry).
+- `sensitive_body` (Dynamic, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) A dynamic attribute that contains the write-only properties of the request body. This will be merge-patched to the body to construct the actual request body.
+- `sensitive_body_version` (Map of String) A map where the key is the path to the property in `sensitive_body` and the value is the version of the property. The key is a string in the format of `path.to.property[index].subproperty`, where `index` is the index of the item in an array. When the version is changed, the property will be included in the request body, otherwise it will be omitted from the request body.
 - `sensitive_response_export_values` (Dynamic) The attribute can accept either a list or a map.
 
 	- **List**: A list of paths that need to be exported from the response body. Setting it to `["*"]` will export the full response body. Here's an example. If it sets to `["properties.loginServer", "properties.policies.quarantinePolicy.status"]`, it will set the following HCL object to the computed property output.

--- a/docs/resources/resource_action.md
+++ b/docs/resources/resource_action.md
@@ -130,7 +130,7 @@ resource "azapi_resource_action" "stop" {
 
 	~> Use the state value when new value is functionally equivalent to the old and thus no change is required.
 - `retry` (Object) The retry object supports the following attributes: See [below for nested schema](#nested--retry).
-- `sensitive_body` (Dynamic, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) A dynamic attribute that contains the write-only properties of the request body. This will be merge-patched to the body to construct the actual request body.
+- `sensitive_body` (Dynamic, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) A dynamic attribute that contains the write-only properties of the request body. This will be merge-patched to the body to construct the actual request body. If a property is defined in both `body` and `sensitive_body`, the `sensitive_body` value takes precedence.
 - `sensitive_body_version` (Map of String) A map where the key is the path to the property in `sensitive_body` and the value is the version of the property. The key is a string in the format of `path.to.property[index].subproperty`, where `index` is the index of the item in an array. When the version is changed, the property will be included in the request body, otherwise it will be omitted from the request body.
 - `sensitive_response_export_values` (Dynamic) The attribute can accept either a list or a map.
 

--- a/docs/resources/update_resource.md
+++ b/docs/resources/update_resource.md
@@ -201,7 +201,7 @@ resource "azapi_update_resource" "example" {
 
 	~> Use the state value when new value is functionally equivalent to the old and thus no change is required.
 - `retry` (Object) The retry object supports the following attributes: See [below for nested schema](#nested--retry).
-- `sensitive_body` (Dynamic, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) A dynamic attribute that contains the write-only properties of the request body. This will be merge-patched to the body to construct the actual request body.
+- `sensitive_body` (Dynamic, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) A dynamic attribute that contains the write-only properties of the request body. This will be merge-patched to the body to construct the actual request body. If a property is defined in both `body` and `sensitive_body`, the `sensitive_body` value takes precedence.
 - `sensitive_body_version` (Map of String) A map where the key is the path to the property in `sensitive_body` and the value is the version of the property. The key is a string in the format of `path.to.property[index].subproperty`, where `index` is the index of the item in an array. When the version is changed, the property will be included in the request body, otherwise it will be omitted from the request body.
 - `timeouts` (Block) See [below for nested schema](#nested--timeouts).
 - `update_headers` (Map of String) A mapping of headers to be sent with the update request.

--- a/internal/clients/client.go
+++ b/internal/clients/client.go
@@ -131,7 +131,7 @@ func (client *Client) Build(ctx context.Context, o *Option) error {
 				Disabled: true,
 			},
 			Logging: policy.LogOptions{
-				IncludeBody:        true,
+				IncludeBody:        false,
 				AllowedHeaders:     allowedHeaders,
 				AllowedQueryParams: allowedQueryParams,
 			},
@@ -155,7 +155,7 @@ func (client *Client) Build(ctx context.Context, o *Option) error {
 				Disabled: true,
 			},
 			Logging: policy.LogOptions{
-				IncludeBody:        true,
+				IncludeBody:        false,
 				AllowedHeaders:     allowedHeaders,
 				AllowedQueryParams: allowedQueryParams,
 			},

--- a/internal/clients/live_traffic_log_policy.go
+++ b/internal/clients/live_traffic_log_policy.go
@@ -2,13 +2,11 @@ package clients
 
 import (
 	"encoding/json"
-	"io"
 	"log"
 	"net/http"
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 )
 
 const redactedValue = "REDACTED"
@@ -83,25 +81,14 @@ func (p *liveTrafficLogPolicy) requestBodyString(req *policy.Request) string {
 	if req.Raw().Body == nil {
 		return ""
 	}
-	body, err := io.ReadAll(req.Raw().Body)
-	if err != nil {
-		log.Printf("[ERROR] Failed to read request body: %v", err)
-		body = []byte(err.Error())
-	}
-	if err := req.RewindBody(); err != nil {
-		log.Printf("[ERROR] Failed to rewind request body: %v", err)
-		return ""
-	}
-	return string(body)
+	return redactedValue
 }
 
 func (p *liveTrafficLogPolicy) responseBodyString(resp *http.Response) string {
-	body, err := runtime.Payload(resp)
-	if err != nil {
-		log.Printf("[ERROR] Failed to read response body: %v", err)
+	if resp.Body == nil {
 		return ""
 	}
-	return string(body)
+	return redactedValue
 }
 
 func (p *liveTrafficLogPolicy) header(input http.Header) map[string]string {

--- a/internal/clients/live_traffic_log_policy_test.go
+++ b/internal/clients/live_traffic_log_policy_test.go
@@ -1,0 +1,141 @@
+package clients
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+)
+
+func TestLiveTrafficLogPolicyRedactsRequestBody(t *testing.T) {
+	p := &liveTrafficLogPolicy{}
+	req, err := runtime.NewRequest(context.Background(), http.MethodPost, "https://example.com")
+	if err != nil {
+		t.Fatalf("failed to create request: %+v", err)
+	}
+	if err := runtime.MarshalAsJSON(req, map[string]string{"secret": "request-secret"}); err != nil {
+		t.Fatalf("failed to marshal request body: %+v", err)
+	}
+
+	got := p.requestBodyString(req)
+	if got != redactedValue {
+		t.Fatalf("expected redacted request body, got %q", got)
+	}
+	if strings.Contains(got, "request-secret") {
+		t.Fatalf("request body included secret")
+	}
+
+	if err := req.RewindBody(); err != nil {
+		t.Fatalf("failed to rewind request body: %+v", err)
+	}
+	body, err := io.ReadAll(req.Raw().Body)
+	if err != nil {
+		t.Fatalf("failed to read request body: %+v", err)
+	}
+	if !strings.Contains(string(body), "request-secret") {
+		t.Fatalf("request body was not preserved")
+	}
+}
+
+func TestLiveTrafficLogPolicyRedactsResponseBody(t *testing.T) {
+	p := &liveTrafficLogPolicy{}
+	resp := &http.Response{
+		Body: io.NopCloser(strings.NewReader(`{"secret":"response-secret"}`)),
+	}
+
+	got := p.responseBodyString(resp)
+	if got != redactedValue {
+		t.Fatalf("expected redacted response body, got %q", got)
+	}
+	if strings.Contains(got, "response-secret") {
+		t.Fatalf("response body included secret")
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("failed to read response body: %+v", err)
+	}
+	if !strings.Contains(string(body), "response-secret") {
+		t.Fatalf("response body was not preserved")
+	}
+}
+
+func TestLiveTrafficLogPolicyEmptyBodies(t *testing.T) {
+	p := &liveTrafficLogPolicy{}
+	req, err := runtime.NewRequest(context.Background(), http.MethodPost, "https://example.com")
+	if err != nil {
+		t.Fatalf("failed to create request: %+v", err)
+	}
+
+	if got := p.requestBodyString(req); got != "" {
+		t.Fatalf("expected empty request body, got %q", got)
+	}
+	if got := p.responseBodyString(&http.Response{}); got != "" {
+		t.Fatalf("expected empty response body, got %q", got)
+	}
+}
+
+func TestLiveTrafficLogPolicyDoesNotLogBodies(t *testing.T) {
+	var logOutput bytes.Buffer
+	originalOutput := log.Writer()
+	originalFlags := log.Flags()
+	log.SetOutput(&logOutput)
+	log.SetFlags(0)
+	defer func() {
+		log.SetOutput(originalOutput)
+		log.SetFlags(originalFlags)
+	}()
+
+	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{
+		PerRetry: []policy.Policy{
+			NewLiveTrafficLogPolicy(),
+		},
+	}, &policy.ClientOptions{
+		Telemetry: policy.TelemetryOptions{Disabled: true},
+		Transport: fakeTransporter{
+			response: &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(`{"secret":"response-secret"}`)),
+			},
+		},
+	})
+
+	req, err := runtime.NewRequest(context.Background(), http.MethodPost, "https://example.com")
+	if err != nil {
+		t.Fatalf("failed to create request: %+v", err)
+	}
+	if err := runtime.MarshalAsJSON(req, map[string]string{"secret": "request-secret"}); err != nil {
+		t.Fatalf("failed to marshal request body: %+v", err)
+	}
+
+	if _, err := pl.Do(req); err != nil {
+		t.Fatalf("unexpected pipeline error: %+v", err)
+	}
+
+	got := logOutput.String()
+	if !strings.Contains(got, redactedValue) {
+		t.Fatalf("expected log output to contain redaction marker, got %q", got)
+	}
+	if strings.Contains(got, "request-secret") {
+		t.Fatalf("log output included request secret: %s", got)
+	}
+	if strings.Contains(got, "response-secret") {
+		t.Fatalf("log output included response secret: %s", got)
+	}
+}
+
+type fakeTransporter struct {
+	response *http.Response
+}
+
+func (f fakeTransporter) Do(req *http.Request) (*http.Response, error) {
+	f.response.Request = req
+	return f.response, nil
+}

--- a/internal/docstrings/write_only_body.go
+++ b/internal/docstrings/write_only_body.go
@@ -1,7 +1,7 @@
 package docstrings
 
 func SensitiveBody() string {
-	return `A dynamic attribute that contains the write-only properties of the request body. This will be merge-patched to the body to construct the actual request body.`
+	return `A dynamic attribute that contains the write-only properties of the request body. This will be merge-patched to the body to construct the actual request body. If a property is defined in both ` + "`body`" + ` and ` + "`sensitive_body`" + `, the ` + "`sensitive_body`" + ` value takes precedence.`
 }
 
 func SensitiveBodyVersion() string {

--- a/internal/services/azapi_resource_action.go
+++ b/internal/services/azapi_resource_action.go
@@ -29,6 +29,7 @@ type AzapiResourceActionModel struct {
 	Action          types.String  `tfsdk:"action"`
 	Method          types.String  `tfsdk:"method"`
 	Body            types.Dynamic `tfsdk:"body"`
+	SensitiveBody   types.Dynamic `tfsdk:"sensitive_body"`
 	Locks           types.List    `tfsdk:"locks"`
 	Headers         types.Map     `tfsdk:"headers"`
 	QueryParameters types.Map     `tfsdk:"query_parameters"`
@@ -94,6 +95,12 @@ func (a *AzapiResourceAction) Schema(ctx context.Context, req action.SchemaReque
 				},
 			},
 
+			"sensitive_body": actionschema.DynamicAttribute{
+				Optional:            true,
+				WriteOnly:           true,
+				MarkdownDescription: docstrings.SensitiveBody(),
+			},
+
 			"locks": actionschema.ListAttribute{
 				Optional:            true,
 				ElementType:         types.StringType,
@@ -138,9 +145,9 @@ func (a *AzapiResourceAction) Invoke(ctx context.Context, req action.InvokeReque
 	}
 	ctx = tflog.SetField(ctx, "resource_id", id.ID())
 
-	var requestBody interface{}
-	if err := unmarshalBody(config.Body, &requestBody); err != nil {
-		resp.Diagnostics.AddError("Invalid body", fmt.Sprintf("The argument \"body\" is invalid: %s", err.Error()))
+	requestBody, err := buildActionRequestBody(config.Body, config.SensitiveBody, types.MapNull(types.StringType), types.MapNull(types.StringType))
+	if err != nil {
+		resp.Diagnostics.AddError("Invalid request body", err.Error())
 		return
 	}
 

--- a/internal/services/azapi_resource_action.go
+++ b/internal/services/azapi_resource_action.go
@@ -145,7 +145,7 @@ func (a *AzapiResourceAction) Invoke(ctx context.Context, req action.InvokeReque
 	}
 	ctx = tflog.SetField(ctx, "resource_id", id.ID())
 
-	requestBody, err := buildActionRequestBody(config.Body, config.SensitiveBody, types.MapNull(types.StringType), types.MapNull(types.StringType))
+	requestBody, err := buildAzapiResourceActionRequestBody(config)
 	if err != nil {
 		resp.Diagnostics.AddError("Invalid request body", err.Error())
 		return
@@ -180,6 +180,10 @@ func (a *AzapiResourceAction) Invoke(ctx context.Context, req action.InvokeReque
 	if resp.SendProgress != nil {
 		resp.SendProgress(action.InvokeProgressEvent{Message: "Action completed"})
 	}
+}
+
+func buildAzapiResourceActionRequestBody(config AzapiResourceActionModel) (interface{}, error) {
+	return buildActionRequestBody(config.Body, config.SensitiveBody, types.MapNull(types.StringType), types.MapNull(types.StringType))
 }
 
 func (a *AzapiResourceAction) RenderOption() tffwdocs.ActionRenderOption {

--- a/internal/services/azapi_resource_action_ephemeral.go
+++ b/internal/services/azapi_resource_action_ephemeral.go
@@ -177,7 +177,7 @@ func (r *ActionEphemeral) Open(ctx context.Context, request ephemeral.OpenReques
 
 	ctx = tflog.SetField(ctx, "resource_id", id.ID())
 
-	requestBody, err := buildActionRequestBody(model.Body, model.SensitiveBody, types.MapNull(types.StringType), types.MapNull(types.StringType))
+	requestBody, err := buildActionEphemeralRequestBody(model)
 	if err != nil {
 		response.Diagnostics.AddError("Invalid request body", err.Error())
 		return
@@ -221,6 +221,10 @@ func (r *ActionEphemeral) Open(ctx context.Context, request ephemeral.OpenReques
 	model.Output = output
 
 	response.Diagnostics.Append(response.Result.Set(ctx, model)...)
+}
+
+func buildActionEphemeralRequestBody(model ActionEphemeralModel) (interface{}, error) {
+	return buildActionRequestBody(model.Body, model.SensitiveBody, types.MapNull(types.StringType), types.MapNull(types.StringType))
 }
 
 func (r *ActionEphemeral) RenderOption() tffwdocs.EphemeralResourceRenderOption {

--- a/internal/services/azapi_resource_action_ephemeral.go
+++ b/internal/services/azapi_resource_action_ephemeral.go
@@ -32,6 +32,7 @@ type ActionEphemeralModel struct {
 	Action               types.String     `tfsdk:"action"`
 	Method               types.String     `tfsdk:"method"`
 	Body                 types.Dynamic    `tfsdk:"body"`
+	SensitiveBody        types.Dynamic    `tfsdk:"sensitive_body"`
 	Locks                types.List       `tfsdk:"locks"`
 	ResponseExportValues types.Dynamic    `tfsdk:"response_export_values"`
 	Output               types.Dynamic    `tfsdk:"output"`
@@ -107,6 +108,11 @@ func (r *ActionEphemeral) Schema(ctx context.Context, request ephemeral.SchemaRe
 				},
 			},
 
+			"sensitive_body": schema.DynamicAttribute{
+				Optional:            true,
+				MarkdownDescription: docstrings.SensitiveBody(),
+			},
+
 			"locks": schema.ListAttribute{
 				ElementType: types.StringType,
 				Optional:    true,
@@ -171,9 +177,9 @@ func (r *ActionEphemeral) Open(ctx context.Context, request ephemeral.OpenReques
 
 	ctx = tflog.SetField(ctx, "resource_id", id.ID())
 
-	var requestBody interface{}
-	if err := unmarshalBody(model.Body, &requestBody); err != nil {
-		response.Diagnostics.AddError("Invalid body", fmt.Sprintf(`The argument "body" is invalid: %s`, err.Error()))
+	requestBody, err := buildActionRequestBody(model.Body, model.SensitiveBody, types.MapNull(types.StringType), types.MapNull(types.StringType))
+	if err != nil {
+		response.Diagnostics.AddError("Invalid request body", err.Error())
 		return
 	}
 

--- a/internal/services/azapi_resource_action_resource.go
+++ b/internal/services/azapi_resource_action_resource.go
@@ -44,6 +44,8 @@ type ActionResourceModel struct {
 	Action                        types.String     `tfsdk:"action"`
 	Method                        types.String     `tfsdk:"method"`
 	Body                          types.Dynamic    `tfsdk:"body"`
+	SensitiveBody                 types.Dynamic    `tfsdk:"sensitive_body"`
+	SensitiveBodyVersion          types.Map        `tfsdk:"sensitive_body_version"`
 	When                          types.String     `tfsdk:"when"`
 	Locks                         types.List       `tfsdk:"locks"`
 	IgnoreNotFound                types.Bool       `tfsdk:"ignore_not_found"`
@@ -82,6 +84,7 @@ func (r *ActionResource) UpgradeState(ctx context.Context) map[int64]resource.St
 	return map[int64]resource.StateUpgrader{
 		0: migration.AzapiResourceActionMigrationV0ToV2(ctx),
 		1: migration.AzapiResourceActionMigrationV1ToV2(ctx),
+		2: migration.AzapiResourceActionMigrationV2ToV3(ctx),
 	}
 }
 
@@ -171,6 +174,18 @@ func (r *ActionResource) Schema(ctx context.Context, request resource.SchemaRequ
 				},
 			},
 
+			"sensitive_body": schema.DynamicAttribute{
+				Optional:            true,
+				WriteOnly:           true,
+				MarkdownDescription: docstrings.SensitiveBody(),
+			},
+
+			"sensitive_body_version": schema.MapAttribute{
+				ElementType:         types.StringType,
+				Optional:            true,
+				MarkdownDescription: docstrings.SensitiveBodyVersion(),
+			},
+
 			"when": schema.StringAttribute{
 				Optional: true,
 				Computed: true,
@@ -255,7 +270,7 @@ func (r *ActionResource) Schema(ctx context.Context, request resource.SchemaRequ
 			}),
 		},
 
-		Version: 2,
+		Version: 3,
 	}
 }
 
@@ -273,6 +288,14 @@ func (r *ActionResource) ModifyPlan(ctx context.Context, request resource.Modify
 		return
 	}
 
+	if !config.SensitiveBody.IsNull() && config.When.ValueString() == "destroy" {
+		response.Diagnostics.AddError(
+			"Invalid configuration",
+			`The argument "sensitive_body" is not supported when "when" is set to "destroy", because write-only configuration is not available during the destroy operation.`,
+		)
+		return
+	}
+
 	if state == nil || !dynamic.SemanticallyEqual(config.Body, state.Body) {
 		plan.Output = basetypes.NewDynamicUnknown()
 		plan.SensitiveOutput = basetypes.NewDynamicUnknown()
@@ -285,14 +308,27 @@ func (r *ActionResource) ModifyPlan(ctx context.Context, request resource.Modify
 		if !plan.SensitiveResponseExportValues.Equal(state.SensitiveResponseExportValues) {
 			plan.SensitiveOutput = basetypes.NewDynamicUnknown()
 		}
+
+		diff, diags := ephemeralBodyChangeInPlan(ctx, request.Private, config.SensitiveBody, config.SensitiveBodyVersion, state.SensitiveBodyVersion)
+		if response.Diagnostics.Append(diags...); response.Diagnostics.HasError() {
+			return
+		}
+		if diff {
+			tflog.Info(ctx, `"sensitive_body" has changed`)
+			plan.Output = basetypes.NewDynamicUnknown()
+			plan.SensitiveOutput = basetypes.NewDynamicUnknown()
+		}
 	}
 
 	response.Diagnostics.Append(response.Plan.Set(ctx, plan)...)
 }
 
 func (r *ActionResource) Create(ctx context.Context, request resource.CreateRequest, response *resource.CreateResponse) {
-	var model ActionResourceModel
+	var model, config ActionResourceModel
 	if response.Diagnostics.Append(request.Plan.Get(ctx, &model)...); response.Diagnostics.HasError() {
+		return
+	}
+	if response.Diagnostics.Append(request.Config.Get(ctx, &config)...); response.Diagnostics.HasError() {
 		return
 	}
 
@@ -304,7 +340,7 @@ func (r *ActionResource) Create(ctx context.Context, request resource.CreateRequ
 	defer cancel()
 
 	if model.When.ValueString() == "apply" {
-		r.Action(ctx, model, &response.State, &response.Diagnostics)
+		r.Action(ctx, model, config, &response.State, &response.Diagnostics, response.Private, types.MapNull(types.StringType))
 	} else {
 		id, err := parse.ResourceIDWithResourceType(model.ResourceId.ValueString(), model.Type.ValueString())
 		if err != nil {
@@ -324,11 +360,14 @@ func (r *ActionResource) Create(ctx context.Context, request resource.CreateRequ
 }
 
 func (r *ActionResource) Update(ctx context.Context, request resource.UpdateRequest, response *resource.UpdateResponse) {
-	var state, plan ActionResourceModel
+	var state, plan, config ActionResourceModel
 	if response.Diagnostics.Append(request.Plan.Get(ctx, &plan)...); response.Diagnostics.HasError() {
 		return
 	}
 	if response.Diagnostics.Append(request.State.Get(ctx, &state)...); response.Diagnostics.HasError() {
+		return
+	}
+	if response.Diagnostics.Append(request.Config.Get(ctx, &config)...); response.Diagnostics.HasError() {
 		return
 	}
 
@@ -348,7 +387,7 @@ func (r *ActionResource) Update(ctx context.Context, request resource.UpdateRequ
 	tflog.Debug(ctx, "azapi_resource.CreateUpdate proceeding with external request as no skippable changes were detected")
 
 	if plan.When.ValueString() == "apply" {
-		r.Action(ctx, plan, &response.State, &response.Diagnostics)
+		r.Action(ctx, plan, config, &response.State, &response.Diagnostics, response.Private, state.SensitiveBodyVersion)
 	} else {
 		response.Diagnostics.Append(response.State.Set(ctx, plan)...)
 	}
@@ -361,7 +400,7 @@ func (r *ActionResource) Delete(ctx context.Context, request resource.DeleteRequ
 	}
 
 	if model.When.ValueString() == "destroy" {
-		r.Action(ctx, model, &response.State, &response.Diagnostics)
+		r.Action(ctx, model, ActionResourceModel{}, &response.State, &response.Diagnostics, nil, types.MapNull(types.StringType))
 	}
 }
 
@@ -378,7 +417,7 @@ func (r *ActionResource) Read(ctx context.Context, request resource.ReadRequest,
 	response.Diagnostics.Append(response.State.Set(ctx, state)...)
 }
 
-func (r *ActionResource) Action(ctx context.Context, model ActionResourceModel, state *tfsdk.State, diagnostics *diag.Diagnostics) {
+func (r *ActionResource) Action(ctx context.Context, model ActionResourceModel, config ActionResourceModel, state *tfsdk.State, diagnostics *diag.Diagnostics, privateData PrivateData, priorSensitiveBodyVersion types.Map) {
 	actionTimeout, diags := model.Timeouts.Create(ctx, 30*time.Minute)
 	diagnostics.Append(diags...)
 	if diagnostics.HasError() {
@@ -396,9 +435,9 @@ func (r *ActionResource) Action(ctx context.Context, model ActionResourceModel, 
 
 	ctx = tflog.SetField(ctx, "resource_id", id.ID())
 
-	var requestBody interface{}
-	if err := unmarshalBody(model.Body, &requestBody); err != nil {
-		diagnostics.AddError("Invalid body", fmt.Sprintf(`The argument "body" is invalid: %s`, err.Error()))
+	requestBody, err := buildActionRequestBody(model.Body, config.SensitiveBody, model.SensitiveBodyVersion, priorSensitiveBodyVersion)
+	if err != nil {
+		diagnostics.AddError("Invalid request body", err.Error())
 		return
 	}
 
@@ -449,6 +488,42 @@ func (r *ActionResource) Action(ctx context.Context, model ActionResourceModel, 
 	model.SensitiveOutput = sensitiveOutput
 
 	diagnostics.Append(state.Set(ctx, model)...)
+
+	if privateData != nil {
+		if model.SensitiveBodyVersion.IsNull() {
+			writeOnlyBytes, err := dynamic.ToJSON(config.SensitiveBody)
+			if err != nil {
+				diagnostics.AddError("Invalid sensitive_body", err.Error())
+				return
+			}
+			diagnostics.Append(ephemeralBodyPrivateMgr.Set(ctx, privateData, writeOnlyBytes)...)
+		} else {
+			diagnostics.Append(ephemeralBodyPrivateMgr.Set(ctx, privateData, nil)...)
+		}
+	}
+}
+
+func buildActionRequestBody(body types.Dynamic, sensitiveBody types.Dynamic, sensitiveBodyVersion types.Map, priorSensitiveBodyVersion types.Map) (interface{}, error) {
+	var requestBody interface{}
+	if err := unmarshalBody(body, &requestBody); err != nil {
+		return nil, fmt.Errorf(`the argument "body" is invalid: %s`, err.Error())
+	}
+
+	if sensitiveBody.IsNull() {
+		return requestBody, nil
+	}
+
+	writeOnlyBody, err := unmarshalSensitiveBody(sensitiveBody, sensitiveBodyVersion, priorSensitiveBodyVersion)
+	if err != nil {
+		return nil, fmt.Errorf(`the argument "sensitive_body" is invalid: %s`, err.Error())
+	}
+	if writeOnlyBody == nil {
+		return requestBody, nil
+	}
+	if requestBody == nil {
+		return writeOnlyBody, nil
+	}
+	return utils.MergeObject(requestBody, writeOnlyBody), nil
 }
 
 func (r *ActionResource) RenderOption() tffwdocs.ResourceRenderOption {

--- a/internal/services/azapi_resource_action_resource_sensitive_body_test.go
+++ b/internal/services/azapi_resource_action_resource_sensitive_body_test.go
@@ -1,0 +1,169 @@
+package services
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/Azure/terraform-provider-azapi/internal/services/dynamic"
+	fwaction "github.com/hashicorp/terraform-plugin-framework/action"
+	actionschema "github.com/hashicorp/terraform-plugin-framework/action/schema"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	fwephemeral "github.com/hashicorp/terraform-plugin-framework/ephemeral"
+	ephemeralschema "github.com/hashicorp/terraform-plugin-framework/ephemeral/schema"
+	fwresource "github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestAzapiResourceActionSchemaSensitiveBody(t *testing.T) {
+	var response fwaction.SchemaResponse
+	a := AzapiResourceAction{}
+	a.Schema(context.Background(), fwaction.SchemaRequest{}, &response)
+
+	sensitiveBody, ok := response.Schema.Attributes["sensitive_body"].(actionschema.DynamicAttribute)
+	if !ok {
+		t.Fatalf("expected sensitive_body to be a dynamic attribute")
+	}
+	if !sensitiveBody.WriteOnly {
+		t.Fatalf("expected sensitive_body to be write-only")
+	}
+}
+
+func TestActionResourceSchemaSensitiveBody(t *testing.T) {
+	var response fwresource.SchemaResponse
+	r := ActionResource{}
+	r.Schema(context.Background(), fwresource.SchemaRequest{}, &response)
+
+	sensitiveBody, ok := response.Schema.Attributes["sensitive_body"].(schema.DynamicAttribute)
+	if !ok {
+		t.Fatalf("expected sensitive_body to be a dynamic attribute")
+	}
+	if !sensitiveBody.WriteOnly {
+		t.Fatalf("expected sensitive_body to be write-only")
+	}
+
+	sensitiveBodyVersion, ok := response.Schema.Attributes["sensitive_body_version"].(schema.MapAttribute)
+	if !ok {
+		t.Fatalf("expected sensitive_body_version to be a map attribute")
+	}
+	if sensitiveBodyVersion.ElementType != types.StringType {
+		t.Fatalf("expected sensitive_body_version element type to be string")
+	}
+	if response.Schema.Version != 3 {
+		t.Fatalf("expected schema version 3, got %d", response.Schema.Version)
+	}
+}
+
+func TestActionEphemeralSchemaSensitiveBody(t *testing.T) {
+	var response fwephemeral.SchemaResponse
+	r := ActionEphemeral{}
+	r.Schema(context.Background(), fwephemeral.SchemaRequest{}, &response)
+
+	sensitiveBody, ok := response.Schema.Attributes["sensitive_body"].(ephemeralschema.DynamicAttribute)
+	if !ok {
+		t.Fatalf("expected sensitive_body to be a dynamic attribute")
+	}
+	if sensitiveBody.IsWriteOnly() {
+		t.Fatalf("expected ephemeral sensitive_body not to be write-only")
+	}
+}
+
+func TestBuildActionRequestBodyMergesSensitiveBody(t *testing.T) {
+	body := mustDynamicFromJSON(t, `{
+		"source": {
+			"registryUri": "dhi.io",
+			"sourceImage": "node:22.22.1-alpine3.23"
+		},
+		"targetTags": ["base/dhi-node"]
+	}`)
+	sensitiveBody := mustDynamicFromJSON(t, `{
+		"source": {
+			"credentials": {
+				"username": "user",
+				"password": "secret"
+			}
+		}
+	}`)
+
+	actual, err := buildActionRequestBody(body, sensitiveBody, types.MapNull(types.StringType), types.MapNull(types.StringType))
+	if err != nil {
+		t.Fatalf("unexpected error: %+v", err)
+	}
+
+	assertJsonEqual(t, actual, `{
+		"source": {
+			"registryUri": "dhi.io",
+			"sourceImage": "node:22.22.1-alpine3.23",
+			"credentials": {
+				"username": "user",
+				"password": "secret"
+			}
+		},
+		"targetTags": ["base/dhi-node"]
+	}`)
+}
+
+func TestBuildActionRequestBodySkipsUnchangedSensitiveBodyVersion(t *testing.T) {
+	body := mustDynamicFromJSON(t, `{
+		"properties": {
+			"mode": "NoForce"
+		}
+	}`)
+	sensitiveBody := mustDynamicFromJSON(t, `{
+		"properties": {
+			"sharedKey": "secret"
+		}
+	}`)
+	version := types.MapValueMust(types.StringType, map[string]attr.Value{
+		"properties.sharedKey": types.StringValue("v1"),
+	})
+
+	actual, err := buildActionRequestBody(body, sensitiveBody, version, version)
+	if err != nil {
+		t.Fatalf("unexpected error: %+v", err)
+	}
+
+	assertJsonEqual(t, actual, `{
+		"properties": {
+			"mode": "NoForce"
+		}
+	}`)
+}
+
+func mustDynamicFromJSON(t *testing.T, input string) types.Dynamic {
+	t.Helper()
+	value, err := dynamic.FromJSONImplied([]byte(input))
+	if err != nil {
+		t.Fatalf("failed to build dynamic value: %+v", err)
+	}
+	return value
+}
+
+func assertJsonEqual(t *testing.T, actual interface{}, expected string) {
+	t.Helper()
+
+	var expectedValue interface{}
+	if err := json.Unmarshal([]byte(expected), &expectedValue); err != nil {
+		t.Fatalf("failed to unmarshal expected JSON: %+v", err)
+	}
+
+	actualJSON, err := json.Marshal(actual)
+	if err != nil {
+		t.Fatalf("failed to marshal actual value: %+v", err)
+	}
+	var actualValue interface{}
+	if err := json.Unmarshal(actualJSON, &actualValue); err != nil {
+		t.Fatalf("failed to unmarshal actual JSON: %+v", err)
+	}
+
+	if !reflect.DeepEqual(actualValue, expectedValue) {
+		t.Fatalf("expected %s but got %s", mustMarshalJSON(expectedValue), mustMarshalJSON(actualValue))
+	}
+}
+
+func mustMarshalJSON(value interface{}) string {
+	out, _ := json.Marshal(value)
+	return string(out)
+}

--- a/internal/services/azapi_resource_action_resource_sensitive_body_test.go
+++ b/internal/services/azapi_resource_action_resource_sensitive_body_test.go
@@ -105,6 +105,90 @@ func TestBuildActionRequestBodyMergesSensitiveBody(t *testing.T) {
 	}`)
 }
 
+func TestAzapiResourceActionRequestBodyMergesSensitiveBody(t *testing.T) {
+	config := AzapiResourceActionModel{
+		Body: mustDynamicFromJSON(t, `{
+			"source": {
+				"registryUri": "dhi.io"
+			}
+		}`),
+		SensitiveBody: mustDynamicFromJSON(t, `{
+			"source": {
+				"credentials": {
+					"password": "secret"
+				}
+			}
+		}`),
+	}
+
+	actual, err := buildAzapiResourceActionRequestBody(config)
+	if err != nil {
+		t.Fatalf("unexpected error: %+v", err)
+	}
+
+	assertJsonEqual(t, actual, `{
+		"source": {
+			"registryUri": "dhi.io",
+			"credentials": {
+				"password": "secret"
+			}
+		}
+	}`)
+}
+
+func TestActionEphemeralRequestBodyMergesSensitiveBody(t *testing.T) {
+	model := ActionEphemeralModel{
+		Body: mustDynamicFromJSON(t, `{
+			"properties": {
+				"mode": "test"
+			}
+		}`),
+		SensitiveBody: mustDynamicFromJSON(t, `{
+			"properties": {
+				"token": "secret"
+			}
+		}`),
+	}
+
+	actual, err := buildActionEphemeralRequestBody(model)
+	if err != nil {
+		t.Fatalf("unexpected error: %+v", err)
+	}
+
+	assertJsonEqual(t, actual, `{
+		"properties": {
+			"mode": "test",
+			"token": "secret"
+		}
+	}`)
+}
+
+func TestBuildActionRequestBodySensitiveBodyOverridesBody(t *testing.T) {
+	body := mustDynamicFromJSON(t, `{
+		"properties": {
+			"sharedKey": "placeholder",
+			"mode": "test"
+		}
+	}`)
+	sensitiveBody := mustDynamicFromJSON(t, `{
+		"properties": {
+			"sharedKey": "secret"
+		}
+	}`)
+
+	actual, err := buildActionRequestBody(body, sensitiveBody, types.MapNull(types.StringType), types.MapNull(types.StringType))
+	if err != nil {
+		t.Fatalf("unexpected error: %+v", err)
+	}
+
+	assertJsonEqual(t, actual, `{
+		"properties": {
+			"sharedKey": "secret",
+			"mode": "test"
+		}
+	}`)
+}
+
 func TestBuildActionRequestBodySkipsUnchangedSensitiveBodyVersion(t *testing.T) {
 	body := mustDynamicFromJSON(t, `{
 		"properties": {

--- a/internal/services/migration/azapi_data_plane_resource_migration_v0_to_v2.go
+++ b/internal/services/migration/azapi_data_plane_resource_migration_v0_to_v2.go
@@ -141,6 +141,7 @@ func AzapiDataPlaneResourceMigrationV0ToV2(ctx context.Context) resource.StateUp
 				ParentID:                      oldState.ParentID,
 				Type:                          oldState.Type,
 				Body:                          bodyVal,
+				SensitiveBody:                 types.DynamicNull(),
 				SensitiveBodyVersion:          types.MapNull(types.StringType),
 				Locks:                         oldState.Locks,
 				IgnoreCasing:                  oldState.IgnoreCasing,

--- a/internal/services/migration/azapi_data_plane_resource_migration_v1_to_v2.go
+++ b/internal/services/migration/azapi_data_plane_resource_migration_v1_to_v2.go
@@ -139,6 +139,7 @@ func AzapiDataPlaneResourceMigrationV1ToV2(ctx context.Context) resource.StateUp
 				ParentID:                      oldState.ParentID,
 				Type:                          oldState.Type,
 				Body:                          bodyVal,
+				SensitiveBody:                 types.DynamicNull(),
 				SensitiveBodyVersion:          types.MapNull(types.StringType),
 				Locks:                         oldState.Locks,
 				IgnoreCasing:                  oldState.IgnoreCasing,

--- a/internal/services/migration/azapi_resource_action_migration_test.go
+++ b/internal/services/migration/azapi_resource_action_migration_test.go
@@ -1,0 +1,186 @@
+package migration_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Azure/terraform-provider-azapi/internal/retry"
+	"github.com/Azure/terraform-provider-azapi/internal/services"
+	"github.com/Azure/terraform-provider-azapi/internal/services/migration"
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestAzapiResourceActionMigrationsIncludeSensitiveBody(t *testing.T) {
+	ctx := context.Background()
+	currentSchema := actionResourceSchema(t, ctx)
+
+	tests := []struct {
+		name     string
+		upgrader resource.StateUpgrader
+		state    any
+	}{
+		{
+			name:     "v0",
+			upgrader: migration.AzapiResourceActionMigrationV0ToV2(ctx),
+			state: actionResourceV0State{
+				ID:                   types.StringValue("test"),
+				Type:                 types.StringValue("Microsoft.Resources/resourceGroups@2021-04-01"),
+				ResourceId:           types.StringValue("/subscriptions/00000000-0000-0000-0000-000000000000"),
+				Action:               types.StringValue("read"),
+				Method:               types.StringValue("GET"),
+				Body:                 types.StringNull(),
+				When:                 types.StringValue("apply"),
+				Locks:                types.ListNull(types.StringType),
+				ResponseExportValues: types.ListNull(types.StringType),
+				Output:               types.StringNull(),
+				Timeouts:             nullTimeouts(),
+			},
+		},
+		{
+			name:     "v1",
+			upgrader: migration.AzapiResourceActionMigrationV1ToV2(ctx),
+			state: actionResourceV1State{
+				ID:                   types.StringValue("test"),
+				Type:                 types.StringValue("Microsoft.Resources/resourceGroups@2021-04-01"),
+				ResourceId:           types.StringValue("/subscriptions/00000000-0000-0000-0000-000000000000"),
+				Action:               types.StringValue("read"),
+				Method:               types.StringValue("GET"),
+				Body:                 types.DynamicNull(),
+				When:                 types.StringValue("apply"),
+				Locks:                types.ListNull(types.StringType),
+				ResponseExportValues: types.ListNull(types.StringType),
+				Output:               types.DynamicNull(),
+				Timeouts:             nullTimeouts(),
+			},
+		},
+		{
+			name:     "v2",
+			upgrader: migration.AzapiResourceActionMigrationV2ToV3(ctx),
+			state: actionResourceV2State{
+				ID:                            types.StringValue("test"),
+				Type:                          types.StringValue("Microsoft.Resources/resourceGroups@2021-04-01"),
+				ResourceId:                    types.StringValue("/subscriptions/00000000-0000-0000-0000-000000000000"),
+				Action:                        types.StringValue("read"),
+				Method:                        types.StringValue("GET"),
+				Body:                          types.DynamicNull(),
+				When:                          types.StringValue("apply"),
+				Locks:                         types.ListNull(types.StringType),
+				IgnoreNotFound:                types.BoolValue(false),
+				Exist:                         types.BoolValue(true),
+				ResponseExportValues:          types.DynamicNull(),
+				SensitiveResponseExportValues: types.DynamicNull(),
+				Output:                        types.DynamicNull(),
+				SensitiveOutput:               types.DynamicNull(),
+				Timeouts:                      nullTimeouts(),
+				Retry:                         retry.NewRetryValueNull(),
+				Headers:                       types.MapNull(types.StringType),
+				QueryParameters:               types.MapNull(types.ListType{ElemType: types.StringType}),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			priorState := tfsdk.State{Schema: *tt.upgrader.PriorSchema}
+			if diags := priorState.Set(ctx, tt.state); diags.HasError() {
+				t.Fatalf("setting prior state returned diagnostics: %v", diags)
+			}
+
+			response := resource.UpgradeStateResponse{
+				State: tfsdk.State{Schema: currentSchema},
+			}
+			tt.upgrader.StateUpgrader(ctx, resource.UpgradeStateRequest{State: &priorState}, &response)
+			if response.Diagnostics.HasError() {
+				t.Fatalf("upgrading state returned diagnostics: %v", response.Diagnostics)
+			}
+
+			var upgraded services.ActionResourceModel
+			if diags := response.State.Get(ctx, &upgraded); diags.HasError() {
+				t.Fatalf("reading upgraded state returned diagnostics: %v", diags)
+			}
+			if !upgraded.SensitiveBody.IsNull() {
+				t.Fatalf("expected sensitive_body to be null, got %s", upgraded.SensitiveBody.String())
+			}
+			if !upgraded.SensitiveBodyVersion.IsNull() {
+				t.Fatalf("expected sensitive_body_version to be null, got %s", upgraded.SensitiveBodyVersion.String())
+			}
+		})
+	}
+}
+
+func actionResourceSchema(t *testing.T, ctx context.Context) schema.Schema {
+	t.Helper()
+
+	var actionResource services.ActionResource
+	var response resource.SchemaResponse
+	actionResource.Schema(ctx, resource.SchemaRequest{}, &response)
+	if response.Diagnostics.HasError() {
+		t.Fatalf("reading action resource schema returned diagnostics: %v", response.Diagnostics)
+	}
+	return response.Schema
+}
+
+func nullTimeouts() timeouts.Value {
+	return timeouts.Value{
+		Object: types.ObjectNull(map[string]attr.Type{
+			"create": types.StringType,
+			"update": types.StringType,
+			"read":   types.StringType,
+			"delete": types.StringType,
+		}),
+	}
+}
+
+type actionResourceV0State struct {
+	ID                   types.String   `tfsdk:"id"`
+	Type                 types.String   `tfsdk:"type"`
+	ResourceId           types.String   `tfsdk:"resource_id"`
+	Action               types.String   `tfsdk:"action"`
+	Method               types.String   `tfsdk:"method"`
+	Body                 types.String   `tfsdk:"body"`
+	When                 types.String   `tfsdk:"when"`
+	Locks                types.List     `tfsdk:"locks"`
+	ResponseExportValues types.List     `tfsdk:"response_export_values"`
+	Output               types.String   `tfsdk:"output"`
+	Timeouts             timeouts.Value `tfsdk:"timeouts"`
+}
+
+type actionResourceV1State struct {
+	ID                   types.String   `tfsdk:"id"`
+	Type                 types.String   `tfsdk:"type"`
+	ResourceId           types.String   `tfsdk:"resource_id"`
+	Action               types.String   `tfsdk:"action"`
+	Method               types.String   `tfsdk:"method"`
+	Body                 types.Dynamic  `tfsdk:"body"`
+	When                 types.String   `tfsdk:"when"`
+	Locks                types.List     `tfsdk:"locks"`
+	ResponseExportValues types.List     `tfsdk:"response_export_values"`
+	Output               types.Dynamic  `tfsdk:"output"`
+	Timeouts             timeouts.Value `tfsdk:"timeouts"`
+}
+
+type actionResourceV2State struct {
+	ID                            types.String     `tfsdk:"id"`
+	Type                          types.String     `tfsdk:"type"`
+	ResourceId                    types.String     `tfsdk:"resource_id"`
+	Action                        types.String     `tfsdk:"action"`
+	Method                        types.String     `tfsdk:"method"`
+	Body                          types.Dynamic    `tfsdk:"body"`
+	When                          types.String     `tfsdk:"when"`
+	Locks                         types.List       `tfsdk:"locks"`
+	IgnoreNotFound                types.Bool       `tfsdk:"ignore_not_found"`
+	Exist                         types.Bool       `tfsdk:"exist"`
+	ResponseExportValues          types.Dynamic    `tfsdk:"response_export_values"`
+	SensitiveResponseExportValues types.Dynamic    `tfsdk:"sensitive_response_export_values"`
+	Output                        types.Dynamic    `tfsdk:"output"`
+	SensitiveOutput               types.Dynamic    `tfsdk:"sensitive_output"`
+	Timeouts                      timeouts.Value   `tfsdk:"timeouts"`
+	Retry                         retry.RetryValue `tfsdk:"retry"`
+	Headers                       types.Map        `tfsdk:"headers"`
+	QueryParameters               types.Map        `tfsdk:"query_parameters"`
+}

--- a/internal/services/migration/azapi_resource_action_migration_v0_to_v2.go
+++ b/internal/services/migration/azapi_resource_action_migration_v0_to_v2.go
@@ -89,6 +89,7 @@ func AzapiResourceActionMigrationV0ToV2(ctx context.Context) resource.StateUpgra
 				Action                        types.String        `tfsdk:"action"`
 				Method                        types.String        `tfsdk:"method"`
 				Body                          types.Dynamic       `tfsdk:"body"`
+				SensitiveBody                 types.Dynamic       `tfsdk:"sensitive_body"`
 				SensitiveBodyVersion          types.Map           `tfsdk:"sensitive_body_version"`
 				When                          types.String        `tfsdk:"when"`
 				Locks                         types.List          `tfsdk:"locks"`
@@ -148,6 +149,7 @@ func AzapiResourceActionMigrationV0ToV2(ctx context.Context) resource.StateUpgra
 				Action:                        oldState.Action,
 				Method:                        oldState.Method,
 				Body:                          bodyVal,
+				SensitiveBody:                 types.DynamicNull(),
 				SensitiveBodyVersion:          types.MapNull(types.StringType),
 				When:                          when,
 				Locks:                         oldState.Locks,

--- a/internal/services/migration/azapi_resource_action_migration_v0_to_v2.go
+++ b/internal/services/migration/azapi_resource_action_migration_v0_to_v2.go
@@ -89,6 +89,7 @@ func AzapiResourceActionMigrationV0ToV2(ctx context.Context) resource.StateUpgra
 				Action                        types.String        `tfsdk:"action"`
 				Method                        types.String        `tfsdk:"method"`
 				Body                          types.Dynamic       `tfsdk:"body"`
+				SensitiveBodyVersion          types.Map           `tfsdk:"sensitive_body_version"`
 				When                          types.String        `tfsdk:"when"`
 				Locks                         types.List          `tfsdk:"locks"`
 				IgnoreNotFound                types.Bool          `tfsdk:"ignore_not_found"`
@@ -147,6 +148,7 @@ func AzapiResourceActionMigrationV0ToV2(ctx context.Context) resource.StateUpgra
 				Action:                        oldState.Action,
 				Method:                        oldState.Method,
 				Body:                          bodyVal,
+				SensitiveBodyVersion:          types.MapNull(types.StringType),
 				When:                          when,
 				Locks:                         oldState.Locks,
 				IgnoreNotFound:                types.BoolValue(false),

--- a/internal/services/migration/azapi_resource_action_migration_v1_to_v2.go
+++ b/internal/services/migration/azapi_resource_action_migration_v1_to_v2.go
@@ -90,6 +90,7 @@ func AzapiResourceActionMigrationV1ToV2(ctx context.Context) resource.StateUpgra
 				Action                        types.String        `tfsdk:"action"`
 				Method                        types.String        `tfsdk:"method"`
 				Body                          types.Dynamic       `tfsdk:"body"`
+				SensitiveBodyVersion          types.Map           `tfsdk:"sensitive_body_version"`
 				When                          types.String        `tfsdk:"when"`
 				Locks                         types.List          `tfsdk:"locks"`
 				IgnoreNotFound                types.Bool          `tfsdk:"ignore_not_found"`
@@ -133,6 +134,7 @@ func AzapiResourceActionMigrationV1ToV2(ctx context.Context) resource.StateUpgra
 				Action:                        oldState.Action,
 				Method:                        oldState.Method,
 				Body:                          bodyVal,
+				SensitiveBodyVersion:          types.MapNull(types.StringType),
 				When:                          oldState.When,
 				Locks:                         oldState.Locks,
 				IgnoreNotFound:                types.BoolValue(false),

--- a/internal/services/migration/azapi_resource_action_migration_v1_to_v2.go
+++ b/internal/services/migration/azapi_resource_action_migration_v1_to_v2.go
@@ -90,6 +90,7 @@ func AzapiResourceActionMigrationV1ToV2(ctx context.Context) resource.StateUpgra
 				Action                        types.String        `tfsdk:"action"`
 				Method                        types.String        `tfsdk:"method"`
 				Body                          types.Dynamic       `tfsdk:"body"`
+				SensitiveBody                 types.Dynamic       `tfsdk:"sensitive_body"`
 				SensitiveBodyVersion          types.Map           `tfsdk:"sensitive_body_version"`
 				When                          types.String        `tfsdk:"when"`
 				Locks                         types.List          `tfsdk:"locks"`
@@ -134,6 +135,7 @@ func AzapiResourceActionMigrationV1ToV2(ctx context.Context) resource.StateUpgra
 				Action:                        oldState.Action,
 				Method:                        oldState.Method,
 				Body:                          bodyVal,
+				SensitiveBody:                 types.DynamicNull(),
 				SensitiveBodyVersion:          types.MapNull(types.StringType),
 				When:                          oldState.When,
 				Locks:                         oldState.Locks,

--- a/internal/services/migration/azapi_resource_action_migration_v2_to_v3.go
+++ b/internal/services/migration/azapi_resource_action_migration_v2_to_v3.go
@@ -110,6 +110,7 @@ func AzapiResourceActionMigrationV2ToV3(ctx context.Context) resource.StateUpgra
 				Action                        types.String     `tfsdk:"action"`
 				Method                        types.String     `tfsdk:"method"`
 				Body                          types.Dynamic    `tfsdk:"body"`
+				SensitiveBody                 types.Dynamic    `tfsdk:"sensitive_body"`
 				SensitiveBodyVersion          types.Map        `tfsdk:"sensitive_body_version"`
 				When                          types.String     `tfsdk:"when"`
 				Locks                         types.List       `tfsdk:"locks"`
@@ -137,6 +138,7 @@ func AzapiResourceActionMigrationV2ToV3(ctx context.Context) resource.StateUpgra
 				Action:                        oldState.Action,
 				Method:                        oldState.Method,
 				Body:                          oldState.Body,
+				SensitiveBody:                 types.DynamicNull(),
 				SensitiveBodyVersion:          types.MapNull(types.StringType),
 				When:                          oldState.When,
 				Locks:                         oldState.Locks,

--- a/internal/services/migration/azapi_resource_action_migration_v2_to_v3.go
+++ b/internal/services/migration/azapi_resource_action_migration_v2_to_v3.go
@@ -1,0 +1,158 @@
+package migration
+
+import (
+	"context"
+
+	"github.com/Azure/terraform-provider-azapi/internal/retry"
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func AzapiResourceActionMigrationV2ToV3(ctx context.Context) resource.StateUpgrader {
+	return resource.StateUpgrader{
+		PriorSchema: &schema.Schema{
+			Attributes: map[string]schema.Attribute{
+				"id": schema.StringAttribute{
+					Computed: true,
+				},
+				"type": schema.StringAttribute{
+					Required: true,
+				},
+				"resource_id": schema.StringAttribute{
+					Required: true,
+				},
+				"action": schema.StringAttribute{
+					Optional: true,
+				},
+				"method": schema.StringAttribute{
+					Optional: true,
+					Computed: true,
+				},
+				"body": schema.DynamicAttribute{
+					Optional: true,
+				},
+				"when": schema.StringAttribute{
+					Optional: true,
+					Computed: true,
+				},
+				"locks": schema.ListAttribute{
+					ElementType: types.StringType,
+					Optional:    true,
+				},
+				"ignore_not_found": schema.BoolAttribute{
+					Optional: true,
+				},
+				"exist": schema.BoolAttribute{
+					Computed: true,
+				},
+				"response_export_values": schema.DynamicAttribute{
+					Optional: true,
+				},
+				"sensitive_response_export_values": schema.DynamicAttribute{
+					Optional: true,
+				},
+				"output": schema.DynamicAttribute{
+					Computed: true,
+				},
+				"sensitive_output": schema.DynamicAttribute{
+					Computed:  true,
+					Sensitive: true,
+				},
+				"retry": retry.RetrySchema(ctx),
+				"headers": schema.MapAttribute{
+					ElementType: types.StringType,
+					Optional:    true,
+				},
+				"query_parameters": schema.MapAttribute{
+					ElementType: types.ListType{
+						ElemType: types.StringType,
+					},
+					Optional: true,
+				},
+			},
+			Blocks: map[string]schema.Block{
+				"timeouts": timeouts.Block(ctx, timeouts.Opts{
+					Create: true,
+					Update: true,
+					Read:   true,
+					Delete: true,
+				}),
+			},
+			Version: 2,
+		},
+		StateUpgrader: func(ctx context.Context, request resource.UpgradeStateRequest, response *resource.UpgradeStateResponse) {
+			type oldModel struct {
+				ID                            types.String     `tfsdk:"id"`
+				Type                          types.String     `tfsdk:"type"`
+				ResourceId                    types.String     `tfsdk:"resource_id"`
+				Action                        types.String     `tfsdk:"action"`
+				Method                        types.String     `tfsdk:"method"`
+				Body                          types.Dynamic    `tfsdk:"body"`
+				When                          types.String     `tfsdk:"when"`
+				Locks                         types.List       `tfsdk:"locks"`
+				IgnoreNotFound                types.Bool       `tfsdk:"ignore_not_found"`
+				Exist                         types.Bool       `tfsdk:"exist"`
+				ResponseExportValues          types.Dynamic    `tfsdk:"response_export_values"`
+				SensitiveResponseExportValues types.Dynamic    `tfsdk:"sensitive_response_export_values"`
+				Output                        types.Dynamic    `tfsdk:"output"`
+				SensitiveOutput               types.Dynamic    `tfsdk:"sensitive_output"`
+				Timeouts                      timeouts.Value   `tfsdk:"timeouts"`
+				Retry                         retry.RetryValue `tfsdk:"retry"`
+				Headers                       types.Map        `tfsdk:"headers"`
+				QueryParameters               types.Map        `tfsdk:"query_parameters"`
+			}
+			type newModel struct {
+				ID                            types.String     `tfsdk:"id"`
+				Type                          types.String     `tfsdk:"type"`
+				ResourceId                    types.String     `tfsdk:"resource_id"`
+				Action                        types.String     `tfsdk:"action"`
+				Method                        types.String     `tfsdk:"method"`
+				Body                          types.Dynamic    `tfsdk:"body"`
+				SensitiveBodyVersion          types.Map        `tfsdk:"sensitive_body_version"`
+				When                          types.String     `tfsdk:"when"`
+				Locks                         types.List       `tfsdk:"locks"`
+				IgnoreNotFound                types.Bool       `tfsdk:"ignore_not_found"`
+				Exist                         types.Bool       `tfsdk:"exist"`
+				ResponseExportValues          types.Dynamic    `tfsdk:"response_export_values"`
+				SensitiveResponseExportValues types.Dynamic    `tfsdk:"sensitive_response_export_values"`
+				Output                        types.Dynamic    `tfsdk:"output"`
+				SensitiveOutput               types.Dynamic    `tfsdk:"sensitive_output"`
+				Timeouts                      timeouts.Value   `tfsdk:"timeouts"`
+				Retry                         retry.RetryValue `tfsdk:"retry"`
+				Headers                       types.Map        `tfsdk:"headers"`
+				QueryParameters               types.Map        `tfsdk:"query_parameters"`
+			}
+
+			var oldState oldModel
+			if response.Diagnostics.Append(request.State.Get(ctx, &oldState)...); response.Diagnostics.HasError() {
+				return
+			}
+
+			newState := newModel{
+				ID:                            oldState.ID,
+				Type:                          oldState.Type,
+				ResourceId:                    oldState.ResourceId,
+				Action:                        oldState.Action,
+				Method:                        oldState.Method,
+				Body:                          oldState.Body,
+				SensitiveBodyVersion:          types.MapNull(types.StringType),
+				When:                          oldState.When,
+				Locks:                         oldState.Locks,
+				IgnoreNotFound:                oldState.IgnoreNotFound,
+				Exist:                         oldState.Exist,
+				ResponseExportValues:          oldState.ResponseExportValues,
+				SensitiveResponseExportValues: oldState.SensitiveResponseExportValues,
+				Output:                        oldState.Output,
+				SensitiveOutput:               oldState.SensitiveOutput,
+				Timeouts:                      oldState.Timeouts,
+				Retry:                         oldState.Retry,
+				Headers:                       oldState.Headers,
+				QueryParameters:               oldState.QueryParameters,
+			}
+
+			response.Diagnostics.Append(response.State.Set(ctx, newState)...)
+		},
+	}
+}

--- a/internal/services/migration/azapi_resource_migration_v0_to_v2.go
+++ b/internal/services/migration/azapi_resource_migration_v0_to_v2.go
@@ -219,6 +219,7 @@ func AzapiResourceMigrationV0ToV2(ctx context.Context) resource.StateUpgrader {
 				Output:                        outputVal,
 				Tags:                          oldState.Tags,
 				Timeouts:                      oldState.Timeouts,
+				SensitiveBody:                 types.DynamicNull(),
 				SensitiveBodyVersion:          types.MapNull(types.StringType),
 			}
 

--- a/internal/services/migration/azapi_resource_migration_v1_to_v2.go
+++ b/internal/services/migration/azapi_resource_migration_v1_to_v2.go
@@ -218,6 +218,7 @@ func AzapiResourceMigrationV1ToV2(ctx context.Context) resource.StateUpgrader {
 				Output:                        outputVal,
 				Tags:                          oldState.Tags,
 				Timeouts:                      oldState.Timeouts,
+				SensitiveBody:                 types.DynamicNull(),
 				SensitiveBodyVersion:          types.MapNull(types.StringType),
 			}
 

--- a/internal/services/migration/azapi_update_resource_migration_v0_to_v2.go
+++ b/internal/services/migration/azapi_update_resource_migration_v0_to_v2.go
@@ -164,6 +164,7 @@ func AzapiUpdateResourceMigrationV0ToV2(ctx context.Context) resource.StateUpgra
 				Output:                        outputVal,
 				Timeouts:                      oldState.Timeouts,
 				Retry:                         retry.NewRetryValueNull(),
+				SensitiveBody:                 types.DynamicNull(),
 				SensitiveBodyVersion:          types.MapNull(types.StringType),
 			}
 

--- a/internal/services/migration/azapi_update_resource_migration_v1_to_v2.go
+++ b/internal/services/migration/azapi_update_resource_migration_v1_to_v2.go
@@ -162,6 +162,7 @@ func AzapiUpdateResourceMigrationV1ToV2(ctx context.Context) resource.StateUpgra
 				Output:                        outputVal,
 				Timeouts:                      oldState.Timeouts,
 				Retry:                         retry.NewRetryValueNull(),
+				SensitiveBody:                 types.DynamicNull(),
 				SensitiveBodyVersion:          types.MapNull(types.StringType),
 			}
 


### PR DESCRIPTION
## Description

Adds `sensitive_body` support to `azapi_resource_action` across the action, managed resource, and ephemeral resource forms.

For the managed resource, `sensitive_body` is write-only and is merge-patched into `body` before sending the request. `sensitive_body_version` follows the existing `azapi_resource` and `azapi_update_resource` pattern so callers can control when individual write-only fields are resent. The resource schema is upgraded to v3 with a state migration for existing v2 state.

For Terraform actions, `sensitive_body` is a write-only action argument so ephemeral secrets can be passed to the action without being serialized into the saved plan. For ephemeral resources, `sensitive_body` is merged into the request body while relying on the ephemeral resource lifecycle for non-persistence.

`sensitive_body` is rejected with `when = "destroy"` on the managed resource because write-only configuration is not available during destroy.

Fixes #1039
Related to #1130