### PR TITLE
Fix missing resource identity after read

### DIFF
--- a/internal/services/azapi_resource.go
+++ b/internal/services/azapi_resource.go
@@ -1006,6 +1006,9 @@ func (r *AzapiResource) Read(ctx context.Context, request resource.ReadRequest, 
 	if response.Diagnostics.Append(request.State.Get(ctx, &model)...); response.Diagnostics.HasError() {
 		return
 	}
+	if response.Diagnostics.Append(response.Identity.SetAttribute(ctx, path.Root("id"), model.ID)...); response.Diagnostics.HasError() {
+		return
+	}
 
 	readTimeout, diags := model.Timeouts.Read(ctx, 5*time.Minute)
 	response.Diagnostics.Append(diags...)
@@ -1159,7 +1162,6 @@ func (r *AzapiResource) Read(ctx context.Context, request resource.ReadRequest, 
 	}
 
 	response.Diagnostics.Append(response.State.Set(ctx, state)...)
-	response.Diagnostics.Append(response.Identity.SetAttribute(ctx, path.Root("id"), state.ID)...)
 }
 
 func (r *AzapiResource) Delete(ctx context.Context, request resource.DeleteRequest, response *resource.DeleteResponse) {

--- a/internal/services/azapi_resource_identity_test.go
+++ b/internal/services/azapi_resource_identity_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
 
-func TestAzapiResourceReadSetsIdentityWhenArmReturnsEmptyObject(t *testing.T) {
+func TestAzapiResourceReadSetsIdentityWhenArmReturnsNotFound(t *testing.T) {
 	ctx := context.Background()
 	resourceID := "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/acctest-rg"
 	resourceType := "Microsoft.Resources/resourceGroups@2021-04-01"
@@ -29,7 +29,7 @@ func TestAzapiResourceReadSetsIdentityWhenArmReturnsEmptyObject(t *testing.T) {
 	resourceClient, err := clients.NewResourceClient(staticTokenCredential{}, &arm.ClientOptions{
 		ClientOptions: policy.ClientOptions{
 			Transport: staticTransport{
-				statusCode: http.StatusOK,
+				statusCode: http.StatusNotFound,
 				body:       `{}`,
 			},
 		},
@@ -86,6 +86,9 @@ func TestAzapiResourceReadSetsIdentityWhenArmReturnsEmptyObject(t *testing.T) {
 	azapiResource.Read(ctx, readRequest, &readResponse)
 	if readResponse.Diagnostics.HasError() {
 		t.Fatalf("reading resource: %+v", readResponse.Diagnostics)
+	}
+	if readResponse.Identity.Raw.IsFullyNull() {
+		t.Fatal("expected identity to be populated from the existing resource state")
 	}
 
 	var identity services.AzapiResourceIdentityModel

--- a/internal/services/azapi_resource_identity_test.go
+++ b/internal/services/azapi_resource_identity_test.go
@@ -1,0 +1,130 @@
+package services_test
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/terraform-provider-azapi/internal/clients"
+	"github.com/Azure/terraform-provider-azapi/internal/services"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+func TestAzapiResourceReadSetsIdentityWhenArmReturnsEmptyObject(t *testing.T) {
+	ctx := context.Background()
+	resourceID := "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/acctest-rg"
+	resourceType := "Microsoft.Resources/resourceGroups@2021-04-01"
+
+	resourceClient, err := clients.NewResourceClient(staticTokenCredential{}, &arm.ClientOptions{
+		ClientOptions: policy.ClientOptions{
+			Transport: staticTransport{
+				statusCode: http.StatusOK,
+				body:       `{}`,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("building resource client: %+v", err)
+	}
+
+	azapiResource := &services.AzapiResource{
+		ProviderData: &clients.Client{
+			ResourceClient: resourceClient,
+		},
+	}
+
+	var schemaResponse resource.SchemaResponse
+	azapiResource.Schema(ctx, resource.SchemaRequest{}, &schemaResponse)
+
+	var identitySchemaResponse resource.IdentitySchemaResponse
+	azapiResource.IdentitySchema(ctx, resource.IdentitySchemaRequest{}, &identitySchemaResponse)
+
+	model := services.NewDefaultAzapiResourceModel()
+	model.ID = types.StringValue(resourceID)
+	model.Type = types.StringValue(resourceType)
+	model.Name = types.StringValue("acctest-rg")
+	model.Location = types.StringValue("eastus")
+	model.Body = types.DynamicValue(types.ObjectValueMust(map[string]attr.Type{}, map[string]attr.Value{}))
+
+	state := tfsdk.State{Schema: schemaResponse.Schema}
+	diags := state.Set(ctx, model)
+	if diags.HasError() {
+		t.Fatalf("setting state: %+v", diags)
+	}
+
+	requestIdentity := &tfsdk.ResourceIdentity{
+		Schema: identitySchemaResponse.IdentitySchema,
+		Raw:    tftypes.NewValue(identitySchemaResponse.IdentitySchema.Type().TerraformType(ctx), nil),
+	}
+	responseIdentity := &tfsdk.ResourceIdentity{
+		Schema: identitySchemaResponse.IdentitySchema,
+		Raw:    tftypes.NewValue(identitySchemaResponse.IdentitySchema.Type().TerraformType(ctx), nil),
+	}
+
+	readRequest := resource.ReadRequest{
+		State:    state,
+		Identity: requestIdentity,
+	}
+	readResponse := resource.ReadResponse{
+		State:    state,
+		Identity: responseIdentity,
+	}
+	setEmptyPrivateState(&readRequest)
+	setEmptyPrivateState(&readResponse)
+
+	azapiResource.Read(ctx, readRequest, &readResponse)
+	if readResponse.Diagnostics.HasError() {
+		t.Fatalf("reading resource: %+v", readResponse.Diagnostics)
+	}
+
+	var identity services.AzapiResourceIdentityModel
+	diags = readResponse.Identity.Get(ctx, &identity)
+	if diags.HasError() {
+		t.Fatalf("reading identity: %+v", diags)
+	}
+
+	if identity.ID.ValueString() != resourceID {
+		t.Fatalf("expected identity ID %q, got %q", resourceID, identity.ID.ValueString())
+	}
+}
+
+type staticTokenCredential struct{}
+
+func (staticTokenCredential) GetToken(context.Context, policy.TokenRequestOptions) (azcore.AccessToken, error) {
+	return azcore.AccessToken{
+		Token:     "token",
+		ExpiresOn: time.Now().Add(time.Hour),
+	}, nil
+}
+
+type staticTransport struct {
+	statusCode int
+	body       string
+}
+
+func (t staticTransport) Do(req *http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: t.statusCode,
+		Header: http.Header{
+			"Content-Type": []string{"application/json"},
+		},
+		Body:    io.NopCloser(strings.NewReader(t.body)),
+		Request: req,
+	}, nil
+}
+
+func setEmptyPrivateState(target any) {
+	field := reflect.ValueOf(target).Elem().FieldByName("Private")
+	field.Set(reflect.New(field.Type().Elem()))
+}

--- a/internal/services/azapi_resource_upgrade_test.go
+++ b/internal/services/azapi_resource_upgrade_test.go
@@ -1,6 +1,7 @@
 package services_test
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -8,10 +9,94 @@ import (
 
 	"github.com/Azure/terraform-provider-azapi/internal/acceptance"
 	"github.com/Azure/terraform-provider-azapi/internal/acceptance/check"
+	"github.com/Azure/terraform-provider-azapi/internal/clients"
+	"github.com/Azure/terraform-provider-azapi/internal/services/parse"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 const PreviousVersion = "1.14.0"
+
+func TestAccAzapiResourceUpgrade_missingIdentityAfterReadWhenDeletedOutsideTerraform(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azapi_resource", "test")
+	r := GenericResource{}
+	config := r.missingIdentityAfterRead(data)
+	var resourceID string
+	var resourceType string
+
+	data.UpgradeTest(t, r, []resource.TestStep{
+		data.UpgradeTestDeployStep(resource.TestStep{
+			Config: config,
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				captureResourceState(data.ResourceName, &resourceID, &resourceType),
+			),
+		}, "2.7.0"),
+		data.UpgradeTestPlanStep(resource.TestStep{
+			Config:             config,
+			ExpectNonEmptyPlan: true,
+			PreConfig: func() {
+				if err := deleteResourceOutsideTerraform(resourceID, resourceType); err != nil {
+					t.Fatalf("deleting resource outside Terraform: %+v", err)
+				}
+			},
+		}),
+		data.UpgradeTestApplyStep(resource.TestStep{
+			Config: config,
+		}),
+	})
+}
+
+func (r GenericResource) missingIdentityAfterRead(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azapi_resource" "test" {
+  type      = "Microsoft.Network/virtualNetworks@2023-11-01"
+  name      = "acctest-vnet-%d"
+  parent_id = azapi_resource.resourceGroup.id
+  location  = azapi_resource.resourceGroup.location
+
+  body = {
+    properties = {
+      addressSpace = {
+        addressPrefixes = ["10.0.0.0/16"]
+      }
+    }
+  }
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func captureResourceState(resourceName string, resourceID, resourceType *string) resource.TestCheckFunc {
+	return func(state *terraform.State) error {
+		resourceState, ok := state.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource %q was not found in state", resourceName)
+		}
+		*resourceID = resourceState.Primary.ID
+		*resourceType = resourceState.Primary.Attributes["type"]
+		return nil
+	}
+}
+
+func deleteResourceOutsideTerraform(resourceID, resourceType string) error {
+	id, err := parse.ResourceIDWithResourceType(resourceID, resourceType)
+	if err != nil {
+		return fmt.Errorf("parsing resource ID: %+v", err)
+	}
+
+	client, err := acceptance.BuildTestClient()
+	if err != nil {
+		return fmt.Errorf("building test client: %+v", err)
+	}
+
+	_, err = client.ResourceClient.Delete(context.Background(), id.AzureResourceId, id.ApiVersion, clients.DefaultRequestOptions())
+	if err != nil {
+		return err
+	}
+	return nil
+}
 
 func TestAccAzapiResourceUpgrade_basic(t *testing.T) {
 	acceptance.SkipIfCoreAcctestsOnly(t, "Acctest subscription has no quota to run this test (Automation accounts quota exceeded)")


### PR DESCRIPTION
## Summary
- Populate `azapi_resource` identity from the existing state before reading the Azure resource.
- Add a focused 404 unit regression.
- Add an upgrade acceptance regression that creates state with AzAPI v2.7.0, deletes the resource outside Terraform, and plans with the current provider.

## Root Cause
AzAPI v2.7.0 did not store Terraform resource identity. After upgrading, a successful read populated identity at the end of `Read()`, but a 404 removed the resource from state and returned before that happened. Terraform Plugin Framework then reported `Missing Resource Identity After Read`.

Fresh resources created by current provider versions already have identity in state, which is why deleting a newly created v2.10.0 resource does not reproduce the issue.

Fixes #1050