### PR TITLE
Regen markdown on bicep type update

### DIFF
--- a/.github/workflows/bicep-types-update.yaml
+++ b/.github/workflows/bicep-types-update.yaml
@@ -93,6 +93,12 @@ jobs:
           find . -type f -name "*.md" -delete
           find . -type f -name "*.out" -delete
 
+      - name: Regenerate markdown doc
+        run: |
+          set -xe
+          go version
+          go generate ./...
+
       - name: Configure git name and email
         run: |
           set -xe

--- a/.github/workflows/bicep-types-update.yaml
+++ b/.github/workflows/bicep-types-update.yaml
@@ -98,10 +98,11 @@ jobs:
           find . -type f -name "*.md" -delete
           find . -type f -name "*.out" -delete
 
-      - name: go generate ./...
+      - name: Sync generated docs to updated source
         run: |
           set -xe
           go version
+          go build -buildvcs=false
           go generate ./...
 
       - name: Configure git name and email
@@ -114,6 +115,7 @@ jobs:
         id: commit
         run: |
           set -xe
+          git diff --name-status
           git add -A
           if git commit -m "Updated bicep types to Azure/azure-rest-api-specs revision $(git -C tools/bicep-types-update/azure-rest-api-specs rev-parse HEAD)"; then
             echo "has_changes=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/bicep-types-update.yaml
+++ b/.github/workflows/bicep-types-update.yaml
@@ -25,6 +25,11 @@ jobs:
         with:
           node-version: '24'
 
+      - name: Install Terraform CLI
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.15.8
+
       - name: Checkout current repository
         uses: actions/checkout@v4
         with:
@@ -93,7 +98,7 @@ jobs:
           find . -type f -name "*.md" -delete
           find . -type f -name "*.out" -delete
 
-      - name: Regenerate markdown doc
+      - name: go generate ./...
         run: |
           set -xe
           go version

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -6,6 +6,8 @@ on:
     paths:
       - '**.go'
       - '**.tf'
+      - 'docs/**'
+      - 'internal/azure/generated/**'
       - 'vendor/**'
       - '.github/workflows/**'
 

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -6,8 +6,6 @@ on:
     paths:
       - '**.go'
       - '**.tf'
-      - 'docs/**'
-      - 'internal/azure/generated/**'
       - 'vendor/**'
       - '.github/workflows/**'
 


### PR DESCRIPTION
This PR fixes a bug on Bicep Types Update workflow where the markdown docs were not re-generated against the updated types, hence causing a drift between supported types vs what's documented on markdown.

## Testing

Ran the Bicep Types Update workflow via manual push: https://github.com/Azure/terraform-provider-azapi/actions/runs/29064833746