### PR TITLE
doc: Highlight diff with AzureRM and AzAPI casing

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ The AzAPI provider is a very thin layer on top of the [Azure ARM REST APIs](http
 
 This provider complements the AzureRM provider by enabling the management of Azure resources that are not yet or may never be supported in the AzureRM provider such as private/public preview services and features.
 
-## Get started with AzApi
+## Get started with AzAPI
 
-* [AzApi Provider Overview](https://docs.microsoft.com/en-us/azure/developer/terraform/overview-azapi-provider)
+* [AzAPI Provider Overview](https://docs.microsoft.com/en-us/azure/developer/terraform/overview-azapi-provider)
 
 * [Learn how to use azapi_resource](https://docs.microsoft.com/en-us/azure/developer/terraform/get-started-azapi-resource)
 
@@ -31,7 +31,7 @@ terraform {
 
 provider "azapi" {
   # More information on the authentication methods supported by
-  # the AzApi Provider can be found here:
+  # the AzAPI Provider can be found here:
   # https://registry.terraform.io/providers/Azure/azapi/latest/docs
 
   # subscription_id = "..."

--- a/docs/guides/2.0-upgrade-guide.md
+++ b/docs/guides/2.0-upgrade-guide.md
@@ -6,13 +6,13 @@ description: |-
 
 ---
 
-# Azapi Provider
+# AzAPI Provider
 
-## Azapi Provider Version v2.0
+## AzAPI Provider Version v2.0
 
 ### Considerations
 
-Version 2.0 of the Azapi Provider is a major release and includes breaking changes which are outlined in this document.
+Version 2.0 of the AzAPI Provider is a major release and includes breaking changes which are outlined in this document.
 
 When upgrading to version 2.0 of the Azure Provider, we recommend upgrading to the latest version of Terraform Core ([which can be found here](https://www.terraform.io/downloads)).
 
@@ -20,7 +20,7 @@ This guide will continue to receive updates as we incorporate feedback and conti
 
 ### Pinning your Provider Version
 
-We recommend pinning the version of each Provider you use in Terraform - you can do this using the `version` attribute within the `required_providers` block, either to a specific version of the Azapi Provider, like so:
+We recommend pinning the version of each Provider you use in Terraform - you can do this using the `version` attribute within the `required_providers` block, either to a specific version of the AzAPI Provider, like so:
 
 ```hcl
 terraform {
@@ -57,7 +57,7 @@ More information on [how to pin the version of a Terraform Provider being used c
 ---
 
 
-## What's available in Version 2.0 of the Azapi Provider?
+## What's available in Version 2.0 of the AzAPI Provider?
 
 Below is an overview of the changes coming 2.0. Each topic is covered in more detail further down.
 

--- a/docs/guides/feature_migrate_from_azurerm.md
+++ b/docs/guides/feature_migrate_from_azurerm.md
@@ -1,14 +1,14 @@
 ---
 layout: "azapi"
-page_title: "Feature: Migrate from Azurerm"
+page_title: "Feature: Migrate from AzureRM"
 description: |-
-  This guide will cover how to migrate your existing AzureRM resources to AzApi in Terraform Module.
+  This guide will cover how to migrate your existing AzureRM resources to AzAPI in Terraform Module.
 
 ---
 
 ## Introduction
 
-This guide is intended to help you migrate your existing AzureRM resources to AzApi in Terraform Module. 
+This guide is intended to help you migrate your existing AzureRM resources to AzAPI in Terraform Module. 
 
 
 ## Prerequisites
@@ -19,7 +19,7 @@ This guide is intended to help you migrate your existing AzureRM resources to Az
 
 ## Migration Steps
 
-This guide will walk you through the steps to migrate your existing AzureRM resources to AzApi in Terraform Module. 
+This guide will walk you through the steps to migrate your existing AzureRM resources to AzAPI in Terraform Module. 
 It will use [terraform-azurerm-avm-ptn-aks-dev](https://github.com/Azure/terraform-azurerm-avm-ptn-aks-dev) as an example.
 The target is to migrate the `azurerm_management_lock` to `azapi_resource` in the module.
 

--- a/docs/guides/frequently_asked_questions.md
+++ b/docs/guides/frequently_asked_questions.md
@@ -47,7 +47,7 @@ its request body won't contain any subnets definitions, so existing subnets will
 
 ## How to use API/properties which is not in embeded schema?
 
-`AzApi` provider will use embedded schema to verify the inputs, to skip the validation, please add `schema_validation_enabled = false` to the resource block.
+`AzAPI` provider will use embedded schema to verify the inputs, to skip the validation, please add `schema_validation_enabled = false` to the resource block.
 
 
 ## How to manage properties which can only be set during update?

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,6 +9,36 @@ description: |-
 
 The AzAPI provider is a very thin layer on top of the [Azure ARM REST APIs](https://learn.microsoft.com/rest/api/azure). This provider complements the [AzureRM provider](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs) by enabling the management of Azure resources that are not yet or may never be supported in the AzureRM provider such as private/public preview services and features.
 
+Following example highlight the main differences between AzAPI and AzureRM for a storage account resource:
+
+```hcl
+# AzAPI
+# API version can be specified in the type attribute
+# the body attribute maps to the REST API payload
+resource "azapi_resource" "sa1" {
+  type      = "Microsoft.Storage/storageAccounts@2025-06-01"
+  parent_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup"
+  name      = "mysa1"
+  location  = "westus"
+
+  body = {
+    "kind" = "StorageV2"
+    "sku" = {
+      name = "Standard_RAGRS"
+    }
+  }
+}
+
+# AzureRM
+resource "azurerm_storage_account" "sa1" {
+  name                     = "mysa1"
+  resource_group_name      = "myResourceGroup"
+  location                 = "westus"
+  account_tier             = "Standard"
+  account_replication_type = "RAGRS"
+}
+```
+
 Documentation regarding the [Data Sources](/docs/configuration/data-sources.html) and [Resources](/docs/configuration/resources.html) supported by the AzAPI Provider can be found in the navigation to the left.
 
 Interested in the provider's latest features, or want to make sure you're up to date? Check out the [changelog](https://github.com/Azure/terraform-provider-azapi/blob/main/CHANGELOG.md) for version information and release notes.


### PR DESCRIPTION
Fixed "AzAPI" character casing in docs and highlighted key differences with AzureRM in index.