### PR TITLE
Fix: OIDC token file path logic

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -96,6 +96,18 @@ type providerEndpointData struct {
 	ResourceManagerAudience      types.String `tfsdk:"resource_manager_audience"`
 }
 
+func getOIDCTokenFilePathFromEnv(useAKSWorkloadIdentity bool) string {
+	if v := os.Getenv("ARM_OIDC_TOKEN_FILE_PATH"); v != "" {
+		return v
+	}
+	if useAKSWorkloadIdentity {
+		if v := os.Getenv("AZURE_FEDERATED_TOKEN_FILE"); v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
 func (p Provider) Metadata(ctx context.Context, request provider.MetadataRequest, response *provider.MetadataResponse) {
 	response.TypeName = "azapi"
 }
@@ -483,9 +495,7 @@ func (p Provider) Configure(ctx context.Context, request provider.ConfigureReque
 	}
 
 	if model.OIDCTokenFilePath.IsNull() {
-		if v := os.Getenv("ARM_OIDC_TOKEN_FILE_PATH"); v != "" {
-			model.OIDCTokenFilePath = types.StringValue(v)
-		} else if v := os.Getenv("AZURE_FEDERATED_TOKEN_FILE"); v != "" {
+		if v := getOIDCTokenFilePathFromEnv(model.UseAKSWorkloadIdentity.ValueBool()); v != "" {
 			model.OIDCTokenFilePath = types.StringValue(v)
 		}
 	}

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -1,0 +1,27 @@
+package provider
+
+import "testing"
+
+func TestGetOIDCTokenFilePathFromEnv(t *testing.T) {
+	t.Run("prefers ARM_OIDC_TOKEN_FILE_PATH", func(t *testing.T) {
+		t.Setenv("ARM_OIDC_TOKEN_FILE_PATH", "/tmp/arm-token")
+		t.Setenv("AZURE_FEDERATED_TOKEN_FILE", "/tmp/azure-token")
+
+		if got := getOIDCTokenFilePathFromEnv(false); got != "/tmp/arm-token" {
+			t.Fatalf("expected ARM_OIDC_TOKEN_FILE_PATH to be used, got %q", got)
+		}
+	})
+
+	t.Run("uses AZURE_FEDERATED_TOKEN_FILE only when AKS workload identity is enabled", func(t *testing.T) {
+		t.Setenv("ARM_OIDC_TOKEN_FILE_PATH", "")
+		t.Setenv("AZURE_FEDERATED_TOKEN_FILE", "/tmp/azure-token")
+
+		if got := getOIDCTokenFilePathFromEnv(false); got != "" {
+			t.Fatalf("expected no token file path when AKS workload identity is disabled, got %q", got)
+		}
+
+		if got := getOIDCTokenFilePathFromEnv(true); got != "/tmp/azure-token" {
+			t.Fatalf("expected AZURE_FEDERATED_TOKEN_FILE to be used when AKS workload identity is enabled, got %q", got)
+		}
+	})
+}

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -2,6 +2,8 @@ package provider
 
 import "testing"
 
+// AzAPI acctest pipeline uses password based secret and does not yet support OIDC / federated token, hence we only
+// do unit test coverage
 func TestGetOIDCTokenFilePathFromEnv(t *testing.T) {
 	t.Run("prefers ARM_OIDC_TOKEN_FILE_PATH", func(t *testing.T) {
 		t.Setenv("ARM_OIDC_TOKEN_FILE_PATH", "/tmp/arm-token")


### PR DESCRIPTION
Fixes #1149 by ensuring the provider only uses AZURE_FEDERATED_TOKEN_FILE when AKS workload identity is explicitly enabled.

When use_aks_workload_identity is left at its default `false`, the provider should not pick up the AKS-injected federated token file and override GitHub OIDC authentication. This change keeps the existing OIDC behavior intact for normal OIDC flows while preventing the AKS workload identity token from hijacking the credential chain.

## Testing

- acctest: https://dev.azure.com/azclitools/internal/_build/results?buildId=328859&view=results