### PR TITLE
`azapi_resource_action` - set output as unknow when action executes

### DIFF
--- a/internal/services/azapi_resource_action_resource.go
+++ b/internal/services/azapi_resource_action_resource.go
@@ -317,6 +317,9 @@ func (r *ActionResource) ModifyPlan(ctx context.Context, request resource.Modify
 		}
 
 		if actionWillRun && !skip.CanSkipExternalRequest(*state, *plan, "update") {
+			// The action response can vary between runs, so output fields must remain unknown until apply.
+			plan.Output = basetypes.NewDynamicUnknown()
+			plan.SensitiveOutput = basetypes.NewDynamicUnknown()
 			plan.Exist = basetypes.NewBoolUnknown()
 		}
 


### PR DESCRIPTION
### Description

Resource action outputs may change after an action executes, which can cause inconsistent post-apply state and test failures. This case the intermittent error in nightly pipeline. 

This PR fixes that behavior by marking output as unknown during planning whenever the action is expected to execute, so Terraform does not lock in a stale output type before applying.

acctest: https://dev.azure.com/azclitools/internal/_build/results?buildId=329472&view=results 