### PR TITLE
Add missing identity fix to v2.11.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ ENHANCEMENTS:
 
 BUG FIXES:
 
+- Fix `Missing Resource Identity After Read` after upgrading from v2.7.0 when a resource is deleted outside Terraform (GH-1050).
 - Fix `azapi_resource_action` output handling when updating existing actions (GH-1158).
 - Fix `azapi_resource_action` output being set incorrectly while the action is executing (GH-1168).
 - Fix `ResourceClient CreateOrUpdate` to return the initial PUT body correctly (GH-1160).


### PR DESCRIPTION
## Summary

- Add the merged fix from #1156 to the v2.11.0 bug fixes.
- Reference the user report in #1050.