### PR TITLE
Refactor `data_plane_client.go` 

### DIFF
--- a/internal/clients/data_plane_client.go
+++ b/internal/clients/data_plane_client.go
@@ -38,128 +38,36 @@ func NewDataPlaneClient(credential azcore.TokenCredential, opt *arm.ClientOption
 	}, nil
 }
 
-func (client *DataPlaneClient) cachedPipeline(rawUrl string) (runtime.Pipeline, error) {
-	client.syncMux.Lock()
-	defer client.syncMux.Unlock()
-
-	parsedUrl, err := url.Parse(rawUrl)
-	if err != nil {
-		return runtime.Pipeline{}, err
-	}
-	serviceName := cloud.ResourceManager
-	cloud := client.clientOptions.Cloud
-	host := parsedUrl.Host
-	for name, serviceConfiguration := range cloud.Services {
-		if strings.HasSuffix(host, strings.TrimPrefix(serviceConfiguration.Endpoint, "https://")) {
-			serviceName = name
-			break
-		}
-	}
-
-	if pipeline, ok := client.cachedPipelines[string(serviceName)]; ok {
-		return pipeline, nil
-	}
-
-	plOpt := runtime.PipelineOptions{}
-	plOpt.APIVersion.Name = "api-version"
-	authPolicy := armruntime.NewBearerTokenPolicy(client.credential, &armpolicy.BearerTokenOptions{Scopes: []string{cloud.Services[serviceName].Audience + "/.default"}})
-	plOpt.PerRetry = append(plOpt.PerRetry, authPolicy)
-	pl := runtime.NewPipeline(moduleName, moduleVersion, plOpt, &client.clientOptions.ClientOptions)
-
-	client.cachedPipelines[string(serviceName)] = pl
-	return pl, nil
-}
-
 func (client *DataPlaneClient) CreateOrUpdateThenPoll(ctx context.Context, id parse.DataPlaneResourceId, body interface{}, options RequestOptions) (interface{}, error) {
-	// build request
-	if options.RetryOptions != nil {
-		ctx = policy.WithRetryOptions(ctx, *options.RetryOptions)
-	}
-	urlPath := fmt.Sprintf("https://%s", id.AzureResourceId)
-	req, err := runtime.NewRequest(ctx, http.MethodPut, urlPath)
+	urlPath := buildURL(id.AzureResourceId, "")
+
+	req, err := buildRequest(ctx, options, urlPath, http.MethodPut, id.ApiVersion)
 	if err != nil {
 		return nil, err
 	}
-	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", id.ApiVersion)
-	for key, value := range options.QueryParameters {
-		reqQP.Set(key, value)
-	}
-	req.Raw().URL.RawQuery = reqQP.Encode()
-	req.Raw().Header.Set("Accept", "application/json")
-	for key, value := range options.Headers {
-		req.Raw().Header.Set(key, value)
-	}
+
 	err = runtime.MarshalAsJSON(req, body)
 	if err != nil {
 		return nil, err
 	}
 
-	// send request
-	pipeline, err := client.cachedPipeline(urlPath)
-	if err != nil {
-		return nil, err
-	}
-	resp, err := pipeline.Do(req)
-	if err != nil {
-		return nil, WrapContextError(err, options.LastRetryError)
-	}
-	if !runtime.HasStatusCode(resp, http.StatusOK, http.StatusCreated, http.StatusAccepted, http.StatusNoContent) {
-		return nil, runtime.NewResponseError(resp)
-	}
-
-	// poll until done
-	pt, err := runtime.NewPoller[interface{}](resp, pipeline, nil)
-	if err == nil {
-		resp, err := pt.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{
-			Frequency: 10 * time.Second,
-		})
-		return resp, err
-	}
-
-	// unmarshal response
-	var responseBody interface{}
-	if err := runtime.UnmarshalAsJSON(resp, &responseBody); err != nil {
-		return nil, err
-	}
-	return responseBody, nil
+	successCodes := []int{http.StatusOK, http.StatusCreated, http.StatusAccepted, http.StatusNoContent}
+	return client.sendRequestThenPoll(ctx, req, urlPath, options, successCodes)
 }
 
 func (client *DataPlaneClient) Get(ctx context.Context, id parse.DataPlaneResourceId, options RequestOptions) (interface{}, error) {
-	// build request
-	if options.RetryOptions != nil {
-		ctx = policy.WithRetryOptions(ctx, *options.RetryOptions)
-	}
-	urlPath := fmt.Sprintf("https://%s", id.AzureResourceId)
-	req, err := runtime.NewRequest(ctx, http.MethodGet, urlPath)
+	urlPath := buildURL(id.AzureResourceId, "")
+	req, err := buildRequest(ctx, options, urlPath, http.MethodGet, id.ApiVersion)
 	if err != nil {
 		return nil, err
 	}
-	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", id.ApiVersion)
-	for key, value := range options.QueryParameters {
-		reqQP.Set(key, value)
-	}
-	req.Raw().URL.RawQuery = reqQP.Encode()
-	req.Raw().Header.Set("Accept", "application/json")
-	for key, value := range options.Headers {
-		req.Raw().Header.Set(key, value)
-	}
 
-	// send request
-	pipeline, err := client.cachedPipeline(urlPath)
+	successCodes := []int{http.StatusOK}
+	resp, _, err := client.sendRequest(req, urlPath, options, successCodes)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := pipeline.Do(req)
-	if err != nil {
-		return nil, WrapContextError(err, options.LastRetryError)
-	}
-	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		return nil, runtime.NewResponseError(resp)
-	}
 
-	// unmarshal response
 	var responseBody interface{}
 	if err := runtime.UnmarshalAsJSON(resp, &responseBody); err != nil {
 		return nil, err
@@ -168,79 +76,23 @@ func (client *DataPlaneClient) Get(ctx context.Context, id parse.DataPlaneResour
 }
 
 func (client *DataPlaneClient) DeleteThenPoll(ctx context.Context, id parse.DataPlaneResourceId, options RequestOptions) (interface{}, error) {
-	// build request
-	if options.RetryOptions != nil {
-		ctx = policy.WithRetryOptions(ctx, *options.RetryOptions)
-	}
-	urlPath := fmt.Sprintf("https://%s", id.AzureResourceId)
-	req, err := runtime.NewRequest(ctx, http.MethodDelete, urlPath)
+	urlPath := buildURL(id.AzureResourceId, "")
+	req, err := buildRequest(ctx, options, urlPath, http.MethodDelete, id.ApiVersion)
 	if err != nil {
 		return nil, err
 	}
-	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", id.ApiVersion)
-	for key, value := range options.QueryParameters {
-		reqQP.Set(key, value)
-	}
-	req.Raw().URL.RawQuery = reqQP.Encode()
-	req.Raw().Header.Set("Accept", "application/json")
-	for key, value := range options.Headers {
-		req.Raw().Header.Set(key, value)
-	}
 
-	// send request
-	pipeline, err := client.cachedPipeline(urlPath)
-	if err != nil {
-		return nil, err
-	}
-	resp, err := pipeline.Do(req)
-	if err != nil {
-		return nil, WrapContextError(err, options.LastRetryError)
-	}
-	if !runtime.HasStatusCode(resp, http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, runtime.NewResponseError(resp)
-	}
-
-	// poll until done
-	pt, err := runtime.NewPoller[interface{}](resp, pipeline, nil)
-	if err == nil {
-		resp, err := pt.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{
-			Frequency: 10 * time.Second,
-		})
-		return resp, err
-	}
-
-	// unmarshal response
-	var responseBody interface{}
-	if err := runtime.UnmarshalAsJSON(resp, &responseBody); err != nil {
-		return nil, err
-	}
-	return responseBody, nil
+	successCodes := []int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}
+	return client.sendRequestThenPoll(ctx, req, urlPath, options, successCodes)
 }
 
 func (client *DataPlaneClient) Action(ctx context.Context, resourceID string, action string, apiVersion string, method string, body interface{}, options RequestOptions) (interface{}, error) {
-	// build request
-	if options.RetryOptions != nil {
-		ctx = policy.WithRetryOptions(ctx, *options.RetryOptions)
-	}
-	urlPath := fmt.Sprintf("https://%s", resourceID)
-	if action != "" {
-		urlPath = fmt.Sprintf("%s/%s", urlPath, action)
-	}
-	req, err := runtime.NewRequest(ctx, method, urlPath)
+	urlPath := buildURL(resourceID, action)
+	req, err := buildRequest(ctx, options, urlPath, method, apiVersion)
 	if err != nil {
 		return nil, err
 	}
-	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", apiVersion)
-	for key, value := range options.QueryParameters {
-		reqQP.Set(key, value)
-	}
-	req.Raw().URL.RawQuery = reqQP.Encode()
-	req.Raw().Header.Set("Accept", "application/json")
-	for key, value := range options.Headers {
-		req.Raw().Header.Set(key, value)
-	}
+
 	if method != "GET" && body != nil {
 		err = runtime.MarshalAsJSON(req, body)
 	}
@@ -248,20 +100,14 @@ func (client *DataPlaneClient) Action(ctx context.Context, resourceID string, ac
 		return nil, err
 	}
 
-	// send request
-	pipeline, err := client.cachedPipeline(urlPath)
+	// Action does not use sendRequestThenPoll because it parses the response body
+	// based on Content-Type (text/plain vs application/json) rather than always as JSON.
+	successCodes := []int{http.StatusOK, http.StatusCreated, http.StatusAccepted}
+	resp, pipeline, err := client.sendRequest(req, urlPath, options, successCodes)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := pipeline.Do(req)
-	if err != nil {
-		return nil, WrapContextError(err, options.LastRetryError)
-	}
-	if !runtime.HasStatusCode(resp, http.StatusOK, http.StatusCreated, http.StatusAccepted) {
-		return nil, runtime.NewResponseError(resp)
-	}
 
-	// poll until done
 	pt, err := runtime.NewPoller[interface{}](resp, pipeline, nil)
 	if err == nil {
 		resp, err := pt.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{
@@ -270,7 +116,6 @@ func (client *DataPlaneClient) Action(ctx context.Context, resourceID string, ac
 		return resp, err
 	}
 
-	// unmarshal response
 	var responseBody interface{}
 	contentType := resp.Header.Get("Content-Type")
 	switch {
@@ -287,4 +132,101 @@ func (client *DataPlaneClient) Action(ctx context.Context, resourceID string, ac
 	default:
 	}
 	return responseBody, nil
+}
+
+func buildURL(resourceId string, action string) (urlPath string) {
+	urlPath = fmt.Sprintf("https://%s", resourceId)
+	if action != "" {
+		urlPath = fmt.Sprintf("%s/%s", urlPath, action)
+	}
+	return
+}
+
+func buildRequest(ctx context.Context, options RequestOptions, urlPath, method, apiVersion string) (*policy.Request, error) {
+	if options.RetryOptions != nil {
+		ctx = policy.WithRetryOptions(ctx, *options.RetryOptions)
+	}
+	req, err := runtime.NewRequest(ctx, method, urlPath)
+	if err != nil {
+		return nil, err
+	}
+	reqQP := req.Raw().URL.Query()
+	reqQP.Set("api-version", apiVersion)
+	for key, value := range options.QueryParameters {
+		reqQP.Set(key, value)
+	}
+	req.Raw().URL.RawQuery = reqQP.Encode()
+	req.Raw().Header.Set("Accept", "application/json")
+	for key, value := range options.Headers {
+		req.Raw().Header.Set(key, value)
+	}
+
+	return req, nil
+}
+
+func (client *DataPlaneClient) sendRequest(req *policy.Request, urlPath string, options RequestOptions, statusCodes []int) (*http.Response, runtime.Pipeline, error) {
+	pipeline, err := client.cachedPipeline(urlPath)
+	if err != nil {
+		return nil, runtime.Pipeline{}, err
+	}
+	resp, err := pipeline.Do(req)
+	if err != nil {
+		return nil, runtime.Pipeline{}, WrapContextError(err, options.LastRetryError)
+	}
+	if !runtime.HasStatusCode(resp, statusCodes...) {
+		return nil, runtime.Pipeline{}, runtime.NewResponseError(resp)
+	}
+	return resp, pipeline, nil
+}
+
+func (client *DataPlaneClient) sendRequestThenPoll(ctx context.Context, req *policy.Request, urlPath string, options RequestOptions, statusCodes []int) (interface{}, error) {
+	resp, pipeline, err := client.sendRequest(req, urlPath, options, statusCodes)
+	if err != nil {
+		return nil, err
+	}
+
+	if pt, err := runtime.NewPoller[interface{}](resp, pipeline, nil); err == nil {
+		return pt.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{
+			Frequency: 10 * time.Second,
+		})
+	}
+
+	// if NewPoller returned an error, return the original resp body directly.
+	var responseBody interface{}
+	if err := runtime.UnmarshalAsJSON(resp, &responseBody); err != nil {
+		return nil, err
+	}
+	return responseBody, nil
+}
+
+func (client *DataPlaneClient) cachedPipeline(rawUrl string) (runtime.Pipeline, error) {
+	client.syncMux.Lock()
+	defer client.syncMux.Unlock()
+
+	parsedUrl, err := url.Parse(rawUrl)
+	if err != nil {
+		return runtime.Pipeline{}, err
+	}
+	serviceName := cloud.ResourceManager
+	cloudConfig := client.clientOptions.Cloud
+	host := parsedUrl.Host
+	for name, serviceConfiguration := range cloudConfig.Services {
+		if strings.HasSuffix(host, strings.TrimPrefix(serviceConfiguration.Endpoint, "https://")) {
+			serviceName = name
+			break
+		}
+	}
+
+	if pipeline, ok := client.cachedPipelines[string(serviceName)]; ok {
+		return pipeline, nil
+	}
+
+	plOpt := runtime.PipelineOptions{}
+	plOpt.APIVersion.Name = "api-version"
+	authPolicy := armruntime.NewBearerTokenPolicy(client.credential, &armpolicy.BearerTokenOptions{Scopes: []string{cloudConfig.Services[serviceName].Audience + "/.default"}})
+	plOpt.PerRetry = append(plOpt.PerRetry, authPolicy)
+	pl := runtime.NewPipeline(moduleName, moduleVersion, plOpt, &client.clientOptions.ClientOptions)
+
+	client.cachedPipelines[string(serviceName)] = pl
+	return pl, nil
 }


### PR DESCRIPTION
This PR is to refactor the `data_plane_client.go` file to improve maintainability and readability:
1. Group the repetitive code in to `buildRequest`, `sendRequest` and `sendRequestThenPoll` function and reuse them across CreateAndUpdate/Get/Delete/Action function 
2. Rearrange `cachedPipeline` into the bottom of the file so that the script follows the top-down format and increase readability 

This PR shouldn't have any functionality change. Acc test https://dev.azure.com/azclitools/internal/_build/results?buildId=330554&view=results