### PR TITLE
`azapi_data_plane_resource` - allow `name` to be optional based on URL format

### DIFF
--- a/internal/services/azapi_data_plane_resource.go
+++ b/internal/services/azapi_data_plane_resource.go
@@ -432,10 +432,6 @@ func (r *DataPlaneResource) CreateUpdate(ctx context.Context, requestConfig tfsd
 	if isNewResource && hasCreateResult {
 		resourceName = "__generated__"
 	}
-	if resourceName == "" {
-		diagnostics.AddError("Invalid configuration", `The argument "name" must be set for this resource type.`)
-		return
-	}
 
 	id, err := parse.NewDataPlaneResourceId(resourceName, plan.ParentID.ValueString(), plan.Type.ValueString())
 	if err != nil {
@@ -613,6 +609,10 @@ func getCreateResultFunc(config *DataPlaneResourceModel) (customization.CreateRe
 
 func validateDataPlaneResourceName(config *DataPlaneResourceModel) error {
 	if config == nil || config.Type.IsNull() || config.Type.IsUnknown() {
+		return nil
+	}
+
+	if !parse.HasNameSegment(config.Type.ValueString()) {
 		return nil
 	}
 

--- a/internal/services/azapi_data_plane_resource.go
+++ b/internal/services/azapi_data_plane_resource.go
@@ -72,11 +72,13 @@ type DataPlaneResource struct {
 	ProviderData *clients.Client
 }
 
-var _ resource.Resource = &DataPlaneResource{}
-var _ resource.ResourceWithConfigure = &DataPlaneResource{}
-var _ resource.ResourceWithModifyPlan = &DataPlaneResource{}
-var _ resource.ResourceWithUpgradeState = &DataPlaneResource{}
-var _ resource.ResourceWithImportState = &DataPlaneResource{}
+var (
+	_ resource.Resource                 = &DataPlaneResource{}
+	_ resource.ResourceWithConfigure    = &DataPlaneResource{}
+	_ resource.ResourceWithModifyPlan   = &DataPlaneResource{}
+	_ resource.ResourceWithUpgradeState = &DataPlaneResource{}
+	_ resource.ResourceWithImportState  = &DataPlaneResource{}
+)
 
 func (r *DataPlaneResource) Configure(ctx context.Context, request resource.ConfigureRequest, response *resource.ConfigureResponse) {
 	tflog.Debug(ctx, "Configuring azapi_data_plane_resource")
@@ -424,21 +426,7 @@ func (r *DataPlaneResource) CreateUpdate(ctx context.Context, requestConfig tfsd
 	}
 
 	isNewResource := responseState == nil || responseState.Raw.IsNull()
-
-	customizedResource := customization.GetCustomization(plan.Type.ValueString())
-	createResultResource, hasCreateResult := func() (customization.DataPlaneResourceWithCreateResult, bool) {
-		if customizedResource == nil {
-			return nil, false
-		}
-		v, ok := (*customizedResource).(customization.DataPlaneResourceWithCreateResult)
-		if !ok {
-			return nil, false
-		}
-		if v.CreateResultFunc() == nil {
-			return nil, false
-		}
-		return v, true
-	}()
+	createResultFunc, hasCreateResult := getCreateResultFunc(plan)
 
 	resourceName := strings.TrimSpace(plan.Name.ValueString())
 	if isNewResource && hasCreateResult {
@@ -448,6 +436,7 @@ func (r *DataPlaneResource) CreateUpdate(ctx context.Context, requestConfig tfsd
 		diagnostics.AddError("Invalid configuration", `The argument "name" must be set for this resource type.`)
 		return
 	}
+
 	id, err := parse.NewDataPlaneResourceId(resourceName, plan.ParentID.ValueString(), plan.Type.ValueString())
 	if err != nil {
 		diagnostics.AddError("Invalid configuration", err.Error())
@@ -475,6 +464,7 @@ func (r *DataPlaneResource) CreateUpdate(ctx context.Context, requestConfig tfsd
 
 	client := r.ProviderData.DataPlaneClient
 
+	customizedResource := customization.GetCustomization(plan.Type.ValueString())
 	if isNewResource && !hasCreateResult {
 		// check if the resource already exists using the non-retry client to avoid issue where user specifies
 		// a FooResourceNotFound error as a retryable error
@@ -538,7 +528,7 @@ func (r *DataPlaneResource) CreateUpdate(ctx context.Context, requestConfig tfsd
 	switch {
 	case isNewResource && hasCreateResult:
 		var createdId parse.DataPlaneResourceId
-		createdId, _, err = createResultResource.CreateResultFunc()(ctx, *r.ProviderData, id, body, requestOptions)
+		createdId, _, err = createResultFunc(ctx, *r.ProviderData, id, body, requestOptions)
 		if err == nil {
 			id = createdId
 			ctx = tflog.SetField(ctx, "resource_id", id.ID())
@@ -607,30 +597,38 @@ func (r *DataPlaneResource) CreateUpdate(ctx context.Context, requestConfig tfsd
 	}
 }
 
+func getCreateResultFunc(config *DataPlaneResourceModel) (customization.CreateResultFunc, bool) {
+	customizedResource := customization.GetCustomization(config.Type.ValueString())
+	if customizedResource == nil {
+		return nil, false
+	}
+	if v, ok := (*customizedResource).(customization.DataPlaneResourceWithCreateResult); ok {
+		if fn := v.CreateResultFunc(); fn != nil {
+			return fn, true
+		}
+	}
+
+	return nil, false
+}
+
 func validateDataPlaneResourceName(config *DataPlaneResourceModel) error {
 	if config == nil || config.Type.IsNull() || config.Type.IsUnknown() {
-		return nil
-	}
-
-	customizedResource := customization.GetCustomization(config.Type.ValueString())
-	hasCreateResult := false
-	if customizedResource != nil {
-		if v, ok := (*customizedResource).(customization.DataPlaneResourceWithCreateResult); ok && v.CreateResultFunc() != nil {
-			hasCreateResult = true
-		}
-	}
-
-	if hasCreateResult {
-		if !config.Name.IsNull() && !config.Name.IsUnknown() && strings.TrimSpace(config.Name.ValueString()) != "" {
-			return fmt.Errorf(`the argument "name" should not be set for resource type %q because the service generates the identifier`, strings.Split(config.Type.ValueString(), "@")[0])
-		}
 		return nil
 	}
 
 	if config.Name.IsUnknown() {
 		return nil
 	}
-	if config.Name.IsNull() || strings.TrimSpace(config.Name.ValueString()) == "" {
+
+	nameIsEmpty := config.Name.IsNull() || strings.TrimSpace(config.Name.ValueString()) == ""
+	if _, ok := getCreateResultFunc(config); ok {
+		// A resource exposing CreateResultFunc has a service-generated name, so "name" must not be set. See PR #1053.
+		if !nameIsEmpty {
+			return fmt.Errorf(`the argument "name" should not be set for resource type %q because the service generates the identifier`, strings.Split(config.Type.ValueString(), "@")[0])
+		}
+		return nil
+	}
+	if nameIsEmpty {
 		return fmt.Errorf(`the argument "name" must be set for resource type %q`, strings.Split(config.Type.ValueString(), "@")[0])
 	}
 	return nil

--- a/internal/services/azapi_data_plane_resource.go
+++ b/internal/services/azapi_data_plane_resource.go
@@ -612,24 +612,27 @@ func validateDataPlaneResourceName(config *DataPlaneResourceModel) error {
 		return nil
 	}
 
-	if !parse.HasNameSegment(config.Type.ValueString()) {
-		return nil
-	}
-
 	if config.Name.IsUnknown() {
 		return nil
 	}
 
 	nameIsEmpty := config.Name.IsNull() || strings.TrimSpace(config.Name.ValueString()) == ""
+	resourceType := strings.Split(config.Type.ValueString(), "@")[0]
 	if _, ok := getCreateResultFunc(config); ok {
 		// A resource exposing CreateResultFunc has a service-generated name, so "name" must not be set. See PR #1053.
 		if !nameIsEmpty {
-			return fmt.Errorf(`the argument "name" should not be set for resource type %q because the service generates the identifier`, strings.Split(config.Type.ValueString(), "@")[0])
+			return fmt.Errorf(`the argument "name" should not be set for resource type %q because the service generates the identifier`, resourceType)
+		}
+		return nil
+	}
+	if !parse.HasNameSegment(config.Type.ValueString()) {
+		if !nameIsEmpty {
+			return fmt.Errorf(`the argument "name" should not be set for resource type %q because this resource type does not have a name`, resourceType)
 		}
 		return nil
 	}
 	if nameIsEmpty {
-		return fmt.Errorf(`the argument "name" must be set for resource type %q`, strings.Split(config.Type.ValueString(), "@")[0])
+		return fmt.Errorf(`the argument "name" must be set for resource type %q`, resourceType)
 	}
 	return nil
 }

--- a/internal/services/azapi_data_plane_resource_test.go
+++ b/internal/services/azapi_data_plane_resource_test.go
@@ -3,6 +3,7 @@ package services_test
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/Azure/terraform-provider-azapi/internal/acceptance"
@@ -113,6 +114,24 @@ func TestAccDataPlaneResource_keyVaultCertificate(t *testing.T) {
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
+		},
+	})
+}
+
+func TestAccDataPlaneResource_keyVaultCertificateContact(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azapi_data_plane_resource", "test")
+	r := DataPlaneResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config:      r.keyVaultCertificateContactWithName(),
+			PlanOnly:    true,
+			ExpectError: regexp.MustCompile(`the argument "name" should not be set`),
+		},
+		{
+			Config:             r.keyVaultCertificateContact(),
+			PlanOnly:           true,
+			ExpectNonEmptyPlan: true,
 		},
 	})
 }
@@ -764,6 +783,39 @@ resource "azapi_resource_action" "add_accesspolicy_certificate" {
 
 
 `, data.LocationPrimary, data.RandomString)
+}
+
+func (r DataPlaneResource) keyVaultCertificateContact() string {
+	return `
+resource "azapi_data_plane_resource" "test" {
+  type      = "Microsoft.KeyVault/vaults/certificates/contacts@7.4"
+  parent_id = "example.vault.azure.net"
+  body = {
+    contacts = [
+      {
+        email = "foo@contoso.com"
+      }
+    ]
+  }
+}
+`
+}
+
+func (r DataPlaneResource) keyVaultCertificateContactWithName() string {
+	return `
+resource "azapi_data_plane_resource" "test" {
+  type      = "Microsoft.KeyVault/vaults/certificates/contacts@7.4"
+  parent_id = "example.vault.azure.net"
+  name      = "foo"
+  body = {
+    contacts = [
+      {
+        email = "foo@contoso.com"
+      }
+    ]
+  }
+}
+`
 }
 
 func (r DataPlaneResource) iotAppsUser(data acceptance.TestData) string {

--- a/internal/services/parse/data_plane_resource_id_test.go
+++ b/internal/services/parse/data_plane_resource_id_test.go
@@ -286,5 +286,8 @@ func Test_DataPlaneResourceIDWithResourceType(t *testing.T) {
 		if actual.ParentId != v.Expected.ParentId {
 			t.Fatalf("Expected %q but got %q for ParentId", v.Expected.ParentId, actual.ParentId)
 		}
+		if actual.Name != v.Expected.Name {
+			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
+		}
 	}
 }

--- a/internal/services/parse/data_plane_type_map.go
+++ b/internal/services/parse/data_plane_type_map.go
@@ -33,3 +33,16 @@ func findApiPathByResourceType(resourceType string) *ApiPath {
 	}
 	return nil
 }
+
+func hasIdentifierSegment(resourceType string, identifier string) bool {
+	apiPath := findApiPathByResourceType(resourceType)
+	if apiPath == nil {
+		return false
+	}
+	return strings.Contains(apiPath.UrlFormat, "{"+identifier+"}") ||
+		strings.Contains(apiPath.UrlFormat, "{"+identifier+"=")
+}
+
+func HasNameSegment(resourceType string) bool {
+	return hasIdentifierSegment(resourceType, "name")
+}

--- a/internal/services/parse/data_plane_type_map.go
+++ b/internal/services/parse/data_plane_type_map.go
@@ -42,7 +42,7 @@ func hasIdentifierSegment(resourceType string, identifier string) bool {
 	}
 	apiPath := findApiPathByResourceType(resourceType)
 	if apiPath == nil {
-		// currently impossible as every service needs to register, but keep it as a defensive guard.
+		// Unknown type: assume it needs an identifier so validation isn't silently skipped.
 		return true
 	}
 	return strings.Contains(apiPath.UrlFormat, "{"+identifier+"}") ||

--- a/internal/services/parse/data_plane_type_map.go
+++ b/internal/services/parse/data_plane_type_map.go
@@ -4,6 +4,8 @@ import (
 	_ "embed"
 	"encoding/json"
 	"strings"
+
+	"github.com/Azure/terraform-provider-azapi/utils"
 )
 
 type ApiPath struct {
@@ -35,9 +37,13 @@ func findApiPathByResourceType(resourceType string) *ApiPath {
 }
 
 func hasIdentifierSegment(resourceType string, identifier string) bool {
+	if azureResourceType, _, err := utils.GetAzureResourceTypeApiVersion(resourceType); err == nil {
+		resourceType = azureResourceType
+	}
 	apiPath := findApiPathByResourceType(resourceType)
 	if apiPath == nil {
-		return false
+		// currently impossible as every service needs to register, but keep it as a defensive guard.
+		return true
 	}
 	return strings.Contains(apiPath.UrlFormat, "{"+identifier+"}") ||
 		strings.Contains(apiPath.UrlFormat, "{"+identifier+"=")

--- a/internal/services/parse/data_plane_type_map_test.go
+++ b/internal/services/parse/data_plane_type_map_test.go
@@ -1,0 +1,70 @@
+package parse
+
+import "testing"
+
+func Test_hasIdentifierSegment(t *testing.T) {
+	testData := []struct {
+		Name         string
+		ResourceType string
+		Identifier   string
+		Expected     bool
+	}{
+		{
+			Name:         "name identifier present with api version suffix",
+			ResourceType: "Microsoft.KeyVault/vaults/certificates@2016-10-01",
+			Identifier:   "name",
+			Expected:     true,
+		},
+		{
+			Name:         "name identifier present without api version suffix",
+			ResourceType: "Microsoft.KeyVault/vaults/certificates",
+			Identifier:   "name",
+			Expected:     true,
+		},
+		{
+			Name:         "parentId identifier present",
+			ResourceType: "Microsoft.KeyVault/vaults/certificates@2016-10-01",
+			Identifier:   "parentId",
+			Expected:     true,
+		},
+		{
+			Name:         "identifier absent from url format",
+			ResourceType: "Microsoft.KeyVault/vaults/certificates/contacts@v1.1-preview.2",
+			Identifier:   "name",
+			Expected:     false,
+		},
+		{
+			Name:         "default form identifier ({name=default})",
+			ResourceType: "Microsoft.Purview/accounts/Scanning/datasources/scans/triggers@2022-02-01-preview",
+			Identifier:   "name",
+			Expected:     true,
+		},
+		{
+			Name:         "embedded identifier (indexes('{name}'))",
+			ResourceType: "Microsoft.Search/searchServices/indexes@2023-11-01",
+			Identifier:   "name",
+			Expected:     true,
+		},
+		{
+			Name:         "identifier prefix does not match longer placeholder",
+			ResourceType: "Microsoft.KeyVault/vaults/certificates@2016-10-01",
+			Identifier:   "nam",
+			Expected:     false,
+		},
+		{
+			Name:         "unmapped type falls back to true",
+			ResourceType: "Microsoft.Foo/bar@2020-01-01",
+			Identifier:   "name",
+			Expected:     true,
+		},
+	}
+
+	for _, v := range testData {
+		t.Run(v.Name, func(t *testing.T) {
+			actual := hasIdentifierSegment(v.ResourceType, v.Identifier)
+			if actual != v.Expected {
+				t.Fatalf("expected %v but got %v for resource type %q and identifier %q", v.Expected, actual, v.ResourceType, v.Identifier)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

This PR:

1. Uses the data plane API format configuration to determine whether the name property is required for a given resource.
2. Performs a small refactor by moving the logic that determines whether the name property is returned by the service into the getCreateResultFunc function.

### Background 
For singleton resource like key vault contact, the data plane api doesn't require `name` property ([api docuementation](https://learn.microsoft.com/en-us/rest/api/keyvault/certificates/set-certificate-contacts/set-certificate-contacts?view=rest-keyvault-certificates-2025-07-01&tabs=HTTP)). However, during the [PR #1053](https://github.com/Azure/terraform-provider-azapi/pull/1053/changes), it introduces the guard toward `name` property that will reject any empty/unset name, which cause the [issue #1091](https://github.com/Azure/terraform-provider-azapi/issues/1091)

Acc test https://dev.azure.com/azclitools/internal/_build/results?buildId=331460&view=results. Failed tests also failed on main and doesn't seem to be related to this PR. 
