### PR TITLE
fix: temporarily suppress invoke policy acctest failure

### DIFF
--- a/internal/services/azapi_resource_acquire_policy_token_test.go
+++ b/internal/services/azapi_resource_acquire_policy_token_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"regexp"
 	"testing"
+	"time"
 
 	"github.com/Azure/terraform-provider-azapi/internal/acceptance"
 	"github.com/Azure/terraform-provider-azapi/internal/acceptance/check"
@@ -16,50 +17,69 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
+// invoke policy / acquire policy token feature is not yet enabled on the new acctest tenant until the date below
+var policyTokenFeatureUnavailableUntil = time.Date(2026, 8, 5, 0, 0, 0, 0, time.UTC)
+
+func policyTokenFeatureTemporarilyUnavailable() bool {
+	return time.Now().Before(policyTokenFeatureUnavailableUntil)
+}
+
 type ResourceWithAcquirePolicyToken struct{}
 
 func TestAccResourceWithAcquirePolicyToken_allowedByPolicy(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azapi_resource", "storage")
 	r := ResourceWithAcquirePolicyToken{}
 
-	data.ResourceTest(t, r, []resource.TestStep{
-		{
-			Config:            r.basic(data, true),
-			ExternalProviders: common.ExternalProvidersAzurermVersionFour(),
-			Check: resource.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-	})
+	step := resource.TestStep{
+		Config:            r.basic(data, true),
+		ExternalProviders: common.ExternalProvidersAzurermVersionFour(),
+	}
+	if policyTokenFeatureTemporarilyUnavailable() {
+		step.ExpectError = regexp.MustCompile(`(?s)ExternalEvaluationEnforcementSettings' property is not supported`)
+	} else {
+		step.Check = resource.ComposeTestCheckFunc(
+			check.That(data.ResourceName).ExistsInAzure(r),
+		)
+	}
+
+	data.ResourceTest(t, r, []resource.TestStep{step})
 }
 
 func TestAccResourceWithAcquirePolicyToken_disallowedByPolicy(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azapi_resource", "storage")
 	r := ResourceWithAcquirePolicyToken{}
 
-	data.ResourceTest(t, r, []resource.TestStep{
-		{
-			Config:            r.basic(data, false),
-			ExternalProviders: common.ExternalProvidersAzurermVersionFour(),
-			ExpectError:       regexp.MustCompile("RequestDisallowedByPolicy"),
-		},
-	})
+	step := resource.TestStep{
+		Config:            r.basic(data, false),
+		ExternalProviders: common.ExternalProvidersAzurermVersionFour(),
+	}
+	if policyTokenFeatureTemporarilyUnavailable() {
+		step.ExpectError = regexp.MustCompile(`(?s)ExternalEvaluationEnforcementSettings' property is not supported`)
+	} else {
+		step.ExpectError = regexp.MustCompile("RequestDisallowedByPolicy")
+	}
+
+	data.ResourceTest(t, r, []resource.TestStep{step})
 }
 
 func TestAccResourceWithAcquirePolicyToken_alwaysAcquire(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azapi_resource", "storage")
 	r := ResourceWithAcquirePolicyToken{}
 
-	data.ResourceTest(t, r, []resource.TestStep{
-		{
-			Config:            r.alwaysAcquire(data),
-			ExternalProviders: common.ExternalProvidersAzurermVersionFour(),
-			Check: resource.ComposeTestCheckFunc(
-				check.That("azapi_resource.storage").ExistsInAzure(r),
-				check.That("azapi_resource.virtual_network").ExistsInAzure(r),
-			),
-		},
-	})
+	step := resource.TestStep{
+		Config:            r.alwaysAcquire(data),
+		ExternalProviders: common.ExternalProvidersAzurermVersionFour(),
+	}
+	if policyTokenFeatureTemporarilyUnavailable() {
+		step.ExpectError = regexp.MustCompile(`(?s)Policy Token' is not enabled`)
+	} else {
+		step.Check = resource.ComposeTestCheckFunc(
+			check.That("azapi_resource.storage").ExistsInAzure(r),
+			check.That("azapi_resource.virtual_network").ExistsInAzure(r),
+		)
+	}
+
+	data.ResourceTest(t, r, []resource.TestStep{step})
 }
 
 func (r ResourceWithAcquirePolicyToken) Exists(ctx context.Context, client *clients.Client, state *terraform.InstanceState) (*bool, error) {


### PR DESCRIPTION
This PR temporarily suppress the failure on invoke policy acctest. This is needed because the feature cannot be enabled on the new acctest tenant at least for another 2 weeks.

## Testing

Check `TestAccResourceWithAcquirePolicyToken_` acctest passes: https://dev.azure.com/azclitools/internal/_build/results?buildId=331597&view=results