### PR TITLE
Use test data location in preflight child resource acctest

### DIFF
--- a/internal/services/azapi_resource_preflight_test.go
+++ b/internal/services/azapi_resource_preflight_test.go
@@ -347,7 +347,7 @@ resource "azapi_resource" "managed_identity" {
   type      = "Microsoft.ManagedIdentity/userAssignedIdentities@2025-01-31-preview"
   name      = "test-managed-identity"
   parent_id = azapi_resource.resourceGroup.id
-  location  = "westeurope"
+  location  = azapi_resource.resourceGroup.location
 }
 
 resource "azapi_resource" "federated_credential" {


### PR DESCRIPTION
## Summary
- refactor TestAccGenericResource_preflightChildResource to use azapi_resource.resourceGroup.location
- remove hardcoded westeurope from managed identity preflight test

## Why
This avoids region-specific preflight failures when the pipeline test location differs or a hardcoded region is ineligible for new resources.

## Testing
- acctest: https://github.com/Azure/terraform-provider-azapi/pull/1181/checks?check_run_id=88852983598
- The refactored test passes locally