### PR TITLE
feat: add telemetry headers

### DIFF
--- a/docs/actions/resource_action.md
+++ b/docs/actions/resource_action.md
@@ -140,7 +140,7 @@ action "azapi_resource_action" "power_on" {
 - `body` (Dynamic) A dynamic attribute that contains the request body.
 
 	-> Ensure the dynamic value is not a string.
-- `headers` (Map of String) Headers to include in the request.
+- `headers` (Map of String) Headers to include in the request. If conflicting with `telemetry_headers`, `telemetry_headers` takes precedence.
 - `locks` (List of String) A list of ARM resource IDs which are used to avoid create/modify/delete azapi resources at the same time.
 
 	-> Element value must satisfy all validations: string length must be at least 1.

--- a/docs/data-sources/resource.md
+++ b/docs/data-sources/resource.md
@@ -70,7 +70,7 @@ output "quarantine_policy" {
 
 ### Optional
 
-- `headers` (Map of String) A map of headers to include in the request.
+- `headers` (Map of String) A map of headers to include in the request. If conflicting with `telemetry_headers`, `telemetry_headers` takes precedence.
 - `ignore_not_found` (Boolean) If set to `true`, the data source will not fail when the specified resource is not found (HTTP 404). Identifier attributes (`id`, `name`, `parent_id`, `resource_id`) will still be populated based on inputs; other computed attributes (`output`, `location`, `identity`, `tags`) will be null/empty. Defaults to `false`.
 - `name` (String) Specifies the name of the Azure resource. Exactly one of the arguments `name` or `resource_id` must be set. It could be omitted if the `type` is `Microsoft.Resources/subscriptions`.
 

--- a/docs/data-sources/resource_action.md
+++ b/docs/data-sources/resource_action.md
@@ -62,7 +62,7 @@ data "azapi_resource_action" "example" {
 - `body` (Dynamic) The body attribute is a dynamic attribute that only allows users to specify the resource body as an HCL object.
 
 	-> Ensure the dynamic value is not a string.
-- `headers` (Map of String) A map of headers to include in the request.
+- `headers` (Map of String) A map of headers to include in the request. If conflicting with `telemetry_headers`, `telemetry_headers` takes precedence.
 - `method` (String) The HTTP method to use when performing the action. Defaults to `POST`.
 
 	-> Value must be one of: ["POST" "GET"].

--- a/docs/data-sources/resource_list.md
+++ b/docs/data-sources/resource_list.md
@@ -71,7 +71,7 @@ data "azapi_resource_list" "listSubnetsByVnet" {
 
 ### Optional
 
-- `headers` (Map of String) A map of headers to include in the request.
+- `headers` (Map of String) A map of headers to include in the request. If conflicting with `telemetry_headers`, `telemetry_headers` takes precedence.
 - `query_parameters` (Map of List of String) A map of query parameters to include in the request.
 - `response_export_values` (Dynamic) The attribute can accept either a list or a map.
 

--- a/docs/ephemeral-resources/resource_action.md
+++ b/docs/ephemeral-resources/resource_action.md
@@ -72,7 +72,7 @@ ephemeral "azapi_resource_action" "listKeys" {
 - `body` (Dynamic) A dynamic attribute that contains the request body.
 
 	-> Ensure the dynamic value is not a string.
-- `headers` (Map of String) A map of headers to include in the request.
+- `headers` (Map of String) A map of headers to include in the request. If conflicting with `telemetry_headers`, `telemetry_headers` takes precedence.
 - `locks` (List of String) A list of ARM resource IDs which are used to avoid create/modify/delete azapi resources at the same time.
 
 	-> Element value must satisfy all validations: string length must be at least 1.

--- a/docs/list-resources/resource.md
+++ b/docs/list-resources/resource.md
@@ -42,7 +42,7 @@ list "azapi_resource" "example" {
 
 ### Optional
 
-- `headers` (Map of String) A map of headers to include in the request.
+- `headers` (Map of String) A map of headers to include in the request. If conflicting with `telemetry_headers`, `telemetry_headers` takes precedence.
 - `query_parameters` (Map of List of String) A map of query parameters to include in the request.
 - `type` (String) In a format like `<resource-type>@<api-version>`. `<resource-type>` is the Azure resource type, for example, `Microsoft.Storage/storageAccounts`. `<api-version>` is version of the API used to manage this azure resource. When omitted, `parent_id` must be a resource group ID and all resources in the resource group will be listed.
 

--- a/docs/resources/data_plane_resource.md
+++ b/docs/resources/data_plane_resource.md
@@ -87,9 +87,9 @@ resource "azapi_data_plane_resource" "dataset" {
 	~> Use the state value when new value is functionally equivalent to the old and thus no change is required.
 
 	-> Ensure the dynamic value is not a string.
-- `create_headers` (Map of String) A mapping of headers to be sent with the create request.
+- `create_headers` (Map of String) A mapping of headers to be sent with the create request. If conflicting with `telemetry_headers`, `telemetry_headers` takes precedence.
 - `create_query_parameters` (Map of List of String) A mapping of query parameters to be sent with the create request.
-- `delete_headers` (Map of String) A mapping of headers to be sent with the delete request.
+- `delete_headers` (Map of String) A mapping of headers to be sent with the delete request. `telemetry_headers` are not applied to delete requests.
 - `delete_query_parameters` (Map of List of String) A mapping of query parameters to be sent with the delete request.
 - `ignore_casing` (Boolean) A dynamic attribute that contains the request body. Defaults to `false`.
 - `ignore_missing_property` (Boolean) Whether ignore not returned properties like credentials in `body` to suppress plan-diff. It's recommend to enable this option when some sensitive properties are not returned in response body, instead of setting them in `lifecycle.ignore_changes` because it will make the sensitive fields unable to update. Defaults to `true`.
@@ -101,7 +101,7 @@ resource "azapi_data_plane_resource" "dataset" {
 	~> Once set, the value of this attribute in state will not change.
 
 	~> If the value of this attribute changes, Terraform will destroy and recreate the resource.
-- `read_headers` (Map of String) A mapping of headers to be sent with the read request.
+- `read_headers` (Map of String) A mapping of headers to be sent with the read request. `telemetry_headers` are not applied to read requests.
 - `read_query_parameters` (Map of List of String) A mapping of query parameters to be sent with the read request.
 - `replace_triggers_external_values` (Dynamic) Will trigger a replace of the resource when the value changes and is not `null`. This can be used by practitioners to force a replace of the resource when certain values change, e.g. changing the SKU of a virtual machine based on the value of variables or locals. The value is a `dynamic`, so practitioners can compose the input however they wish. For a "break glass" set the value to `null` to prevent the plan modifier taking effect.
 	If you have `null` values that you do want to be tracked as affecting the resource replacement, include these inside an object.
@@ -164,7 +164,7 @@ resource "azapi_data_plane_resource" "dataset" {
 - `sensitive_body` (Dynamic, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) A dynamic attribute that contains the write-only properties of the request body. This will be merge-patched to the body to construct the actual request body. If a property is defined in both `body` and `sensitive_body`, the `sensitive_body` value takes precedence.
 - `sensitive_body_version` (Map of String) A map where the key is the path to the property in `sensitive_body` and the value is the version of the property. The key is a string in the format of `path.to.property[index].subproperty`, where `index` is the index of the item in an array. When the version is changed, the property will be included in the request body, otherwise it will be omitted from the request body.
 - `timeouts` (Block) See [below for nested schema](#nested--timeouts).
-- `update_headers` (Map of String) A mapping of headers to be sent with the update request.
+- `update_headers` (Map of String) A mapping of headers to be sent with the update request. If conflicting with `telemetry_headers`, `telemetry_headers` takes precedence.
 - `update_query_parameters` (Map of List of String) A mapping of query parameters to be sent with the update request.
 
 ### Read-Only
@@ -1347,4 +1347,3 @@ import {
   id = "exampleappconf.azconfig.io/kv/mykey|Microsoft.AppConfiguration/configurationStores/keyValues@1.0"
 }
 ```
-

--- a/docs/resources/resource.md
+++ b/docs/resources/resource.md
@@ -93,9 +93,9 @@ output "quarantine_policy" {
 	~> Use the state value when new value is functionally equivalent to the old and thus no change is required.
 
 	-> Ensure the dynamic value is not a string.
-- `create_headers` (Map of String) A mapping of headers to be sent with the create request.
+- `create_headers` (Map of String) A mapping of headers to be sent with the create request. If conflicting with `telemetry_headers`, `telemetry_headers` takes precedence.
 - `create_query_parameters` (Map of List of String) A mapping of query parameters to be sent with the create request.
-- `delete_headers` (Map of String) A mapping of headers to be sent with the delete request.
+- `delete_headers` (Map of String) A mapping of headers to be sent with the delete request. `telemetry_headers` are not applied to delete requests.
 - `delete_query_parameters` (Map of List of String) A mapping of query parameters to be sent with the delete request.
 - `identity` (List of Block) The identity of this resource. See [below for nested schema](#nested--identity).
 - `ignore_casing` (Boolean) Whether ignore the casing of the property names in the response body. Defaults to `false`.
@@ -129,7 +129,7 @@ output "quarantine_policy" {
 	~> If the value of this attribute changes, Terraform will destroy and recreate the resource.
 
 	-> Ensure this in resource ID format.
-- `read_headers` (Map of String) A mapping of headers to be sent with the read request.
+- `read_headers` (Map of String) A mapping of headers to be sent with the read request. `telemetry_headers` are not applied to read requests.
 - `read_query_parameters` (Map of List of String) A mapping of query parameters to be sent with the read request.
 - `replace_triggers_external_values` (Dynamic) Will trigger a replace of the resource when the value changes and is not `null`. This can be used by practitioners to force a replace of the resource when certain values change, e.g. changing the SKU of a virtual machine based on the value of variables or locals. The value is a `dynamic`, so practitioners can compose the input however they wish. For a "break glass" set the value to `null` to prevent the plan modifier taking effect.
 	If you have `null` values that you do want to be tracked as affecting the resource replacement, include these inside an object.
@@ -197,7 +197,7 @@ output "quarantine_policy" {
 
 	-> Ensure this is a valid Azure tags map. Maximum of 50 tags can be applied. Each key is up to 512 characters long and each value is up to 256 characters long.
 - `timeouts` (Block) See [below for nested schema](#nested--timeouts).
-- `update_headers` (Map of String) A mapping of headers to be sent with the update request.
+- `update_headers` (Map of String) A mapping of headers to be sent with the update request. If conflicting with `telemetry_headers`, `telemetry_headers` takes precedence.
 - `update_query_parameters` (Map of List of String) A mapping of query parameters to be sent with the update request.
 
 ### Read-Only

--- a/docs/resources/update_resource.md
+++ b/docs/resources/update_resource.md
@@ -135,7 +135,7 @@ resource "azapi_update_resource" "example" {
 	~> Once set, the value of this attribute in state will not change.
 
 	-> Ensure this in resource ID format.
-- `read_headers` (Map of String) A mapping of headers to be sent with the read request.
+- `read_headers` (Map of String) A mapping of headers to be sent with the read request. `telemetry_headers` are not applied to read requests.
 - `read_query_parameters` (Map of List of String) A mapping of query parameters to be sent with the read request.
 - `replace_triggers_external_values` (Dynamic) Will trigger a replace of the resource when the value changes and is not `null`. This can be used by practitioners to force a replace of the resource when certain values change, e.g. changing the SKU of a virtual machine based on the value of variables or locals. The value is a `dynamic`, so practitioners can compose the input however they wish. For a "break glass" set the value to `null` to prevent the plan modifier taking effect.
 	If you have `null` values that you do want to be tracked as affecting the resource replacement, include these inside an object.
@@ -204,7 +204,7 @@ resource "azapi_update_resource" "example" {
 - `sensitive_body` (Dynamic, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) A dynamic attribute that contains the write-only properties of the request body. This will be merge-patched to the body to construct the actual request body. If a property is defined in both `body` and `sensitive_body`, the `sensitive_body` value takes precedence.
 - `sensitive_body_version` (Map of String) A map where the key is the path to the property in `sensitive_body` and the value is the version of the property. The key is a string in the format of `path.to.property[index].subproperty`, where `index` is the index of the item in an array. When the version is changed, the property will be included in the request body, otherwise it will be omitted from the request body.
 - `timeouts` (Block) See [below for nested schema](#nested--timeouts).
-- `update_headers` (Map of String) A mapping of headers to be sent with the update request.
+- `update_headers` (Map of String) A mapping of headers to be sent with the update request. If conflicting with `telemetry_headers`, `telemetry_headers` takes precedence.
 - `update_query_parameters` (Map of List of String) A mapping of query parameters to be sent with the update request.
 
 ### Read-Only

--- a/internal/services/azapi_data_plane_resource.go
+++ b/internal/services/azapi_data_plane_resource.go
@@ -66,6 +66,7 @@ type DataPlaneResourceModel struct {
 	DeleteQueryParameters         types.Map        `tfsdk:"delete_query_parameters" skip_on:"update"`
 	ReadHeaders                   types.Map        `tfsdk:"read_headers" skip_on:"update"`
 	ReadQueryParameters           types.Map        `tfsdk:"read_query_parameters" skip_on:"update"`
+	TelemetryHeaders              types.Object     `tfsdk:"telemetry_headers"`
 }
 
 type DataPlaneResource struct {
@@ -294,6 +295,13 @@ func (r *DataPlaneResource) Schema(ctx context.Context, request resource.SchemaR
 				Optional:            true,
 				MarkdownDescription: "A mapping of query parameters to be sent with the read request.",
 			},
+
+			"telemetry_headers": schema.ObjectAttribute{
+				AttributeTypes:      telemetryHeadersAttributeTypes(),
+				Optional:            true,
+				WriteOnly:           true,
+				MarkdownDescription: telemetryHeadersMarkdownDescription,
+			},
 		},
 
 		Blocks: map[string]schema.Block{
@@ -466,7 +474,7 @@ func (r *DataPlaneResource) CreateUpdate(ctx context.Context, requestConfig tfsd
 		// a FooResourceNotFound error as a retryable error
 
 		requestOptions := clients.RequestOptions{
-			Headers:         common.AsMapOfString(plan.ReadHeaders),
+			Headers:         withTelemetryHeaders(common.AsMapOfString(plan.ReadHeaders), config.TelemetryHeaders),
 			QueryParameters: clients.NewQueryParameters(common.AsMapOfLists(plan.ReadQueryParameters)),
 		}
 		if customizedResource != nil && (*customizedResource).ReadFunc() != nil {
@@ -511,13 +519,13 @@ func (r *DataPlaneResource) CreateUpdate(ctx context.Context, requestConfig tfsd
 	}
 
 	requestOptions := clients.RequestOptions{
-		Headers:         common.AsMapOfString(plan.CreateHeaders),
+		Headers:         withTelemetryHeaders(common.AsMapOfString(plan.CreateHeaders), config.TelemetryHeaders),
 		QueryParameters: clients.NewQueryParameters(common.AsMapOfLists(plan.CreateQueryParameters)),
 	}
 	requestOptions.RetryOptions, requestOptions.LastRetryError = clients.NewRetryOptions(plan.Retry)
 
 	if !isNewResource {
-		requestOptions.Headers = common.AsMapOfString(plan.UpdateHeaders)
+		requestOptions.Headers = withTelemetryHeaders(common.AsMapOfString(plan.UpdateHeaders), config.TelemetryHeaders)
 		requestOptions.QueryParameters = clients.NewQueryParameters(common.AsMapOfLists(plan.UpdateQueryParameters))
 	}
 
@@ -545,7 +553,7 @@ func (r *DataPlaneResource) CreateUpdate(ctx context.Context, requestConfig tfsd
 	userRetryOpts, _ := clients.NewRetryOptions(plan.Retry)
 	combinedRetryOpts, combinedLastRetryErr := clients.CombineRetryOptions(readAfterCreateOpts, userRetryOpts)
 	requestOptions = clients.RequestOptions{
-		Headers:         common.AsMapOfString(plan.ReadHeaders),
+		Headers:         withTelemetryHeaders(common.AsMapOfString(plan.ReadHeaders), config.TelemetryHeaders),
 		QueryParameters: clients.NewQueryParameters(common.AsMapOfLists(plan.ReadQueryParameters)),
 		RetryOptions:    combinedRetryOpts,
 		LastRetryError:  combinedLastRetryErr,

--- a/internal/services/azapi_resource.go
+++ b/internal/services/azapi_resource.go
@@ -86,6 +86,7 @@ type AzapiResourceModel struct {
 	DeleteQueryParameters         types.Map        `tfsdk:"delete_query_parameters" skip_on:"update"`
 	ReadHeaders                   types.Map        `tfsdk:"read_headers" skip_on:"update"`
 	ReadQueryParameters           types.Map        `tfsdk:"read_query_parameters" skip_on:"update"`
+	TelemetryHeaders              types.Object     `tfsdk:"telemetry_headers"`
 }
 
 // AzapiResourceIdentityModel represents the identity data for importing a resource
@@ -133,6 +134,7 @@ func NewDefaultAzapiResourceModel() AzapiResourceModel {
 		DeleteQueryParameters: types.MapNull(types.ListType{ElemType: types.StringType}),
 		ReadHeaders:           types.MapNull(types.StringType),
 		ReadQueryParameters:   types.MapNull(types.ListType{ElemType: types.StringType}),
+		TelemetryHeaders:      types.ObjectNull(telemetryHeadersAttributeTypes()),
 	}
 }
 
@@ -413,6 +415,13 @@ func (r *AzapiResource) Schema(ctx context.Context, _ resource.SchemaRequest, re
 				},
 				Optional:            true,
 				MarkdownDescription: "A mapping of query parameters to be sent with the read request.",
+			},
+
+			"telemetry_headers": schema.ObjectAttribute{
+				AttributeTypes:      telemetryHeadersAttributeTypes(),
+				Optional:            true,
+				WriteOnly:           true,
+				MarkdownDescription: telemetryHeadersMarkdownDescription,
 			},
 		},
 		Blocks: map[string]schema.Block{
@@ -813,7 +822,7 @@ func (r *AzapiResource) CreateUpdate(ctx context.Context, requestConfig tfsdk.Co
 		// check if the resource already exists using the non-retry client to avoid issue where user specifies
 		// a FooResourceNotFound error as a retryable error
 		requestOptions := clients.RequestOptions{
-			Headers:         common.AsMapOfString(plan.ReadHeaders),
+			Headers:         withTelemetryHeaders(common.AsMapOfString(plan.ReadHeaders), config.TelemetryHeaders),
 			QueryParameters: clients.NewQueryParameters(common.AsMapOfLists(plan.ReadQueryParameters)),
 		}
 		_, err = client.Get(ctx, id.AzureResourceId, id.ApiVersion, requestOptions)
@@ -883,12 +892,12 @@ func (r *AzapiResource) CreateUpdate(ctx context.Context, requestConfig tfsdk.Co
 	}
 
 	requestOptions := clients.RequestOptions{
-		Headers:         common.AsMapOfString(plan.CreateHeaders),
+		Headers:         withTelemetryHeaders(common.AsMapOfString(plan.CreateHeaders), config.TelemetryHeaders),
 		QueryParameters: clients.NewQueryParameters(common.AsMapOfLists(plan.CreateQueryParameters)),
 	}
 	requestOptions.RetryOptions, requestOptions.LastRetryError = clients.NewRetryOptions(plan.Retry)
 	if !isNewResource {
-		requestOptions.Headers = common.AsMapOfString(plan.UpdateHeaders)
+		requestOptions.Headers = withTelemetryHeaders(common.AsMapOfString(plan.UpdateHeaders), config.TelemetryHeaders)
 		requestOptions.QueryParameters = clients.NewQueryParameters(common.AsMapOfLists(plan.UpdateQueryParameters))
 	}
 	_, err = client.CreateOrUpdate(ctx, id.AzureResourceId, id.ApiVersion, body, requestOptions)
@@ -898,7 +907,7 @@ func (r *AzapiResource) CreateUpdate(ctx context.Context, requestConfig tfsdk.Co
 		})
 		if isNewResource {
 			requestOptions := clients.RequestOptions{
-				Headers:         common.AsMapOfString(plan.ReadHeaders),
+				Headers:         withTelemetryHeaders(common.AsMapOfString(plan.ReadHeaders), config.TelemetryHeaders),
 				QueryParameters: clients.NewQueryParameters(common.AsMapOfLists(plan.ReadQueryParameters)),
 			}
 			requestOptions.RetryOptions, requestOptions.LastRetryError = clients.NewRetryOptions(plan.Retry)
@@ -943,7 +952,7 @@ func (r *AzapiResource) CreateUpdate(ctx context.Context, requestConfig tfsdk.Co
 	userRetryOpts, _ := clients.NewRetryOptions(plan.Retry)
 	combinedRetryOpts, combinedLastRetryErr := clients.CombineRetryOptions(readAfterCreateOpts, userRetryOpts)
 	requestOptions = clients.RequestOptions{
-		Headers:         common.AsMapOfString(plan.ReadHeaders),
+		Headers:         withTelemetryHeaders(common.AsMapOfString(plan.ReadHeaders), config.TelemetryHeaders),
 		QueryParameters: clients.NewQueryParameters(common.AsMapOfLists(plan.ReadQueryParameters)),
 		RetryOptions:    combinedRetryOpts,
 		LastRetryError:  combinedLastRetryErr,

--- a/internal/services/azapi_resource_action.go
+++ b/internal/services/azapi_resource_action.go
@@ -24,15 +24,16 @@ import (
 
 // AzapiResourceActionModel defines the configuration for the action equivalent of the stateful `azapi_resource_action` resource.
 type AzapiResourceActionModel struct {
-	Type            types.String  `tfsdk:"type"`
-	ResourceId      types.String  `tfsdk:"resource_id"`
-	Action          types.String  `tfsdk:"action"`
-	Method          types.String  `tfsdk:"method"`
-	Body            types.Dynamic `tfsdk:"body"`
-	SensitiveBody   types.Dynamic `tfsdk:"sensitive_body"`
-	Locks           types.List    `tfsdk:"locks"`
-	Headers         types.Map     `tfsdk:"headers"`
-	QueryParameters types.Map     `tfsdk:"query_parameters"`
+	Type             types.String  `tfsdk:"type"`
+	ResourceId       types.String  `tfsdk:"resource_id"`
+	Action           types.String  `tfsdk:"action"`
+	Method           types.String  `tfsdk:"method"`
+	Body             types.Dynamic `tfsdk:"body"`
+	SensitiveBody    types.Dynamic `tfsdk:"sensitive_body"`
+	Locks            types.List    `tfsdk:"locks"`
+	Headers          types.Map     `tfsdk:"headers"`
+	QueryParameters  types.Map     `tfsdk:"query_parameters"`
+	TelemetryHeaders types.Object  `tfsdk:"telemetry_headers"`
 }
 
 // AzapiResourceAction implements performing an action without persisting state (stateless invocation).
@@ -121,6 +122,13 @@ func (a *AzapiResourceAction) Schema(ctx context.Context, req action.SchemaReque
 				ElementType:         types.ListType{ElemType: types.StringType},
 				MarkdownDescription: "Query parameters to include in the request.",
 			},
+
+			"telemetry_headers": actionschema.ObjectAttribute{
+				AttributeTypes:      telemetryHeadersAttributeTypes(),
+				Optional:            true,
+				WriteOnly:           true,
+				MarkdownDescription: telemetryHeadersMarkdownDescription,
+			},
 		},
 	}
 }
@@ -159,7 +167,7 @@ func (a *AzapiResourceAction) Invoke(ctx context.Context, req action.InvokeReque
 	}
 
 	requestOptions := clients.RequestOptions{
-		Headers:         common.AsMapOfString(config.Headers),
+		Headers:         withTelemetryHeaders(common.AsMapOfString(config.Headers), config.TelemetryHeaders),
 		QueryParameters: clients.NewQueryParameters(common.AsMapOfLists(config.QueryParameters)),
 	}
 

--- a/internal/services/azapi_resource_action_data_source.go
+++ b/internal/services/azapi_resource_action_data_source.go
@@ -37,6 +37,7 @@ type ResourceActionDataSourceModel struct {
 	Retry                         retry.RetryValue `tfsdk:"retry"`
 	Headers                       types.Map        `tfsdk:"headers"`
 	QueryParameters               types.Map        `tfsdk:"query_parameters"`
+	TelemetryHeaders              types.Object     `tfsdk:"telemetry_headers"`
 }
 
 type ResourceActionDataSource struct {
@@ -141,6 +142,12 @@ func (r *ResourceActionDataSource) Schema(ctx context.Context, request datasourc
 				Optional:            true,
 				MarkdownDescription: "A map of query parameters to include in the request.",
 			},
+
+			"telemetry_headers": schema.ObjectAttribute{
+				AttributeTypes:      telemetryHeadersAttributeTypes(),
+				Optional:            true,
+				MarkdownDescription: telemetryHeadersMarkdownDescription,
+			},
 		},
 
 		Blocks: map[string]schema.Block{
@@ -185,7 +192,7 @@ func (r *ResourceActionDataSource) Read(ctx context.Context, request datasource.
 
 	client := r.ProviderData.ResourceClient
 	requestOptions := clients.RequestOptions{
-		Headers:         common.AsMapOfString(model.Headers),
+		Headers:         withTelemetryHeaders(common.AsMapOfString(model.Headers), model.TelemetryHeaders),
 		QueryParameters: clients.NewQueryParameters(common.AsMapOfLists(model.QueryParameters)),
 	}
 	requestOptions.RetryOptions, requestOptions.LastRetryError = clients.NewRetryOptions(model.Retry)
@@ -210,6 +217,7 @@ func (r *ResourceActionDataSource) Read(ctx context.Context, request datasource.
 		return
 	}
 	model.SensitiveOutput = sensitiveOutput
+	model.TelemetryHeaders = types.ObjectNull(telemetryHeadersAttributeTypes())
 
 	response.Diagnostics.Append(response.State.Set(ctx, &model)...)
 }

--- a/internal/services/azapi_resource_action_ephemeral.go
+++ b/internal/services/azapi_resource_action_ephemeral.go
@@ -40,6 +40,7 @@ type ActionEphemeralModel struct {
 	Retry                retry.RetryValue `tfsdk:"retry"`
 	Headers              types.Map        `tfsdk:"headers"`
 	QueryParameters      types.Map        `tfsdk:"query_parameters"`
+	TelemetryHeaders     types.Object     `tfsdk:"telemetry_headers"`
 }
 
 type ActionEphemeral struct {
@@ -147,6 +148,12 @@ func (r *ActionEphemeral) Schema(ctx context.Context, request ephemeral.SchemaRe
 				Optional:            true,
 				MarkdownDescription: "A map of query parameters to include in the request.",
 			},
+
+			"telemetry_headers": schema.ObjectAttribute{
+				AttributeTypes:      telemetryHeadersAttributeTypes(),
+				Optional:            true,
+				MarkdownDescription: telemetryHeadersMarkdownDescription,
+			},
 		},
 
 		Blocks: map[string]schema.Block{
@@ -197,7 +204,7 @@ func (r *ActionEphemeral) Open(ctx context.Context, request ephemeral.OpenReques
 
 	client := r.ProviderData.ResourceClient
 	requestOptions := clients.RequestOptions{
-		Headers:         common.AsMapOfString(model.Headers),
+		Headers:         withTelemetryHeaders(common.AsMapOfString(model.Headers), model.TelemetryHeaders),
 		QueryParameters: clients.NewQueryParameters(common.AsMapOfLists(model.QueryParameters)),
 	}
 	requestOptions.RetryOptions, requestOptions.LastRetryError = clients.NewRetryOptions(model.Retry)
@@ -219,6 +226,7 @@ func (r *ActionEphemeral) Open(ctx context.Context, request ephemeral.OpenReques
 		return
 	}
 	model.Output = output
+	model.TelemetryHeaders = types.ObjectNull(telemetryHeadersAttributeTypes())
 
 	response.Diagnostics.Append(response.Result.Set(ctx, model)...)
 }

--- a/internal/services/azapi_resource_action_resource.go
+++ b/internal/services/azapi_resource_action_resource.go
@@ -57,6 +57,7 @@ type ActionResourceModel struct {
 	Retry                         retry.RetryValue `tfsdk:"retry" skip_on:"update"`
 	Headers                       types.Map        `tfsdk:"headers"`
 	QueryParameters               types.Map        `tfsdk:"query_parameters"`
+	TelemetryHeaders              types.Object     `tfsdk:"telemetry_headers"`
 }
 
 type ActionResource struct {
@@ -256,6 +257,13 @@ func (r *ActionResource) Schema(ctx context.Context, request resource.SchemaRequ
 				},
 				Optional:            true,
 				MarkdownDescription: "A map of query parameters to include in the request.",
+			},
+
+			"telemetry_headers": schema.ObjectAttribute{
+				AttributeTypes:      telemetryHeadersAttributeTypes(),
+				Optional:            true,
+				WriteOnly:           true,
+				MarkdownDescription: telemetryHeadersMarkdownDescription,
 			},
 		},
 
@@ -466,7 +474,7 @@ func (r *ActionResource) Action(ctx context.Context, model ActionResourceModel, 
 	}
 
 	requestOptions := clients.RequestOptions{
-		Headers:         common.AsMapOfString(model.Headers),
+		Headers:         withTelemetryHeaders(common.AsMapOfString(model.Headers), config.TelemetryHeaders),
 		QueryParameters: clients.NewQueryParameters(common.AsMapOfLists(model.QueryParameters)),
 	}
 	requestOptions.RetryOptions, requestOptions.LastRetryError = clients.NewRetryOptions(model.Retry)

--- a/internal/services/azapi_resource_data_source.go
+++ b/internal/services/azapi_resource_data_source.go
@@ -44,6 +44,7 @@ type AzapiResourceDataSourceModel struct {
 	Retry                retry.RetryValue `tfsdk:"retry"`
 	Headers              types.Map        `tfsdk:"headers"`
 	QueryParameters      types.Map        `tfsdk:"query_parameters"`
+	TelemetryHeaders     types.Object     `tfsdk:"telemetry_headers"`
 }
 
 type AzapiResourceDataSource struct {
@@ -184,6 +185,12 @@ func (r *AzapiResourceDataSource) Schema(ctx context.Context, request datasource
 				Optional:            true,
 				MarkdownDescription: "A map of query parameters to include in the request.",
 			},
+
+			"telemetry_headers": schema.ObjectAttribute{
+				AttributeTypes:      telemetryHeadersAttributeTypes(),
+				Optional:            true,
+				MarkdownDescription: telemetryHeadersMarkdownDescription,
+			},
 		},
 
 		Blocks: map[string]schema.Block{
@@ -272,7 +279,7 @@ func (r *AzapiResourceDataSource) Read(ctx context.Context, request datasource.R
 	// Ensure the context deadline has been set before calling ConfigureClientWithCustomRetry().
 	client := r.ProviderData.ResourceClient
 	requestOptions := clients.RequestOptions{
-		Headers:         common.AsMapOfString(model.Headers),
+		Headers:         withTelemetryHeaders(common.AsMapOfString(model.Headers), model.TelemetryHeaders),
 		QueryParameters: clients.NewQueryParameters(common.AsMapOfLists(model.QueryParameters)),
 	}
 	requestOptions.RetryOptions, requestOptions.LastRetryError = clients.NewRetryOptions(model.Retry)
@@ -291,6 +298,7 @@ func (r *AzapiResourceDataSource) Read(ctx context.Context, request datasource.R
 				model.Tags = basetypes.NewMapNull(types.StringType)
 				model.Output = basetypes.NewDynamicNull()
 				model.Exists = basetypes.NewBoolValue(false)
+				model.TelemetryHeaders = types.ObjectNull(telemetryHeadersAttributeTypes())
 				response.Diagnostics.Append(response.State.Set(ctx, &model)...)
 				return
 			}
@@ -329,6 +337,7 @@ func (r *AzapiResourceDataSource) Read(ctx context.Context, request datasource.R
 	}
 	model.Output = output
 	model.Exists = basetypes.NewBoolValue(true)
+	model.TelemetryHeaders = types.ObjectNull(telemetryHeadersAttributeTypes())
 
 	response.Diagnostics.Append(response.State.Set(ctx, &model)...)
 }

--- a/internal/services/azapi_resource_list.go
+++ b/internal/services/azapi_resource_list.go
@@ -25,10 +25,11 @@ import (
 )
 
 type AzapiResourceListModel struct {
-	Type            types.String `tfsdk:"type"`
-	ParentID        types.String `tfsdk:"parent_id"`
-	Headers         types.Map    `tfsdk:"headers"`
-	QueryParameters types.Map    `tfsdk:"query_parameters"`
+	Type             types.String `tfsdk:"type"`
+	ParentID         types.String `tfsdk:"parent_id"`
+	Headers          types.Map    `tfsdk:"headers"`
+	QueryParameters  types.Map    `tfsdk:"query_parameters"`
+	TelemetryHeaders types.Object `tfsdk:"telemetry_headers"`
 }
 
 // resourceListConfigValidator validates the configuration for azapi_resource_list
@@ -131,6 +132,12 @@ func (r *AzapiResourceList) ListResourceConfigSchema(_ context.Context, _ list.L
 				Optional:            true,
 				MarkdownDescription: "A map of query parameters to include in the request.",
 			},
+
+			"telemetry_headers": schema.ObjectAttribute{
+				AttributeTypes:      telemetryHeadersAttributeTypes(),
+				Optional:            true,
+				MarkdownDescription: telemetryHeadersMarkdownDescription,
+			},
 		},
 	}
 }
@@ -175,7 +182,7 @@ func (r *AzapiResourceList) List(ctx context.Context, request list.ListRequest, 
 	// Prepare request options
 	client := r.ProviderData.ResourceClient
 	requestOptions := clients.RequestOptions{
-		Headers:         common.AsMapOfString(model.Headers),
+		Headers:         withTelemetryHeaders(common.AsMapOfString(model.Headers), model.TelemetryHeaders),
 		QueryParameters: clients.NewQueryParameters(common.AsMapOfLists(model.QueryParameters)),
 	}
 

--- a/internal/services/azapi_resource_list_data_source.go
+++ b/internal/services/azapi_resource_list_data_source.go
@@ -33,6 +33,7 @@ type ResourceListDataSourceModel struct {
 	Retry                retry.RetryValue `tfsdk:"retry"`
 	Headers              types.Map        `tfsdk:"headers"`
 	QueryParameters      types.Map        `tfsdk:"query_parameters"`
+	TelemetryHeaders     types.Object     `tfsdk:"telemetry_headers"`
 }
 
 type ResourceListDataSource struct {
@@ -103,6 +104,12 @@ func (r *ResourceListDataSource) Schema(ctx context.Context, request datasource.
 				Optional:            true,
 				MarkdownDescription: "A map of query parameters to include in the request.",
 			},
+
+			"telemetry_headers": schema.ObjectAttribute{
+				AttributeTypes:      telemetryHeadersAttributeTypes(),
+				Optional:            true,
+				MarkdownDescription: telemetryHeadersMarkdownDescription,
+			},
 		},
 
 		Blocks: map[string]schema.Block{
@@ -138,7 +145,7 @@ func (r *ResourceListDataSource) Read(ctx context.Context, request datasource.Re
 
 	client := r.ProviderData.ResourceClient
 	requestOptions := clients.RequestOptions{
-		Headers:         common.AsMapOfString(model.Headers),
+		Headers:         withTelemetryHeaders(common.AsMapOfString(model.Headers), model.TelemetryHeaders),
 		QueryParameters: clients.NewQueryParameters(common.AsMapOfLists(model.QueryParameters)),
 	}
 	requestOptions.RetryOptions, requestOptions.LastRetryError = clients.NewRetryOptions(model.Retry)
@@ -160,6 +167,7 @@ func (r *ResourceListDataSource) Read(ctx context.Context, request datasource.Re
 		return
 	}
 	model.Output = output
+	model.TelemetryHeaders = types.ObjectNull(telemetryHeadersAttributeTypes())
 
 	response.Diagnostics.Append(response.State.Set(ctx, &model)...)
 }

--- a/internal/services/azapi_resource_telemetry_headers_test.go
+++ b/internal/services/azapi_resource_telemetry_headers_test.go
@@ -1,0 +1,108 @@
+package services_test
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/Azure/terraform-provider-azapi/internal/acceptance"
+	"github.com/Azure/terraform-provider-azapi/internal/acceptance/check"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+func TestAccGenericResource_telemetryHeadersNoPlanDiff(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azapi_resource", "test")
+	r := GenericResource{}
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.resourceGroupWithTelemetryHeaders(data, "", ""),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		{
+			Config:             r.resourceGroupWithTelemetryHeaders(data, "module-added", "1.0.0"),
+			PlanOnly:           true,
+			ExpectNonEmptyPlan: false,
+		},
+		{
+			Config:             r.resourceGroupWithTelemetryHeaders(data, "module-changed", "2.0.0"),
+			PlanOnly:           true,
+			ExpectNonEmptyPlan: false,
+		},
+		{
+			Config:             r.resourceGroupWithTelemetryHeaders(data, "", ""),
+			PlanOnly:           true,
+			ExpectNonEmptyPlan: false,
+		},
+	})
+}
+
+func TestAccGenericResource_telemetryHeadersSentOnCreate(t *testing.T) {
+	mitmLogPath := os.Getenv("AZAPI_ACCTEST_MITMPROXY_LOG")
+	if mitmLogPath == "" {
+		mitmLogPath = "/tmp/azapi-acctest/mitmproxy.log"
+	}
+	if _, err := exec.LookPath("mitmdump"); err != nil {
+		t.Skip("mitmdump is required to verify telemetry headers in captured HTTP requests")
+	}
+	if _, err := os.Stat(mitmLogPath); err != nil {
+		t.Skipf("mitmproxy capture file not found: %s", mitmLogPath)
+	}
+
+	data := acceptance.BuildTestData(t, "azapi_resource", "test")
+	r := GenericResource{}
+	moduleID := "module-create-telemetry"
+	moduleVersion := "1.2.3"
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.resourceGroupWithTelemetryHeaders(data, moduleID, moduleVersion),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				checkTelemetryHeadersCapturedInMitmLog(mitmLogPath, moduleID, moduleVersion),
+			),
+		},
+	})
+}
+
+func checkTelemetryHeadersCapturedInMitmLog(mitmLogPath, moduleID, moduleVersion string) resource.TestCheckFunc {
+	return func(*terraform.State) error {
+		out, err := exec.Command("mitmdump", "-nr", mitmLogPath, "--set", "flow_detail=4").CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("failed to parse mitmproxy log: %w", err)
+		}
+		content := strings.ToLower(string(out))
+		expectedModuleID := strings.ToLower("x-module-id: " + moduleID)
+		expectedModuleVersion := strings.ToLower("x-module-version: " + moduleVersion)
+		if !strings.Contains(content, expectedModuleID) {
+			return fmt.Errorf("expected telemetry module id header %q in captured HTTP requests", expectedModuleID)
+		}
+		if !strings.Contains(content, expectedModuleVersion) {
+			return fmt.Errorf("expected telemetry module version header %q in captured HTTP requests", expectedModuleVersion)
+		}
+		return nil
+	}
+}
+
+func (r GenericResource) resourceGroupWithTelemetryHeaders(data acceptance.TestData, moduleID, moduleVersion string) string {
+	telemetryHeaders := ""
+	if moduleID != "" || moduleVersion != "" {
+		telemetryHeaders = fmt.Sprintf(`
+  telemetry_headers = {
+    module_id      = %q
+    module_version = %q
+  }`, moduleID, moduleVersion)
+	}
+
+	return fmt.Sprintf(`
+resource "azapi_resource" "test" {
+  type     = "Microsoft.Resources/resourceGroups@2021-04-01"
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+%[3]s
+}`, data.RandomInteger, data.LocationPrimary, telemetryHeaders)
+}

--- a/internal/services/azapi_update_resource.go
+++ b/internal/services/azapi_update_resource.go
@@ -60,6 +60,7 @@ type AzapiUpdateResourceModel struct {
 	UpdateQueryParameters         types.Map        `tfsdk:"update_query_parameters"`
 	ReadHeaders                   types.Map        `tfsdk:"read_headers" skip_on:"update"`
 	ReadQueryParameters           types.Map        `tfsdk:"read_query_parameters" skip_on:"update"`
+	TelemetryHeaders              types.Object     `tfsdk:"telemetry_headers"`
 }
 
 type AzapiUpdateResource struct {
@@ -284,6 +285,13 @@ func (r *AzapiUpdateResource) Schema(ctx context.Context, request resource.Schem
 				Optional:            true,
 				MarkdownDescription: "A mapping of query parameters to be sent with the read request.",
 			},
+
+			"telemetry_headers": schema.ObjectAttribute{
+				AttributeTypes:      telemetryHeadersAttributeTypes(),
+				Optional:            true,
+				WriteOnly:           true,
+				MarkdownDescription: telemetryHeadersMarkdownDescription,
+			},
 		},
 
 		Blocks: map[string]schema.Block{
@@ -452,7 +460,7 @@ func (r *AzapiUpdateResource) CreateUpdate(ctx context.Context, requestConfig tf
 
 	client := r.ProviderData.ResourceClient
 	readRequestOptions := clients.RequestOptions{
-		Headers:         common.AsMapOfString(model.ReadHeaders),
+		Headers:         withTelemetryHeaders(common.AsMapOfString(model.ReadHeaders), config.TelemetryHeaders),
 		QueryParameters: clients.NewQueryParameters(common.AsMapOfLists(model.ReadQueryParameters)),
 	}
 	readRequestOptions.RetryOptions, readRequestOptions.LastRetryError = clients.NewRetryOptions(model.Retry)
@@ -512,7 +520,7 @@ func (r *AzapiUpdateResource) CreateUpdate(ctx context.Context, requestConfig tf
 	}
 
 	updateRequestOptions := clients.RequestOptions{
-		Headers:         common.AsMapOfString(model.UpdateHeaders),
+		Headers:         withTelemetryHeaders(common.AsMapOfString(model.UpdateHeaders), config.TelemetryHeaders),
 		QueryParameters: clients.NewQueryParameters(common.AsMapOfLists(model.UpdateQueryParameters)),
 	}
 	updateRequestOptions.RetryOptions, updateRequestOptions.LastRetryError = clients.NewRetryOptions(model.Retry)

--- a/internal/services/migration/azapi_data_plane_resource_migration_v0_to_v2.go
+++ b/internal/services/migration/azapi_data_plane_resource_migration_v0_to_v2.go
@@ -109,6 +109,7 @@ func AzapiDataPlaneResourceMigrationV0ToV2(ctx context.Context) resource.StateUp
 				DeleteQueryParameters         map[string][]string `tfsdk:"delete_query_parameters"`
 				ReadHeaders                   map[string]string   `tfsdk:"read_headers"`
 				ReadQueryParameters           map[string][]string `tfsdk:"read_query_parameters"`
+				TelemetryHeaders              types.Object        `tfsdk:"telemetry_headers"`
 			}
 
 			var oldState OldModel
@@ -152,6 +153,7 @@ func AzapiDataPlaneResourceMigrationV0ToV2(ctx context.Context) resource.StateUp
 				Retry:                         retry.NewRetryValueNull(),
 				Output:                        outputVal,
 				Timeouts:                      oldState.Timeouts,
+				TelemetryHeaders:              types.ObjectNull(telemetryHeadersAttributeTypes()),
 			}
 
 			response.Diagnostics.Append(response.State.Set(ctx, newState)...)

--- a/internal/services/migration/azapi_data_plane_resource_migration_v1_to_v2.go
+++ b/internal/services/migration/azapi_data_plane_resource_migration_v1_to_v2.go
@@ -109,6 +109,7 @@ func AzapiDataPlaneResourceMigrationV1ToV2(ctx context.Context) resource.StateUp
 				DeleteQueryParameters         map[string][]string `tfsdk:"delete_query_parameters"`
 				ReadHeaders                   map[string]string   `tfsdk:"read_headers"`
 				ReadQueryParameters           map[string][]string `tfsdk:"read_query_parameters"`
+				TelemetryHeaders              types.Object        `tfsdk:"telemetry_headers"`
 			}
 
 			var oldState OldModel
@@ -150,6 +151,7 @@ func AzapiDataPlaneResourceMigrationV1ToV2(ctx context.Context) resource.StateUp
 				Retry:                         retry.NewRetryValueNull(),
 				Output:                        outputVal,
 				Timeouts:                      oldState.Timeouts,
+				TelemetryHeaders:              types.ObjectNull(telemetryHeadersAttributeTypes()),
 			}
 
 			response.Diagnostics.Append(response.State.Set(ctx, newState)...)

--- a/internal/services/migration/azapi_resource_action_migration_v0_to_v2.go
+++ b/internal/services/migration/azapi_resource_action_migration_v0_to_v2.go
@@ -103,6 +103,7 @@ func AzapiResourceActionMigrationV0ToV2(ctx context.Context) resource.StateUpgra
 				Retry                         retry.RetryValue    `tfsdk:"retry"`
 				Headers                       map[string]string   `tfsdk:"headers"`
 				QueryParameters               map[string][]string `tfsdk:"query_parameters"`
+				TelemetryHeaders              types.Object        `tfsdk:"telemetry_headers"`
 			}
 
 			var oldState OldModel
@@ -161,6 +162,7 @@ func AzapiResourceActionMigrationV0ToV2(ctx context.Context) resource.StateUpgra
 				SensitiveOutput:               types.DynamicNull(),
 				Timeouts:                      oldState.Timeouts,
 				Retry:                         retry.NewRetryValueNull(),
+				TelemetryHeaders:              types.ObjectNull(telemetryHeadersAttributeTypes()),
 			}
 
 			response.Diagnostics.Append(response.State.Set(ctx, newState)...)

--- a/internal/services/migration/azapi_resource_action_migration_v1_to_v2.go
+++ b/internal/services/migration/azapi_resource_action_migration_v1_to_v2.go
@@ -104,6 +104,7 @@ func AzapiResourceActionMigrationV1ToV2(ctx context.Context) resource.StateUpgra
 				Retry                         retry.RetryValue    `tfsdk:"retry"`
 				Headers                       map[string]string   `tfsdk:"headers"`
 				QueryParameters               map[string][]string `tfsdk:"query_parameters"`
+				TelemetryHeaders              types.Object        `tfsdk:"telemetry_headers"`
 			}
 
 			var oldState OldModel
@@ -147,6 +148,7 @@ func AzapiResourceActionMigrationV1ToV2(ctx context.Context) resource.StateUpgra
 				SensitiveOutput:               types.DynamicNull(),
 				Timeouts:                      oldState.Timeouts,
 				Retry:                         retry.NewRetryValueNull(),
+				TelemetryHeaders:              types.ObjectNull(telemetryHeadersAttributeTypes()),
 			}
 
 			response.Diagnostics.Append(response.State.Set(ctx, newState)...)

--- a/internal/services/migration/azapi_resource_action_migration_v2_to_v3.go
+++ b/internal/services/migration/azapi_resource_action_migration_v2_to_v3.go
@@ -124,6 +124,7 @@ func AzapiResourceActionMigrationV2ToV3(ctx context.Context) resource.StateUpgra
 				Retry                         retry.RetryValue `tfsdk:"retry"`
 				Headers                       types.Map        `tfsdk:"headers"`
 				QueryParameters               types.Map        `tfsdk:"query_parameters"`
+				TelemetryHeaders              types.Object     `tfsdk:"telemetry_headers"`
 			}
 
 			var oldState oldModel
@@ -152,6 +153,7 @@ func AzapiResourceActionMigrationV2ToV3(ctx context.Context) resource.StateUpgra
 				Retry:                         oldState.Retry,
 				Headers:                       oldState.Headers,
 				QueryParameters:               oldState.QueryParameters,
+				TelemetryHeaders:              types.ObjectNull(telemetryHeadersAttributeTypes()),
 			}
 
 			response.Diagnostics.Append(response.State.Set(ctx, newState)...)

--- a/internal/services/migration/azapi_resource_migration_v0_to_v2.go
+++ b/internal/services/migration/azapi_resource_migration_v0_to_v2.go
@@ -171,6 +171,7 @@ func AzapiResourceMigrationV0ToV2(ctx context.Context) resource.StateUpgrader {
 				DeleteQueryParameters         map[string][]string `tfsdk:"delete_query_parameters"`
 				ReadHeaders                   map[string]string   `tfsdk:"read_headers"`
 				ReadQueryParameters           map[string][]string `tfsdk:"read_query_parameters"`
+				TelemetryHeaders              types.Object        `tfsdk:"telemetry_headers"`
 			}
 
 			var oldState OldModel
@@ -221,6 +222,7 @@ func AzapiResourceMigrationV0ToV2(ctx context.Context) resource.StateUpgrader {
 				Timeouts:                      oldState.Timeouts,
 				SensitiveBody:                 types.DynamicNull(),
 				SensitiveBodyVersion:          types.MapNull(types.StringType),
+				TelemetryHeaders:              types.ObjectNull(telemetryHeadersAttributeTypes()),
 			}
 
 			response.Diagnostics.Append(response.State.Set(ctx, newState)...)

--- a/internal/services/migration/azapi_resource_migration_v1_to_v2.go
+++ b/internal/services/migration/azapi_resource_migration_v1_to_v2.go
@@ -172,6 +172,7 @@ func AzapiResourceMigrationV1ToV2(ctx context.Context) resource.StateUpgrader {
 				DeleteQueryParameters         map[string][]string `tfsdk:"delete_query_parameters"`
 				ReadHeaders                   map[string]string   `tfsdk:"read_headers"`
 				ReadQueryParameters           map[string][]string `tfsdk:"read_query_parameters"`
+				TelemetryHeaders              types.Object        `tfsdk:"telemetry_headers"`
 			}
 
 			var oldState OldModel
@@ -220,6 +221,7 @@ func AzapiResourceMigrationV1ToV2(ctx context.Context) resource.StateUpgrader {
 				Timeouts:                      oldState.Timeouts,
 				SensitiveBody:                 types.DynamicNull(),
 				SensitiveBodyVersion:          types.MapNull(types.StringType),
+				TelemetryHeaders:              types.ObjectNull(telemetryHeadersAttributeTypes()),
 			}
 
 			response.Diagnostics.Append(response.State.Set(ctx, newState)...)

--- a/internal/services/migration/azapi_update_resource_migration_v0_to_v2.go
+++ b/internal/services/migration/azapi_update_resource_migration_v0_to_v2.go
@@ -121,6 +121,7 @@ func AzapiUpdateResourceMigrationV0ToV2(ctx context.Context) resource.StateUpgra
 				UpdateQueryParameters         map[string][]string `tfsdk:"update_query_parameters"`
 				ReadHeaders                   map[string]string   `tfsdk:"read_headers"`
 				ReadQueryParameters           map[string][]string `tfsdk:"read_query_parameters"`
+				TelemetryHeaders              types.Object        `tfsdk:"telemetry_headers"`
 			}
 
 			var oldState OldModel
@@ -166,6 +167,7 @@ func AzapiUpdateResourceMigrationV0ToV2(ctx context.Context) resource.StateUpgra
 				Retry:                         retry.NewRetryValueNull(),
 				SensitiveBody:                 types.DynamicNull(),
 				SensitiveBodyVersion:          types.MapNull(types.StringType),
+				TelemetryHeaders:              types.ObjectNull(telemetryHeadersAttributeTypes()),
 			}
 
 			response.Diagnostics.Append(response.State.Set(ctx, newState)...)

--- a/internal/services/migration/azapi_update_resource_migration_v1_to_v2.go
+++ b/internal/services/migration/azapi_update_resource_migration_v1_to_v2.go
@@ -121,6 +121,7 @@ func AzapiUpdateResourceMigrationV1ToV2(ctx context.Context) resource.StateUpgra
 				UpdateQueryParameters         map[string][]string `tfsdk:"update_query_parameters"`
 				ReadHeaders                   map[string]string   `tfsdk:"read_headers"`
 				ReadQueryParameters           map[string][]string `tfsdk:"read_query_parameters"`
+				TelemetryHeaders              types.Object        `tfsdk:"telemetry_headers"`
 			}
 
 			var oldState OldModel
@@ -164,6 +165,7 @@ func AzapiUpdateResourceMigrationV1ToV2(ctx context.Context) resource.StateUpgra
 				Retry:                         retry.NewRetryValueNull(),
 				SensitiveBody:                 types.DynamicNull(),
 				SensitiveBodyVersion:          types.MapNull(types.StringType),
+				TelemetryHeaders:              types.ObjectNull(telemetryHeadersAttributeTypes()),
 			}
 
 			response.Diagnostics.Append(response.State.Set(ctx, newState)...)

--- a/internal/services/migration/telemetry_headers.go
+++ b/internal/services/migration/telemetry_headers.go
@@ -1,0 +1,13 @@
+package migration
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func telemetryHeadersAttributeTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"module_id":      types.StringType,
+		"module_version": types.StringType,
+	}
+}

--- a/internal/services/telemetry_headers.go
+++ b/internal/services/telemetry_headers.go
@@ -1,0 +1,57 @@
+package services
+
+import (
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+const telemetryHeadersMarkdownDescription = "Optional telemetry headers to include in requests. Values are sent as request headers but not persisted in Terraform state. Supported fields: `module_id` (`X-MODULE-ID`) and `module_version` (`X-MODULE-VERSION`). For stateful resources, these headers are applied on create and update requests."
+
+const (
+	telemetryHeaderModuleID      = "X-MODULE-ID"
+	telemetryHeaderModuleVersion = "X-MODULE-VERSION"
+)
+
+func telemetryHeadersAttributeTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"module_id":      types.StringType,
+		"module_version": types.StringType,
+	}
+}
+
+func withTelemetryHeaders(headers map[string]string, telemetryHeaders types.Object) map[string]string {
+	merged := make(map[string]string, len(headers)+2)
+	for k, v := range headers {
+		merged[k] = v
+	}
+
+	if telemetryHeaders.IsNull() || telemetryHeaders.IsUnknown() {
+		return merged
+	}
+
+	attributes := telemetryHeaders.Attributes()
+	moduleID, hasModuleID := attributes["module_id"].(types.String)
+	moduleVersion, hasModuleVersion := attributes["module_version"].(types.String)
+	hasModuleID = hasModuleID && !moduleID.IsNull() && !moduleID.IsUnknown()
+	hasModuleVersion = hasModuleVersion && !moduleVersion.IsNull() && !moduleVersion.IsUnknown()
+
+	if hasModuleID {
+		for k := range merged {
+			if strings.EqualFold(k, telemetryHeaderModuleID) {
+				delete(merged, k)
+			}
+		}
+		merged[telemetryHeaderModuleID] = moduleID.ValueString()
+	}
+	if hasModuleVersion {
+		for k := range merged {
+			if strings.EqualFold(k, telemetryHeaderModuleVersion) {
+				delete(merged, k)
+			}
+		}
+		merged[telemetryHeaderModuleVersion] = moduleVersion.ValueString()
+	}
+	return merged
+}

--- a/internal/services/telemetry_headers_test.go
+++ b/internal/services/telemetry_headers_test.go
@@ -1,0 +1,42 @@
+package services
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestWithTelemetryHeaders(t *testing.T) {
+	headers := map[string]string{
+		"X-Custom-Header":    "custom",
+		"x-module-id":        "from-headers-lower",
+		"X-MODULE-VERSION":   "from-headers-upper",
+		"x-module-version":   "from-headers-lower-version",
+		"another-header-key": "another-value",
+	}
+	telemetryHeaders := types.ObjectValueMust(telemetryHeadersAttributeTypes(), map[string]attr.Value{
+		"module_id":      types.StringValue("Azure/avm-res-network-virtualnetwork/azurerm"),
+		"module_version": types.StringValue("0.19.0"),
+	})
+
+	merged := withTelemetryHeaders(headers, telemetryHeaders)
+	if got := merged["X-Custom-Header"]; got != "custom" {
+		t.Fatalf("expected custom header to be preserved, got %q", got)
+	}
+	if got := merged[telemetryHeaderModuleID]; got != "Azure/avm-res-network-virtualnetwork/azurerm" {
+		t.Fatalf("expected %s header to be set, got %q", telemetryHeaderModuleID, got)
+	}
+	if got := merged[telemetryHeaderModuleVersion]; got != "0.19.0" {
+		t.Fatalf("expected %s header to be set, got %q", telemetryHeaderModuleVersion, got)
+	}
+	if _, ok := merged["x-module-id"]; ok {
+		t.Fatalf("expected lowercase module id header key to be removed")
+	}
+	if _, ok := merged["x-module-version"]; ok {
+		t.Fatalf("expected lowercase module version header key to be removed")
+	}
+	if _, ok := headers[telemetryHeaderModuleID]; ok {
+		t.Fatalf("expected source header map to remain unchanged")
+	}
+}


### PR DESCRIPTION
Implements #1138 where a new optional block is added to all resources and data sources for AVM modules to be able to report analytics.:

```
telemetry_headers {
  module_id      = "some-module-name"
  module_version = "0.0.1"
}
```

The headers `X-MODULE-ID` and `X-MODULE-VERSION` will then be sent in the Create and Update only http requests. Due to the design of HC framework where we can't see the config during Read and Delete, so it's not supported there.

This is write-only and doesn't get stored into state. Previously analytics was done using `create_headers`, `update_headers` etc. but it created unecessary plan diff when module version is bumped.

It is deliberately designed to allow only specific headers to reduce the security risk.

## Testing

- Added unit test and acctest coverage
- Locally ran acctest with mitmdump to inspect the header do get sent
- Pipeline acctest: https://github.com/Azure/terraform-provider-azapi/pull/1182/checks?check_run_id=89375189951