### PR TITLE
Preserve azapi_resource state for in-flight Create interrupted by SIGINT

### DIFF
--- a/internal/clients/resource_client_sigint_test.go
+++ b/internal/clients/resource_client_sigint_test.go
@@ -1,0 +1,196 @@
+package clients
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+)
+
+// sigintTransport simulates ARM while an azapi_resource Create is interrupted by
+// SIGINT, reproducing https://github.com/Azure/terraform-provider-azapi/issues/1110.
+//
+// Sequence modelled:
+//  1. PUT (CreateOrUpdate) is accepted by ARM: the resource is created
+//     server-side and a long-running-operation (LRO) poller is returned via the
+//     Azure-AsyncOperation header.
+//  2. While the provider polls the LRO, terraform core receives SIGINT and
+//     cancels the context (simulated here by cancelling on the first poll GET).
+//     The poll therefore fails with context.Canceled.
+//
+// Like the real net/http transport, Do returns ctx.Err() when the request's
+// context is already cancelled. This is what makes the provider's post-failure
+// recovery Get in azapi_resource.go (which reuses the same cancelled context)
+// fail as well, leaving the resource orphaned in Azure but absent from state.
+type sigintTransport struct {
+	host         string
+	resourcePath string
+	asyncOpPath  string
+	cancel       context.CancelFunc
+
+	mu        sync.Mutex
+	created   bool
+	pollCount int
+}
+
+func (t *sigintTransport) Do(req *http.Request) (*http.Response, error) {
+	if err := req.Context().Err(); err != nil {
+		return nil, err
+	}
+
+	switch {
+	case req.Method == http.MethodPut && req.URL.Path == t.resourcePath:
+		// ARM accepts the create and starts an async operation.
+		t.mu.Lock()
+		t.created = true
+		t.mu.Unlock()
+		resp := &http.Response{
+			StatusCode: http.StatusCreated,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body: io.NopCloser(strings.NewReader(
+				`{"id":"` + t.resourcePath + `","properties":{"provisioningState":"Creating"}}`)),
+			Request: req,
+		}
+		resp.Header.Set("Azure-AsyncOperation", t.host+t.asyncOpPath)
+		return resp, nil
+
+	case req.Method == http.MethodGet && req.URL.Path == t.asyncOpPath:
+		// SIGINT arrives mid-poll: cancel the context exactly as terraform core
+		// would when the operation is stopped, then report "still in progress".
+		// azcore observes the cancellation and PollUntilDone returns context.Canceled.
+		t.mu.Lock()
+		t.pollCount++
+		t.mu.Unlock()
+		if t.cancel != nil {
+			t.cancel()
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(`{"status":"InProgress"}`)),
+			Request:    req,
+		}, nil
+
+	case req.Method == http.MethodGet && req.URL.Path == t.resourcePath:
+		// A read of the resource: ARM already created it, so it is returned with
+		// its id and a terminal provisioning state.
+		t.mu.Lock()
+		created := t.created
+		t.mu.Unlock()
+		if !created {
+			return &http.Response{
+				StatusCode: http.StatusNotFound,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       io.NopCloser(strings.NewReader(`{"error":{"code":"ResourceNotFound"}}`)),
+				Request:    req,
+			}, nil
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body: io.NopCloser(strings.NewReader(
+				`{"id":"` + t.resourcePath + `","properties":{"provisioningState":"Succeeded"}}`)),
+			Request: req,
+		}, nil
+	}
+
+	return nil, fmt.Errorf("unexpected request %s %s", req.Method, req.URL.Path)
+}
+
+func (t *sigintTransport) wasCreated() bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.created
+}
+
+// TestResourceClientCreateOrUpdate_SIGINTLeavesResourceOrphaned reproduces
+// https://github.com/Azure/terraform-provider-azapi/issues/1110 and validates the
+// approach used by the fix.
+//
+// When an in-flight Create is interrupted by SIGINT, ARM has already created the
+// resource but the provider cancels its poll context and CreateOrUpdate returns
+// context.Canceled. A recovery Get that reuses the SAME cancelled context also
+// fails, so nothing is written to state and the resource is orphaned in Azure.
+//
+// The fix in azapi_resource.go CreateUpdate performs the recovery Get on a
+// context detached from cancellation (context.WithoutCancel + a bounded timeout),
+// which — as asserted below — successfully reads back the id ARM created so it can
+// be persisted to state.
+func TestResourceClientCreateOrUpdate_SIGINTLeavesResourceOrphaned(t *testing.T) {
+	const (
+		host         = "https://management.azure.com"
+		resourcePath = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/example-rg/providers/Microsoft.Storage/storageAccounts/stcanceltestsample"
+		asyncOpPath  = "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/westeurope/asyncoperations/11111111-1111-1111-1111-111111111111"
+		apiVersion   = "2023-01-01"
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	transport := &sigintTransport{
+		host:         host,
+		resourcePath: resourcePath,
+		asyncOpPath:  asyncOpPath,
+		cancel:       cancel,
+	}
+
+	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &policy.ClientOptions{
+		Telemetry: policy.TelemetryOptions{Disabled: true},
+		Transport: transport,
+	})
+	client := &ResourceClient{
+		host: host,
+		pl:   pl,
+	}
+
+	// 1. In-flight Create interrupted by SIGINT. ARM accepted the PUT (the
+	//    resource now exists) but the poll context is cancelled, so the provider's
+	//    CreateOrUpdate fails with context.Canceled and returns no id.
+	body := map[string]interface{}{
+		"location": "westeurope",
+		"sku":      map[string]interface{}{"name": "Standard_LRS"},
+		"kind":     "StorageV2",
+	}
+	if _, err := client.CreateOrUpdate(ctx, resourcePath, apiVersion, body, RequestOptions{}); err == nil {
+		t.Fatal("expected CreateOrUpdate to fail once the poll context was cancelled")
+	} else if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled from the interrupted poll, got %v", err)
+	}
+
+	if !transport.wasCreated() {
+		t.Fatal("precondition failed: ARM should have accepted the PUT and created the resource")
+	}
+	if transport.pollCount == 0 {
+		t.Fatal("precondition failed: the LRO poller should have been reached before cancellation")
+	}
+
+	// 2. The naive recovery (the pre-fix behaviour) reuses the SAME context that
+	//    SIGINT cancelled, so the recovery Get fails, no id is captured, and
+	//    terraform writes nothing to state even though the resource exists in Azure.
+	if _, err := client.Get(ctx, resourcePath, apiVersion, RequestOptions{}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected recovery Get on the cancelled context to fail with context.Canceled, got %v", err)
+	}
+
+	// 3. The fix: azapi_resource.go CreateUpdate runs the recovery Get on a context
+	//    detached from cancellation, which reads back the resource ARM created and
+	//    yields the id the provider persists to state, avoiding the orphan.
+	recoverCtx := context.WithoutCancel(ctx)
+	responseBody, err := client.Get(recoverCtx, resourcePath, apiVersion, RequestOptions{})
+	if err != nil {
+		t.Fatalf("recovery Get on a detached context should succeed, got %v", err)
+	}
+	responseMap, ok := responseBody.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected map response body, got %T", responseBody)
+	}
+	if responseMap["id"] != resourcePath {
+		t.Fatalf("expected recovered resource id %q, got %v", resourcePath, responseMap["id"])
+	}
+}

--- a/internal/services/azapi_resource.go
+++ b/internal/services/azapi_resource.go
@@ -3,6 +3,7 @@ package services
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"reflect"
@@ -897,12 +898,27 @@ func (r *AzapiResource) CreateUpdate(ctx context.Context, requestConfig tfsdk.Co
 			"err": err,
 		})
 		if isNewResource {
+			// If the create failed because terraform was interrupted (SIGINT,
+			// context.Canceled) or the operation exceeded its timeout
+			// (context.DeadlineExceeded), the resource may already have been
+			// created in Azure while the poll was aborted. Read it back on a
+			// context detached from the cancelled/expired parent so its id can
+			// still be persisted to state, avoiding an orphaned resource that a
+			// subsequent apply would reject with "already exists".
+			// See https://github.com/Azure/terraform-provider-azapi/issues/1110
+			// and https://github.com/Azure/terraform-provider-azapi/issues/1078.
+			recoveryCtx := ctx
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				var cancel context.CancelFunc
+				recoveryCtx, cancel = context.WithTimeout(context.WithoutCancel(ctx), 5*time.Minute)
+				defer cancel()
+			}
 			requestOptions := clients.RequestOptions{
 				Headers:         common.AsMapOfString(plan.ReadHeaders),
 				QueryParameters: clients.NewQueryParameters(common.AsMapOfLists(plan.ReadQueryParameters)),
 			}
 			requestOptions.RetryOptions, requestOptions.LastRetryError = clients.NewRetryOptions(plan.Retry)
-			if responseBody, err := client.Get(ctx, id.AzureResourceId, id.ApiVersion, requestOptions); err == nil {
+			if responseBody, err := client.Get(recoveryCtx, id.AzureResourceId, id.ApiVersion, requestOptions); err == nil {
 				// generate the computed fields
 				plan.ID = types.StringValue(id.ID())
 
@@ -931,7 +947,7 @@ func (r *AzapiResource) CreateUpdate(ctx context.Context, requestConfig tfsdk.Co
 						plan.Identity = identity.ToList(planIdentity)
 					}
 				}
-				diagnostics.Append(responseState.Set(ctx, plan)...)
+				diagnostics.Append(responseState.Set(recoveryCtx, plan)...)
 			}
 		}
 		diagnostics.AddError("Failed to create/update resource", fmt.Errorf("creating/updating %s: %+v", id, err).Error())


### PR DESCRIPTION
Fixes #1110. Also covers the `context.DeadlineExceeded` case from #1078.

## Problem

When `terraform apply` is interrupted with SIGINT (Ctrl+C, CI cancellation, job timeout) while an `azapi_resource` Create is mid-flight, the resource ends up **created in Azure but absent from state**. The next apply then fails with `A resource with the ID "<id>" already exists ... needs to be imported`, requiring a manual `terraform import` to recover.

## Root cause

In `AzapiResource.CreateUpdate` (`internal/services/azapi_resource.go`), when `CreateOrUpdate` fails it already attempts a recovery `Get` to still capture the resource id for a new resource. But that recovery `Get` — and the `responseState.Set` that follows — reused the **same context** that SIGINT had already cancelled (`context.Canceled`), or that had expired (`context.DeadlineExceeded`, #1078). So the recovery read failed too, no id was captured, and terraform wrote nothing to state.

On first SIGINT, terraform core cancels the RPC context but still flushes whatever state the provider returns — so if the provider returns the id alongside the error, core persists it and the next apply reconciles instead of erroring.

## Fix

Run the recovery `Get` (and the subsequent state write) on a context **detached** from the cancelled/expired parent when the create fails with `context.Canceled` or `context.DeadlineExceeded`:

```go
recoveryCtx := ctx
if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
    var cancel context.CancelFunc
    recoveryCtx, cancel = context.WithTimeout(context.WithoutCancel(ctx), 5*time.Minute)
    defer cancel()
}
```

- `context.WithoutCancel` drops cancellation but preserves values (auth, logging fields); the bounded timeout prevents a hung read from blocking terraform shutdown.
- Non-context errors keep the original behaviour unchanged.
- If the resource genuinely was not created (cancel before ARM accepted the PUT), the recovery read returns 404, so no false state is written.

## Testing

Adds `internal/clients/resource_client_sigint_test.go`, a no-Azure test using a fake ARM transport that:
1. Accepts the PUT (resource created server-side) and returns an LRO poller.
2. Cancels the context mid-poll (simulating SIGINT) so `CreateOrUpdate` returns `context.Canceled`.
3. Asserts a recovery `Get` on the **same cancelled** context fails (the orphaning bug).
4. Asserts a recovery `Get` on a **detached** context succeeds and returns the id (the fix).

Also ran acctest: https://github.com/Azure/terraform-provider-azapi/pull/1183/checks?check_run_id=89890752648