### PR TITLE
Strip UTF-8 BOM prefix from JSON responses

### DIFF
--- a/internal/clients/client.go
+++ b/internal/clients/client.go
@@ -65,6 +65,7 @@ func (client *Client) Build(ctx context.Context, o *Option) error {
 	}
 	perRetryPolicies := make([]policy.Policy, 0)
 	perRetryPolicies = append(perRetryPolicies, NewLiveTrafficLogPolicy())
+	perRetryPolicies = append(perRetryPolicies, newUTF8BOMPolicy())
 
 	allowedHeaders := []string{
 		"Access-Control-Allow-Methods",

--- a/internal/clients/utf8_bom_policy.go
+++ b/internal/clients/utf8_bom_policy.go
@@ -1,0 +1,54 @@
+package clients
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"mime"
+	"net/http"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+)
+
+var utf8BOM = []byte{0xef, 0xbb, 0xbf}
+
+type utf8BOMPolicy struct{}
+
+func newUTF8BOMPolicy() policy.Policy {
+	return &utf8BOMPolicy{}
+}
+
+func (*utf8BOMPolicy) Do(req *policy.Request) (*http.Response, error) {
+	resp, err := req.Next()
+	if err != nil || resp.Body == nil || !isJSONContentType(resp.Header.Get("Content-Type")) {
+		return resp, err
+	}
+
+	reader := bufio.NewReader(resp.Body)
+	prefix, peekErr := reader.Peek(len(utf8BOM))
+	if peekErr == nil && bytes.Equal(prefix, utf8BOM) {
+		_, _ = reader.Discard(len(utf8BOM))
+		if resp.ContentLength >= int64(len(utf8BOM)) {
+			resp.ContentLength -= int64(len(utf8BOM))
+		}
+	}
+	resp.Body = struct {
+		io.Reader
+		io.Closer
+	}{
+		Reader: reader,
+		Closer: resp.Body,
+	}
+
+	return resp, nil
+}
+
+func isJSONContentType(contentType string) bool {
+	mediaType, _, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		return false
+	}
+	mediaType = strings.ToLower(mediaType)
+	return mediaType == "application/json" || strings.HasSuffix(mediaType, "+json")
+}

--- a/internal/clients/utf8_bom_policy_test.go
+++ b/internal/clients/utf8_bom_policy_test.go
@@ -1,0 +1,91 @@
+package clients
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+)
+
+func TestUTF8BOMPolicyJSONResponse(t *testing.T) {
+	testCases := []struct {
+		name string
+		body string
+	}{
+		{
+			name: "removes BOM",
+			body: "\xef\xbb\xbf{\"value\":\"expected\"}",
+		},
+		{
+			name: "preserves body without BOM",
+			body: "{\"value\":\"expected\"}",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			resp := runUTF8BOMPolicy(t, "application/json; charset=utf-8", testCase.body)
+
+			var got map[string]string
+			if err := runtime.UnmarshalAsJSON(resp, &got); err != nil {
+				t.Fatalf("unmarshalling response: %+v", err)
+			}
+			if got["value"] != "expected" {
+				t.Fatalf("expected decoded value, got %#v", got)
+			}
+			if resp.ContentLength != int64(len(`{"value":"expected"}`)) {
+				t.Fatalf("expected adjusted content length, got %d", resp.ContentLength)
+			}
+		})
+	}
+}
+
+func TestUTF8BOMPolicyPreservesNonJSONResponse(t *testing.T) {
+	const body = "\xef\xbb\xbfplain text"
+	resp := runUTF8BOMPolicy(t, "text/plain", body)
+
+	got, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("reading response: %+v", err)
+	}
+	if string(got) != body {
+		t.Fatalf("expected body %q, got %q", body, got)
+	}
+	if resp.ContentLength != int64(len(body)) {
+		t.Fatalf("expected unchanged content length, got %d", resp.ContentLength)
+	}
+}
+
+func runUTF8BOMPolicy(t *testing.T, contentType string, body string) *http.Response {
+	t.Helper()
+
+	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{
+		PerRetry: []policy.Policy{
+			newUTF8BOMPolicy(),
+		},
+	}, &policy.ClientOptions{
+		Telemetry: policy.TelemetryOptions{Disabled: true},
+		Transport: fakeTransporter{
+			response: &http.Response{
+				StatusCode:    http.StatusOK,
+				Header:        http.Header{"Content-Type": []string{contentType}},
+				Body:          io.NopCloser(strings.NewReader(body)),
+				ContentLength: int64(len(body)),
+			},
+		},
+	})
+
+	req, err := runtime.NewRequest(context.Background(), http.MethodGet, "https://example.com")
+	if err != nil {
+		t.Fatalf("creating request: %+v", err)
+	}
+	resp, err := pl.Do(req)
+	if err != nil {
+		t.Fatalf("executing request: %+v", err)
+	}
+	return resp
+}

--- a/internal/services/azapi_resource_bom_test.go
+++ b/internal/services/azapi_resource_bom_test.go
@@ -1,0 +1,203 @@
+//go:build unix
+
+package services_test
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/Azure/terraform-provider-azapi/internal/acceptance"
+	"github.com/Azure/terraform-provider-azapi/internal/acceptance/check"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccGenericResource_utf8BOMResponse(t *testing.T) {
+	startPeeringBOMMockProxy(t)
+
+	data := acceptance.BuildTestData(t, "azapi_resource", "test")
+	r := GenericResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.peeringWithBOMResponse(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStepWithImportStateIdFunc(r.ImportIdFunc, defaultIgnores()...),
+	})
+}
+
+func (r GenericResource) peeringWithBOMResponse(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azapi" {
+  # The Microsoft.Peering endpoints are fully mocked (see
+  # testdata/peering_bom_mock.py), so skip the real resource-provider
+  # registration call, which would otherwise reach live Azure.
+  skip_provider_registration = true
+}
+
+resource "azapi_resource" "test" {
+  type      = "Microsoft.Peering/peerings@2025-05-01"
+  name      = "acctest-peering-%[1]d"
+  parent_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/acctestRG-%[1]d"
+  location  = "eastus"
+
+  schema_validation_enabled = false
+
+  body = {
+    kind = "Exchange"
+    sku = {
+      name = "Basic_Exchange_Free"
+    }
+    properties = {
+      peeringLocation = "peeringLocation0"
+      exchange = {
+        peerAsn = {
+          id = "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Peering/peerAsns/myAsn1"
+        }
+        connections = [
+          {
+            connectionIdentifier = "CE495334-0E94-4E51-8164-8116D6CD284D"
+            peeringDBFacilityId  = 99999
+            bgpSession = {
+              maxPrefixesAdvertisedV4 = 1000
+              maxPrefixesAdvertisedV6 = 100
+              peerSessionIPv4Address  = "192.168.2.1"
+              peerSessionIPv6Address  = "fd00::1"
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+`, data.RandomInteger)
+}
+
+func startPeeringBOMMockProxy(t *testing.T) {
+	t.Helper()
+
+	if os.Getenv("TF_ACC") == "" {
+		return
+	}
+
+	mitm, err := exec.LookPath("mitmdump")
+	if err != nil {
+		t.Skip("mitmdump not found in PATH; it is required to mock the Microsoft.Peering/peerings API (see the azapi-acctest skill)")
+	}
+
+	host, port := "127.0.0.1", "7070"
+	if proxy := firstNonEmptyEnv("HTTPS_PROXY", "HTTP_PROXY"); proxy != "" {
+		if h, p := proxyHostPort(proxy); p != "" {
+			host, port = h, p
+		}
+	} else {
+		proxy := fmt.Sprintf("http://%s:%s", host, port)
+		if err := os.Setenv("HTTP_PROXY", proxy); err != nil {
+			t.Fatalf("setting HTTP_PROXY: %v", err)
+		}
+		if err := os.Setenv("HTTPS_PROXY", proxy); err != nil {
+			t.Fatalf("setting HTTPS_PROXY: %v", err)
+		}
+	}
+
+	addon, err := filepath.Abs(filepath.Join("testdata", "peering_bom_mock.py"))
+	if err != nil {
+		t.Fatalf("resolving mock addon path: %v", err)
+	}
+
+	addr := net.JoinHostPort(host, port)
+	if c, derr := net.DialTimeout("tcp", addr, 3000*time.Millisecond); derr == nil {
+		_ = c.Close()
+		t.Skipf("%s is already in use; stop any other proxy on that port before running this reproduction test", addr)
+	}
+
+	logFile, err := os.CreateTemp("", "peering-bom-mitmdump-*.log")
+	if err != nil {
+		t.Fatalf("creating mitmdump log file: %v", err)
+	}
+	logPath := logFile.Name()
+	readLog := func() string {
+		b, _ := os.ReadFile(logPath)
+		return string(b)
+	}
+
+	cmd := exec.Command(mitm, "--listen-host", host, "--listen-port", port, "-s", addon, "-q")
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if err := cmd.Start(); err != nil {
+		_ = logFile.Close()
+		_ = os.Remove(logPath)
+		t.Fatalf("starting mitmdump: %v", err)
+	}
+	if err := logFile.Close(); err != nil {
+		_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+		_ = cmd.Wait()
+		_ = os.Remove(logPath)
+		t.Fatalf("closing mitmdump log file: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+
+	stop := func() {
+		_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+		<-done
+		_ = os.Remove(logPath)
+	}
+
+	deadline := time.Now().Add(30 * time.Second)
+	for {
+		select {
+		case werr := <-done:
+			out := readLog()
+			_ = os.Remove(logPath)
+			t.Fatalf("mitmdump exited before becoming ready: %v\n%s", werr, out)
+		default:
+		}
+		if c, derr := net.DialTimeout("tcp", addr, time.Second); derr == nil {
+			_ = c.Close()
+			t.Cleanup(stop)
+			return
+		}
+		if time.Now().After(deadline) {
+			stop()
+			t.Fatalf("timed out waiting for mitmdump to listen on %s\n%s", addr, readLog())
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
+}
+
+func firstNonEmptyEnv(keys ...string) string {
+	for _, k := range keys {
+		if v := os.Getenv(k); v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+func proxyHostPort(proxy string) (string, string) {
+	if !strings.Contains(proxy, "://") {
+		proxy = "http://" + proxy
+	}
+	u, err := url.Parse(proxy)
+	if err != nil {
+		return "", ""
+	}
+	host := u.Hostname()
+	if host == "" {
+		host = "127.0.0.1"
+	}
+	return host, u.Port()
+}

--- a/internal/services/testdata/peering_bom_mock.py
+++ b/internal/services/testdata/peering_bom_mock.py
@@ -1,0 +1,122 @@
+"""mitmproxy addon that mocks the Microsoft.Peering/peerings ARM API.
+
+It reproduces https://github.com/Azure/terraform-provider-azapi/issues/1098: the
+real Azure Peering API prepends a UTF-8 byte-order mark (EF BB BF) to its JSON
+response body. Go's encoding/json cannot parse a leading BOM, so azapi fails to
+read the resource with:
+
+    unmarshalling type *interface {}: invalid character 'ï' looking for beginning of value
+
+A real peering cannot be provisioned in a test subscription (it needs a
+registered ASN and a signed peering agreement), so this addon fully mocks the
+peering resource lifecycle instead. It is stateful so the whole create/read/
+import/delete flow works once the provider learns to strip the BOM:
+
+    * PUT / PATCH -> 200 with a clean body, and marks the peering as "created"
+    * GET         -> 404 until created, then 200 with a BOM-prefixed body (the bug)
+    * DELETE      -> 200, and marks the peering as "deleted"
+
+Only requests to the peering resource itself are intercepted; every other
+request (AAD auth, resource provider registration, ...) is passed through to the
+real endpoint.
+
+Usage:
+    mitmdump -p 7070 -s peering_bom_mock.py
+"""
+
+import json
+import re
+
+from mitmproxy import http
+
+# UTF-8 byte-order mark that the Azure Peering API prepends to its JSON body.
+UTF8_BOM = b"\xef\xbb\xbf"
+
+PEERING_RE = re.compile(
+    r"^/subscriptions/[^/]+/resourceGroups/[^/]+"
+    r"/providers/Microsoft\.Peering/peerings/[^/?]+$",
+    re.IGNORECASE,
+)
+
+_created = set()
+
+
+def _peering_body(resource_id, name):
+    """A realistic exchange-peering body, modelled on the 2025-05-01 API spec."""
+    return {
+        "name": name,
+        "type": "Microsoft.Peering/peerings",
+        "id": resource_id,
+        "kind": "Exchange",
+        "location": "eastus",
+        "properties": {
+            "peeringLocation": "peeringLocation0",
+            "provisioningState": "Succeeded",
+            "exchange": {
+                "peerAsn": {
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Peering/peerAsns/myAsn1"
+                },
+                "connections": [
+                    {
+                        "connectionIdentifier": "CE495334-0E94-4E51-8164-8116D6CD284D",
+                        "peeringDBFacilityId": 99999,
+                        "connectionState": "Active",
+                        "bgpSession": {
+                            "maxPrefixesAdvertisedV4": 1000,
+                            "maxPrefixesAdvertisedV6": 100,
+                            "peerSessionIPv4Address": "192.168.2.1",
+                            "peerSessionIPv6Address": "fd00::1",
+                        },
+                    }
+                ],
+            },
+        },
+        "sku": {
+            "name": "Basic_Exchange_Free",
+            "family": "Exchange",
+            "size": "Free",
+            "tier": "Basic",
+        },
+    }
+
+
+def _json_response(status, body_bytes):
+    return http.Response.make(
+        status, body_bytes, {"Content-Type": "application/json"}
+    )
+
+
+def request(flow: http.HTTPFlow) -> None:
+    host = flow.request.pretty_host
+    path = flow.request.path.split("?", 1)[0]
+
+    if "management.azure.com" not in host or not PEERING_RE.match(path):
+        return 
+
+    name = path.rstrip("/").rsplit("/", 1)[-1]
+    body = json.dumps(_peering_body(path, name)).encode("utf-8")
+    method = flow.request.method.upper()
+
+    if method == "GET":
+        if path in _created:
+            flow.response = _json_response(200, UTF8_BOM + body)
+        else:
+            not_found = json.dumps(
+                {
+                    "error": {
+                        "code": "NotFound",
+                        "message": "The peering resource was not found.",
+                    }
+                }
+            ).encode("utf-8")
+            flow.response = _json_response(404, not_found)
+    elif method in ("PUT", "PATCH"):
+        _created.add(path)
+        flow.response = _json_response(200, body)
+    elif method == "DELETE":
+        _created.discard(path)
+        flow.response = _json_response(
+            200, json.dumps({"status": "Succeeded"}).encode("utf-8")
+        )
+    else:
+        flow.response = _json_response(200, body)


### PR DESCRIPTION
Fixes #1098 by introducing a http transport policy that strips UTF-8 BOM prefix on JSON response payload. Go net/http deliberately does not strip the UTF-8 BOM because they prefer downstream packages to do it.

## Testing

1. I added an acctest that rely on mitmproxy since actual Microsoft.Peering is difficult to setup, this test only works locally because I'm not sure how reliable it will be in ADO pipeline
2. Run acctest to ensure no regression: https://github.com/Azure/terraform-provider-azapi/pull/1190/checks?check_run_id=91622596732

