### PR TITLE
Update changelog for 2.12 release 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## v2.12.0
+
+ENHANCEMENTS:
+
+- `azapi` provider: Support `preserve_resource_id_casing` feature flag (default `false`). When enabled, if the resource ID the provider would write back to state differs from the existing state value only by casing, the existing casing is preserved. This avoids spurious `Unexpected Identity Change` errors and diffs when consumers (or upstream modules) rely on a specific casing the Azure API may not preserve. Only the `id` and `resource_id` attributes are affected. Can also be sourced from the `ARM_PRESERVE_RESOURCE_ID_CASING` environment variable (GH-1122).
+- `azapi_resource` resource: Re-introduce the `ignore_body_changes` property to ignore changes to specified fields in the request body (GH-1192).
+- `azapi_data_plane_resource` resource: Allow `name` to be optional based on the URL format (GH-1178).
+- `azapi_data_plane_resource` resource: Support Key Vault certificates (GH-1174).
+
+BUG FIXES:
+
+- Strip UTF-8 BOM prefix from JSON responses (GH-1190).
+- Preserve `azapi_resource` state for an in-flight Create interrupted by SIGINT (GH-1183).
+- Fix `MoveState` target identity for `azurerm` resource moves (GH-1175).
+- Fix OIDC token file path logic (GH-1164).
+
 ## v2.11.0
 
 ENHANCEMENTS:
@@ -9,7 +25,6 @@ ENHANCEMENTS:
 - Acquire a policy token when a request is blocked by an invoke policy (GH-1145).
 - Update bicep types to Azure/azure-rest-api-specs revision 51d53915b5f31b10e6645c136807b9d95f9f09d1 (GH-1159).
 - Improve the bicep types update process (GH-1155).
-- `azapi` provider: Support `preserve_resource_id_casing` feature flag (default `false`). When enabled, if the resource ID the provider would write back to state differs from the existing state value only by casing, the existing casing is preserved. This avoids spurious `Unexpected Identity Change` errors and diffs when consumers (or upstream modules) rely on a specific casing the Azure API may not preserve. Only the `id` and `resource_id` attributes are affected. Can also be sourced from the `ARM_PRESERVE_RESOURCE_ID_CASING` environment variable (GH-1122).
 
 BUG FIXES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,6 @@ ENHANCEMENTS:
 - `azapi_resource` resource: Re-introduce the `ignore_body_changes` property to ignore changes to specified fields in the request body (GH-1192).
 - `azapi_data_plane_resource` resource: Allow `name` to be optional based on the URL format (GH-1178).
 - `azapi_data_plane_resource` resource: Support Key Vault certificates (GH-1174).
-- Bump `github.com/go-git/go-git/v5` from v5.19.1 to v5.19.2 (GH-1188).
-- Bump `github.com/hashicorp/terraform-plugin-log` from v0.10.0 to v0.11.0 (GH-1191).
 
 BUG FIXES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ ENHANCEMENTS:
 - `azapi_resource` resource: Re-introduce the `ignore_body_changes` property to ignore changes to specified fields in the request body (GH-1192).
 - `azapi_data_plane_resource` resource: Allow `name` to be optional based on the URL format (GH-1178).
 - `azapi_data_plane_resource` resource: Support Key Vault certificates (GH-1174).
+- Bump `github.com/go-git/go-git/v5` from v5.19.1 to v5.19.2 (GH-1188).
+- Bump `github.com/hashicorp/terraform-plugin-log` from v0.10.0 to v0.11.0 (GH-1191).
 
 BUG FIXES:
 


### PR DESCRIPTION
Commit hisotry as below: 

- 7d923f69b (HEAD -> main, origin/main, origin/HEAD) Add `preserve_resource_id_casing` provider feature flag (#1122)
- e774e61ee azapi_resource: re-introduce ignore_body_changes property (#1192)
- b057c501d Strip UTF-8 BOM prefix from JSON responses (#1190)
- d8f3a4d38 Bump github.com/hashicorp/terraform-plugin-log from 0.10.0 to 0.11.0 in the gomod-dependencies group (#1191)
- 9cdbd4918 (tag: v2.12.0-test) Bump github.com/go-git/go-git/v5 from 5.19.1 to 5.19.2 in the gomod-dependencies group (#1188)
- 5229b847d chore: Cleanup acquire policy token test suppression (#1186)
- 4fae1b397 Preserve azapi_resource state for in-flight Create interrupted by SIGINT (#1183)
- 420194907 Use test data location in preflight child resource acctest (#1181)
- 05dee4d83 `azapi_data_plane_resource` - allow `name` to be optional based on URL format (#1178)
- 4131661ce fix: temporarily suppress invoke policy acctest failure (#1180)
- e2799ae27 test coverage: resource_client.go - List: high latency paging error (#1177)
- dfaa305a7 Fix MoveState target identity for azurerm resource moves (#1175)
- cf331c47a Refactor `data_plane_client.go`  (#1176)
- 4607abb85 `azapi_data_plane_resource` - support key vault certificate (#1174)
- 29c93f305 Fix: OIDC token file path logic (#1164)