### PR TITLE
Update v2.12.0 changelog for windows_arm64 binaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ENHANCEMENTS:
 
+- Publish official windows_arm64 provider binaries (GH-1148).
 - `azapi` provider: Support `preserve_resource_id_casing` feature flag (default `false`). When enabled, if the resource ID the provider would write back to state differs from the existing state value only by casing, the existing casing is preserved. This avoids spurious `Unexpected Identity Change` errors and diffs when consumers (or upstream modules) rely on a specific casing the Azure API may not preserve. Only the `id` and `resource_id` attributes are affected. Can also be sourced from the `ARM_PRESERVE_RESOURCE_ID_CASING` environment variable (GH-1122).
 - `azapi_resource` resource: Re-introduce the `ignore_body_changes` property to ignore changes to specified fields in the request body (GH-1192).
 - `azapi_data_plane_resource` resource: Allow `name` to be optional based on the URL format (GH-1178).


### PR DESCRIPTION
Add the official Windows ARM64 provider binaries to the v2.12.0 changelog.

Closes #1148.