### PR TITLE
acctest fix: TestAccResourceWithAcquirePolicyToken_disallowedByPolicy - add wait after policy is assigned

### DIFF
--- a/internal/services/azapi_resource_acquire_policy_token_test.go
+++ b/internal/services/azapi_resource_acquire_policy_token_test.go
@@ -18,13 +18,22 @@ import (
 
 type ResourceWithAcquirePolicyToken struct{}
 
+func acquirePolicyTokenExternalProviders() map[string]resource.ExternalProvider {
+	providers := common.ExternalProvidersAzurermVersionFour()
+	providers["time"] = resource.ExternalProvider{
+		Source:            "hashicorp/time",
+		VersionConstraint: "0.12.0",
+	}
+	return providers
+}
+
 func TestAccResourceWithAcquirePolicyToken_allowedByPolicy(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azapi_resource", "storage")
 	r := ResourceWithAcquirePolicyToken{}
 
 	step := resource.TestStep{
 		Config:            r.basic(data, true),
-		ExternalProviders: common.ExternalProvidersAzurermVersionFour(),
+		ExternalProviders: acquirePolicyTokenExternalProviders(),
 		Check: resource.ComposeTestCheckFunc(
 			check.That(data.ResourceName).ExistsInAzure(r),
 		),
@@ -39,7 +48,7 @@ func TestAccResourceWithAcquirePolicyToken_disallowedByPolicy(t *testing.T) {
 
 	step := resource.TestStep{
 		Config:            r.basic(data, false),
-		ExternalProviders: common.ExternalProvidersAzurermVersionFour(),
+		ExternalProviders: acquirePolicyTokenExternalProviders(),
 		ExpectError:       regexp.MustCompile("RequestDisallowedByPolicy"),
 	}
 
@@ -52,7 +61,7 @@ func TestAccResourceWithAcquirePolicyToken_alwaysAcquire(t *testing.T) {
 
 	step := resource.TestStep{
 		Config:            r.alwaysAcquire(data),
-		ExternalProviders: common.ExternalProvidersAzurermVersionFour(),
+		ExternalProviders: acquirePolicyTokenExternalProviders(),
 		Check: resource.ComposeTestCheckFunc(
 			check.That("azapi_resource.storage").ExistsInAzure(r),
 			check.That("azapi_resource.virtual_network").ExistsInAzure(r),
@@ -159,6 +168,12 @@ resource "azurerm_resource_group_policy_assignment" "test" {
   }
 }
 
+resource "time_sleep" "wait_for_policy_assignment" {
+  create_duration = "1m"
+
+  depends_on = [azurerm_resource_group_policy_assignment.test]
+}
+
 resource "azapi_resource" "storage" {
   type      = "Microsoft.Storage/storageAccounts@2023-05-01"
   name      = "acctestsa%[3]s"
@@ -188,7 +203,7 @@ resource "azapi_resource" "storage" {
     }
   }
 
-  depends_on = [azurerm_resource_group_policy_assignment.test]
+  depends_on = [time_sleep.wait_for_policy_assignment]
 }
 `, data.RandomInteger, data.LocationPrimary, data.RandomString, claimValue)
 }
@@ -264,6 +279,12 @@ resource "azurerm_resource_group_policy_assignment" "test" {
   }
 }
 
+resource "time_sleep" "wait_for_policy_assignment" {
+  create_duration = "5m"
+
+  depends_on = [azurerm_resource_group_policy_assignment.test]
+}
+
 resource "azapi_resource" "storage" {
   type      = "Microsoft.Storage/storageAccounts@2023-05-01"
   name      = "acctestsa%[3]s"
@@ -293,7 +314,7 @@ resource "azapi_resource" "storage" {
     }
   }
 
-  depends_on = [azurerm_resource_group_policy_assignment.test]
+  depends_on = [time_sleep.wait_for_policy_assignment]
 }
 
 resource "azapi_resource" "virtual_network" {
@@ -310,7 +331,7 @@ resource "azapi_resource" "virtual_network" {
     }
   }
 
-  depends_on = [azurerm_resource_group_policy_assignment.test]
+  depends_on = [time_sleep.wait_for_policy_assignment]
 }
 `, data.RandomInteger, data.LocationPrimary, data.RandomString)
 }


### PR DESCRIPTION
Fixes the following test flake error:

```
2026-08-11T13:05:36.6881771Z     testcase.go:217: Step 1/1, expected an error but got none
2026-08-11T13:05:36.6881950Z --- FAIL: TestAccResourceWithAcquirePolicyToken_disallowedByPolicy (302.21s)
```

By adding a 1m sleep after RG policy assignment. This is needed due to eventual consistency lag in the API.

acctest: https://github.com/Azure/terraform-provider-azapi/pull/1204/checks?check_run_id=93981516033