### PR TITLE
feat(schema): expose resource property capabilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,9 @@ terraform.tfplan
 terraform.tfstate
 bin/
 modules-dev/
-/pkg/
+/pkg/*
+!/pkg/schema/
+!/pkg/schema/**
 website/.vagrant
 website/.bundle
 website/build

--- a/pkg/schema/doc.go
+++ b/pkg/schema/doc.go
@@ -1,0 +1,6 @@
+// Package schema exposes resource schema capabilities backed by AzAPI's embedded Bicep type definitions.
+//
+// The embedded definitions are generated from Bicep types and periodically synchronized with
+// azure-rest-api-specs. This package intentionally exposes capability results rather than the
+// generated schema model so consumers do not depend on implementation details.
+package schema

--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -1,0 +1,113 @@
+package schema
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/Azure/terraform-provider-azapi/internal/azure"
+	"github.com/Azure/terraform-provider-azapi/internal/azure/types"
+)
+
+var (
+	// ErrInvalidResourceType indicates that a resource type is not in standard AzAPI form.
+	ErrInvalidResourceType = errors.New("resource type must be in the form provider/type@api-version")
+
+	// ErrInvalidAPIVersion indicates that a resource type does not include an API version.
+	ErrInvalidAPIVersion = errors.New("resource type must include an API version")
+
+	// ErrInvalidProperty indicates that a top-level property name is empty.
+	ErrInvalidProperty = errors.New("property name must not be empty")
+
+	// ErrDefinitionUnavailable indicates that no embedded schema definition could be loaded.
+	ErrDefinitionUnavailable = errors.New("resource schema definition is unavailable")
+)
+
+// PropertyStatus describes whether a top-level property can be written to a resource.
+type PropertyStatus string
+
+const (
+	// PropertyStatusWritable means the property is present and writable.
+	PropertyStatusWritable PropertyStatus = "writable"
+
+	// PropertyStatusReadOnly means the property is present but cannot be written.
+	PropertyStatusReadOnly PropertyStatus = "read_only"
+
+	// PropertyStatusUnsupported means the property is absent from the resource definition.
+	PropertyStatusUnsupported PropertyStatus = "unsupported"
+
+	// PropertyStatusUnknown means the property could not be inspected. The returned error explains why.
+	PropertyStatusUnknown PropertyStatus = "unknown"
+)
+
+// TopLevelPropertyStatus returns the capability of property in resourceType.
+//
+// resourceType must use the standard AzAPI format, such as
+// "Microsoft.Resources/resourceGroups@2021-04-01". The result is PropertyStatusUnknown and a
+// non-nil error when the input is invalid or the embedded definition is unavailable.
+func TopLevelPropertyStatus(resourceType, property string) (PropertyStatus, error) {
+	resourceName, apiVersion, err := parseResourceType(resourceType)
+	if err != nil {
+		return PropertyStatusUnknown, err
+	}
+	if property == "" || property != strings.TrimSpace(property) {
+		return PropertyStatusUnknown, ErrInvalidProperty
+	}
+
+	definition, err := azure.GetResourceDefinition(resourceName, apiVersion)
+	if err != nil {
+		return PropertyStatusUnknown, fmt.Errorf("%w for %q: %v", ErrDefinitionUnavailable, resourceType, err)
+	}
+	if definition == nil || definition.Body == nil || definition.Body.Type == nil {
+		return PropertyStatusUnknown, fmt.Errorf("%w for %q: resource body is unavailable", ErrDefinitionUnavailable, resourceType)
+	}
+
+	status, ok := propertyStatus(*definition.Body.Type, property)
+	if !ok {
+		return PropertyStatusUnknown, fmt.Errorf("%w for %q: resource body is not an object", ErrDefinitionUnavailable, resourceType)
+	}
+	if definition.IsReadOnly() {
+		if status == PropertyStatusUnsupported {
+			return status, nil
+		}
+		return PropertyStatusReadOnly, nil
+	}
+	return status, nil
+}
+
+func parseResourceType(resourceType string) (string, string, error) {
+	if resourceType == "" || resourceType != strings.TrimSpace(resourceType) || strings.Count(resourceType, "@") != 1 {
+		return "", "", ErrInvalidResourceType
+	}
+
+	resourceName, apiVersion, _ := strings.Cut(resourceType, "@")
+	if resourceName == "" {
+		return "", "", ErrInvalidResourceType
+	}
+	if apiVersion == "" {
+		return "", "", ErrInvalidAPIVersion
+	}
+	return resourceName, apiVersion, nil
+}
+
+func propertyStatus(body types.TypeBase, property string) (PropertyStatus, bool) {
+	switch body := body.(type) {
+	case *types.ObjectType:
+		return objectPropertyStatus(body.Properties, property), true
+	case *types.DiscriminatedObjectType:
+		return objectPropertyStatus(body.BaseProperties, property), true
+	default:
+		return PropertyStatusUnknown, false
+	}
+}
+
+func objectPropertyStatus(properties map[string]types.ObjectProperty, property string) PropertyStatus {
+	propertyDefinition, ok := properties[property]
+	if !ok {
+		return PropertyStatusUnsupported
+	}
+	if propertyDefinition.IsReadOnly() {
+		return PropertyStatusReadOnly
+	}
+	return PropertyStatusWritable
+}

--- a/pkg/schema/schema_test.go
+++ b/pkg/schema/schema_test.go
@@ -1,0 +1,119 @@
+package schema_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/Azure/terraform-provider-azapi/pkg/schema"
+)
+
+func TestTopLevelPropertyStatus(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		resourceType string
+		property     string
+		want         schema.PropertyStatus
+	}{
+		"writable tags": {
+			resourceType: "Microsoft.Resources/resourceGroups@2021-04-01",
+			property:     "tags",
+			want:         schema.PropertyStatusWritable,
+		},
+		"unsupported tags": {
+			resourceType: "Microsoft.Authorization/roleAssignments@2022-04-01",
+			property:     "tags",
+			want:         schema.PropertyStatusUnsupported,
+		},
+		"read-only system data": {
+			resourceType: "Microsoft.Authorization/roleAssignments@2022-04-01",
+			property:     "systemData",
+			want:         schema.PropertyStatusReadOnly,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := schema.TopLevelPropertyStatus(test.resourceType, test.property)
+			if err != nil {
+				t.Fatalf("TopLevelPropertyStatus() error = %v", err)
+			}
+			if got != test.want {
+				t.Errorf("TopLevelPropertyStatus() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestTopLevelPropertyStatusUnavailableDefinition(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]string{
+		"unknown resource type": "Microsoft.Contoso/notAResource@2021-01-01",
+		"unknown API version":   "Microsoft.Resources/resourceGroups@1900-01-01",
+	}
+
+	for name, resourceType := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := schema.TopLevelPropertyStatus(resourceType, "tags")
+			if got != schema.PropertyStatusUnknown {
+				t.Errorf("TopLevelPropertyStatus() = %q, want %q", got, schema.PropertyStatusUnknown)
+			}
+			if !errors.Is(err, schema.ErrDefinitionUnavailable) {
+				t.Errorf("TopLevelPropertyStatus() error = %v, want ErrDefinitionUnavailable", err)
+			}
+		})
+	}
+}
+
+func TestTopLevelPropertyStatusInvalidInput(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		resourceType string
+		property     string
+		wantErr      error
+	}{
+		"empty resource type": {
+			wantErr: schema.ErrInvalidResourceType,
+		},
+		"missing API version separator": {
+			resourceType: "Microsoft.Resources/resourceGroups",
+			wantErr:      schema.ErrInvalidResourceType,
+		},
+		"empty resource name": {
+			resourceType: "@2021-04-01",
+			wantErr:      schema.ErrInvalidResourceType,
+		},
+		"empty API version": {
+			resourceType: "Microsoft.Resources/resourceGroups@",
+			wantErr:      schema.ErrInvalidAPIVersion,
+		},
+		"multiple API version separators": {
+			resourceType: "Microsoft.Resources/resourceGroups@2021-04-01@preview",
+			wantErr:      schema.ErrInvalidResourceType,
+		},
+		"empty property": {
+			resourceType: "Microsoft.Resources/resourceGroups@2021-04-01",
+			wantErr:      schema.ErrInvalidProperty,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := schema.TopLevelPropertyStatus(test.resourceType, test.property)
+			if got != schema.PropertyStatusUnknown {
+				t.Errorf("TopLevelPropertyStatus() = %q, want %q", got, schema.PropertyStatusUnknown)
+			}
+			if !errors.Is(err, test.wantErr) {
+				t.Errorf("TopLevelPropertyStatus() error = %v, want %v", err, test.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- expose a stable public API for top-level resource property capabilities
- source results from AzAPI's embedded generated Bicep schema definitions
- cover writable, read-only, unsupported, unknown, and invalid input cases

## Validation
- go test ./pkg/schema -count=1
- go vet ./pkg/schema
- go test ./internal/azure -run Test_AllBicepTypes -count=1 -timeout 30m