### PR TITLE
API version index skips: added Microsoft.Portal/dashboards 2026-04-01, removed Microsoft.Keyvault 2026-02-01 and 2026-03-01-preview

### DIFF
--- a/docs/resources/Microsoft.KeyVault_vaults_keys.md
+++ b/docs/resources/Microsoft.KeyVault_vaults_keys.md
@@ -139,7 +139,7 @@ resource "azapi_resource_action" "put_key" {
 
 The following arguments are supported:
 
-* `type` - (Required) The type of the resource. This should be set to `Microsoft.KeyVault/vaults/keys@api-version`. The available api-versions for this resource are: [`2019-09-01`, `2020-04-01-preview`, `2021-04-01-preview`, `2021-06-01-preview`, `2021-10-01`, `2021-11-01-preview`, `2022-02-01-preview`, `2022-07-01`, `2022-11-01`, `2023-02-01`, `2023-07-01`, `2024-04-01-preview`, `2024-11-01`, `2024-12-01-preview`, `2025-05-01`].
+* `type` - (Required) The type of the resource. This should be set to `Microsoft.KeyVault/vaults/keys@api-version`. The available api-versions for this resource are: [`2019-09-01`, `2020-04-01-preview`, `2021-04-01-preview`, `2021-06-01-preview`, `2021-10-01`, `2021-11-01-preview`, `2022-02-01-preview`, `2022-07-01`, `2022-11-01`, `2023-02-01`, `2023-07-01`, `2024-04-01-preview`, `2024-11-01`, `2024-12-01-preview`, `2025-05-01`, `2026-02-01`, `2026-03-01-preview`].
 
 * `parent_id` - (Required) The ID of the azure resource in which this resource is created. The allowed values are:  
   `/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.KeyVault/vaults/{resourceName}`
@@ -157,5 +157,5 @@ For other arguments, please refer to the [azapi_resource](https://registry.terra
  terraform import azapi_resource.example /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.KeyVault/vaults/{resourceName}/keys/{resourceName}
  
  # It also supports specifying API version by using the resource id with api-version as a query parameter, e.g.
- terraform import azapi_resource.example /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.KeyVault/vaults/{resourceName}/keys/{resourceName}?api-version=2025-05-01
+ terraform import azapi_resource.example /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.KeyVault/vaults/{resourceName}/keys/{resourceName}?api-version=2026-03-01-preview
  ```

--- a/docs/resources/Microsoft.KeyVault_vaults_secrets.md
+++ b/docs/resources/Microsoft.KeyVault_vaults_secrets.md
@@ -104,7 +104,7 @@ resource "azapi_resource_action" "put_secret" {
 
 The following arguments are supported:
 
-* `type` - (Required) The type of the resource. This should be set to `Microsoft.KeyVault/vaults/secrets@api-version`. The available api-versions for this resource are: [`2016-10-01`, `2018-02-14`, `2018-02-14-preview`, `2019-09-01`, `2020-04-01-preview`, `2021-04-01-preview`, `2021-06-01-preview`, `2021-10-01`, `2021-11-01-preview`, `2022-02-01-preview`, `2022-07-01`, `2022-11-01`, `2023-02-01`, `2023-07-01`, `2024-04-01-preview`, `2024-11-01`, `2024-12-01-preview`, `2025-05-01`].
+* `type` - (Required) The type of the resource. This should be set to `Microsoft.KeyVault/vaults/secrets@api-version`. The available api-versions for this resource are: [`2016-10-01`, `2018-02-14`, `2018-02-14-preview`, `2019-09-01`, `2020-04-01-preview`, `2021-04-01-preview`, `2021-06-01-preview`, `2021-10-01`, `2021-11-01-preview`, `2022-02-01-preview`, `2022-07-01`, `2022-11-01`, `2023-02-01`, `2023-07-01`, `2024-04-01-preview`, `2024-11-01`, `2024-12-01-preview`, `2025-05-01`, `2026-02-01`, `2026-03-01-preview`].
 
 * `parent_id` - (Required) The ID of the azure resource in which this resource is created. The allowed values are:  
   `/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.KeyVault/vaults/{resourceName}`
@@ -122,5 +122,5 @@ For other arguments, please refer to the [azapi_resource](https://registry.terra
  terraform import azapi_resource.example /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.KeyVault/vaults/{resourceName}/secrets/{resourceName}
  
  # It also supports specifying API version by using the resource id with api-version as a query parameter, e.g.
- terraform import azapi_resource.example /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.KeyVault/vaults/{resourceName}/secrets/{resourceName}?api-version=2025-05-01
+ terraform import azapi_resource.example /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.KeyVault/vaults/{resourceName}/secrets/{resourceName}?api-version=2026-03-01-preview
  ```

--- a/docs/resources/Microsoft.Portal_dashboards.md
+++ b/docs/resources/Microsoft.Portal_dashboards.md
@@ -68,7 +68,7 @@ resource "azapi_resource" "dashboard" {
 
 The following arguments are supported:
 
-* `type` - (Required) The type of the resource. This should be set to `Microsoft.Portal/dashboards@api-version`. The available api-versions for this resource are: [`2015-08-01-preview`, `2018-10-01-preview`, `2019-01-01-preview`, `2020-09-01-preview`, `2022-12-01-preview`, `2025-04-01-preview`, `2026-04-01`].
+* `type` - (Required) The type of the resource. This should be set to `Microsoft.Portal/dashboards@api-version`. The available api-versions for this resource are: [`2015-08-01-preview`, `2018-10-01-preview`, `2019-01-01-preview`, `2020-09-01-preview`, `2022-12-01-preview`, `2025-04-01-preview`].
 
 * `parent_id` - (Required) The ID of the azure resource in which this resource is created. The allowed values are:  
   `/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}`
@@ -86,5 +86,5 @@ For other arguments, please refer to the [azapi_resource](https://registry.terra
  terraform import azapi_resource.example /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Portal/dashboards/{resourceName}
  
  # It also supports specifying API version by using the resource id with api-version as a query parameter, e.g.
- terraform import azapi_resource.example /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Portal/dashboards/{resourceName}?api-version=2026-04-01
+ terraform import azapi_resource.example /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Portal/dashboards/{resourceName}?api-version=2025-04-01-preview
  ```

--- a/internal/azure/loader.go
+++ b/internal/azure/loader.go
@@ -41,8 +41,7 @@ func GetAzureSchema() *Schema {
 // in the schema but not yet supported by Azure, causing "NoRegisteredProviderFound" errors at runtime.
 // Key: resource type (case-insensitive, stored lowercase), Value: set of API versions to skip.
 var skipApiVersions = map[string]map[string]bool{
-	"microsoft.keyvault/vaults/keys":    {"2026-02-01": true, "2026-03-01-preview": true},
-	"microsoft.keyvault/vaults/secrets": {"2026-02-01": true, "2026-03-01-preview": true},
+	"microsoft.portal/dashboards": {"2026-04-01": true},
 }
 
 func GetApiVersions(resourceType string) []string {

--- a/internal/services/azapi_resource_move_state_test.go
+++ b/internal/services/azapi_resource_move_state_test.go
@@ -1,0 +1,103 @@
+package services_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/Azure/terraform-provider-azapi/internal/acceptance"
+	"github.com/Azure/terraform-provider-azapi/internal/clients"
+	"github.com/Azure/terraform-provider-azapi/internal/services/common"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccGenericResource_movePortalDashboardFromAzureRMUsesConfiguredApiVersion(t *testing.T) {
+	acceptance.SkipIfCoreAcctestsOnly(t, "Edge case: latest spec version runtime not yet functional")
+
+	data := acceptance.BuildTestData(t, "azapi_resource", "test")
+	r := GenericResource{}
+
+	defer func() {
+		client, err := acceptance.BuildTestClient()
+		if err != nil {
+			t.Errorf("building test client for cleanup: %+v", err)
+			return
+		}
+
+		resourceGroupID := fmt.Sprintf("/subscriptions/%s/resourceGroups/acctestRG-%d", client.Account.GetSubscriptionId(), data.RandomInteger)
+		_, _ = client.ResourceClient.Delete(context.Background(), resourceGroupID, "2023-07-01", clients.DefaultRequestOptions())
+	}()
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config:            r.portalDashboardAzureRM(data),
+			ExternalProviders: common.ExternalProvidersAzurermVersionFour(),
+		},
+		{
+			Config:             r.portalDashboardAzureRMMoved(data),
+			ExternalProviders:  common.ExternalProvidersAzurermVersionFour(),
+			ExpectNonEmptyPlan: false,
+		},
+	})
+}
+
+func (r GenericResource) portalDashboardAzureRM(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+provider "azurerm" {
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
+}
+
+resource "azurerm_portal_dashboard" "test" {
+  name                 = "acctest%[2]s"
+  resource_group_name  = azapi_resource.resourceGroup.name
+  location             = azapi_resource.resourceGroup.location
+  dashboard_properties = jsonencode({ lenses = {} })
+
+  tags = {
+    source = "acctest"
+  }
+}
+`, r.template(data), data.RandomString)
+}
+
+func (r GenericResource) portalDashboardAzureRMMoved(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+provider "azurerm" {
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
+}
+
+moved {
+  from = azurerm_portal_dashboard.test
+  to   = azapi_resource.test
+}
+
+resource "azapi_resource" "test" {
+  type      = "Microsoft.Portal/dashboards@2019-01-01-preview"
+  name      = "acctest%[2]s"
+  parent_id = azapi_resource.resourceGroup.id
+  location  = azapi_resource.resourceGroup.location
+
+  tags = {
+    source = "acctest"
+  }
+
+  body = {
+    properties = {
+      lenses = {}
+    }
+  }
+}
+`, r.template(data), data.RandomString)
+}


### PR DESCRIPTION
When moving Microsoft.Portal/dashboards from AzureRM to AzAPI, AzAPI MoveState function has no visibility of the intended API version, so it choses the latest indexed one 2026-02-01 which happen to not yet function (service team haven't completed deployment but already publishes the spec).

To address this the offending version is skipped in the hardcoded skip map.

While doing this I also notice there are outdated keyvault skips which is now functional, so they're removed.

## Testing

1. Added non-core acctest to reproduce the problem, tested working locally
2. Checked using az rest CLI the keyvault versions are now operational
3. Check for regression in acctest: https://github.com/Azure/terraform-provider-azapi/pull/1223/checks?check_run_id=98750380372

Fixes #1216