### PR TITLE
doc: acquire policy token: fix broken link

### DIFF
--- a/docs/guides/feature_acquire_policy_token.md
+++ b/docs/guides/feature_acquire_policy_token.md
@@ -24,7 +24,7 @@ The provider inspects the responses of HTTP requests. The flow is as follows:
 6. If no usable token is returned, the original policy denial is surfaced unchanged.
 
 <!-- Source: ../images/acquire_policy_token_reactive.mmd -- regenerate the SVG with mermaid-cli after editing it. -->
-![Reactive policy token acquisition flow](../images/acquire_policy_token_reactive.svg)
+![Reactive policy token acquisition flow](https://raw.githubusercontent.com/Azure/terraform-provider-azapi/refs/heads/main/docs/images/acquire_policy_token_reactive.svg)
 
 ## Always acquiring a policy token
 
@@ -41,7 +41,7 @@ provider "azapi" {
 This attribute defaults to `false` and can also be sourced from the `ARM_ALWAYS_ACQUIRE_POLICY_TOKEN` environment variable. Enabling it improves performance when the number of changed resources is known to be large beforehand. If a proactive acquisition does not return a usable token, the provider falls back to the reactive flow described above.
 
 <!-- Source: ../images/acquire_policy_token_proactive.mmd -- regenerate the SVG with mermaid-cli after editing it. -->
-![Proactive policy token acquisition flow](../images/acquire_policy_token_proactive.svg)
+![Proactive policy token acquisition flow](https://raw.githubusercontent.com/Azure/terraform-provider-azapi/refs/heads/main/docs/images/acquire_policy_token_proactive.svg)
 
 ## Limitations
 


### PR DESCRIPTION
Fixes broken image link in Terraform registry doc: https://registry.terraform.io/providers/Azure/azapi/latest/docs/guides/feature_acquire_policy_token.

Terraform registry doc does not allow images, so we use github-hosted raw URL instead.

<img width="1390" height="922" alt="image" src="https://github.com/user-attachments/assets/13188abc-497e-49dc-8139-c665189cd1dd" />
