### PR TITLE
feat: add support for creating evaluations and evaluation runs for Microsoft Foundry

### DIFF
--- a/docs/resources/data_plane_resource.md
+++ b/docs/resources/data_plane_resource.md
@@ -91,12 +91,15 @@ resource "azapi_data_plane_resource" "dataset" {
 - `create_query_parameters` (Map of List of String) A mapping of query parameters to be sent with the create request.
 - `delete_headers` (Map of String) A mapping of headers to be sent with the delete request.
 - `delete_query_parameters` (Map of List of String) A mapping of query parameters to be sent with the delete request.
+- `evaluation_id` (String) The ID of the evaluation for a Microsoft.Foundry evaluation run.
+
+	~> If the value of this attribute changes, Terraform will destroy and recreate the resource.
 - `ignore_casing` (Boolean) A dynamic attribute that contains the request body. Defaults to `false`.
 - `ignore_missing_property` (Boolean) Whether ignore not returned properties like credentials in `body` to suppress plan-diff. It's recommend to enable this option when some sensitive properties are not returned in response body, instead of setting them in `lifecycle.ignore_changes` because it will make the sensitive fields unable to update. Defaults to `true`.
 - `locks` (List of String) A list of ARM resource IDs which are used to avoid create/modify/delete azapi resources at the same time.
 
 	-> Element value must satisfy all validations: string length must be at least 1.
-- `name` (String) Specifies the name (identifier segment) of the data plane resource. Changing this forces a new resource to be created.
+- `name` (String) Specifies the name (identifier segment) of the data plane resource. For resource types where the service generates the identifier, this argument must not be set. Changing this forces a new resource to be created.
 
 	~> Once set, the value of this attribute in state will not change.
 
@@ -250,6 +253,8 @@ Optional:
 | Microsoft.DigitalTwins/digitalTwinsInstances/eventroutes | /eventroutes/{id} | {instanceName}.api.weu.digitaltwins.azure.net                                               |
 | Microsoft.DigitalTwins/digitalTwinsInstances/jobs/imports | /jobs/imports/{id} | {instanceName}.api.weu.digitaltwins.azure.net                                               |
 | Microsoft.Foundry/agents | /agents/{agentName} | {aiServicesId}.services.ai.azure.com/api/projects/{projectName}                             |
+| Microsoft.Foundry/evaluation/runs | /openai/v1/evals/{evalId}/runs/{runId} | {aiServicesId}.services.ai.azure.com/api/projects/{projectName}                             |
+| Microsoft.Foundry/evaluation/versions | /openai/v1/evals/{evalId} | {aiServicesId}.services.ai.azure.com/api/projects/{projectName}                             |
 | Microsoft.IoTCentral/IoTApps/organizations | /organizations/{organizationId} | {appSubdomain}.azureiotcentral.com                                                          |
 | Microsoft.IoTCentral/IoTApps/scheduledJobs | /scheduledJobs/{scheduledJobId} | {appSubdomain}.azureiotcentral.com                                                          |
 | Microsoft.IoTCentral/IoTApps/users | /users/{userId} | {appSubdomain}.azureiotcentral.com                                                          |
@@ -563,6 +568,94 @@ output "project_name" {
   value = azapi_resource.foundry_project.name
 }
 ```
+
+### Microsoft.Foundry/evaluation/runs
+
+```terraform
+resource "azapi_data_plane_resource" "evaluation_run" {
+  type = "Microsoft.Foundry/evaluation/runs@2025-05-01"
+
+  parent_id = "foundry-account-id.services.ai.azure.com/api/projects/foundry-project-id"
+
+  evaluation_id = "eval_id"
+
+  body = {
+    name = "evaluation-run-name"
+
+    data_source = {
+      type = "azure_ai_target_completions"
+
+      source = {
+        type = "file_id"
+        id   = "azureai://accounts/foundry-account-id/projects/foundry-project-id/data/dataset/versions/1"
+      }
+
+      input_messages = {
+        type = "template"
+
+        template = [{
+          role    = "user"
+          content = "{{item.input}}"
+        }]
+      }
+
+      target = {
+        type = "azure_ai_agent"
+        name = "agent-name"
+      }
+    }
+
+    evaluation_level = "turn"
+  }
+}```
+
+### Microsoft.Foundry/evaluation/versions
+
+```terraform
+resource "azapi_data_plane_resource" "evaluation" {
+  type = "Microsoft.Foundry/evaluation/versions@2025-05-01"
+
+  parent_id = "foundry-account-id.services.ai.azure.com/api/projects/foundry-project-id"
+
+  body = {
+    name = "evaluation-name"
+
+    data_source_config = {
+      type = "custom"
+
+      item_schema = {
+        type = "object"
+
+        properties = {
+          input           = { type = "string" }
+          expected_output = { type = "string" }
+        }
+
+        required = []
+      }
+
+      include_sample_schema = false
+    }
+
+    testing_criteria = [{
+      type           = "azure_ai_evaluator"
+      name           = "TaskCompletion"
+      evaluator_name = "builtin.task_completion"
+
+      data_mapping = {
+        query            = "{{item.input}}"
+        response         = "{{sample.output_text}}"
+        ground_truth     = "{{item.expected_output}}"
+        tool_calls       = "{{sample.tool_calls}}"
+        tool_definitions = "{{sample.tool_definitions}}"
+      }
+
+      initialization_parameters = {
+        deployment_name = "gpt5.4-nano"
+      }
+    }]
+  }
+}```
 
 ### Microsoft.IoTCentral/IoTApps/users
 

--- a/examples/resources/azapi_data_plane_resource/Microsoft.Foundry_evaluation/main.tf
+++ b/examples/resources/azapi_data_plane_resource/Microsoft.Foundry_evaluation/main.tf
@@ -1,0 +1,44 @@
+resource "azapi_data_plane_resource" "evaluation" {
+  type = "Microsoft.Foundry/evaluation/versions@2025-05-01"
+
+  parent_id = "foundry-account-id.services.ai.azure.com/api/projects/foundry-project-id"
+
+  body = {
+    name = "evaluation-name"
+
+    data_source_config = {
+      type = "custom"
+
+      item_schema = {
+        type = "object"
+
+        properties = {
+          input           = { type = "string" }
+          expected_output = { type = "string" }
+        }
+
+        required = []
+      }
+
+      include_sample_schema = false
+    }
+
+    testing_criteria = [{
+      type           = "azure_ai_evaluator"
+      name           = "TaskCompletion"
+      evaluator_name = "builtin.task_completion"
+
+      data_mapping = {
+        query            = "{{item.input}}"
+        response         = "{{sample.output_text}}"
+        ground_truth     = "{{item.expected_output}}"
+        tool_calls       = "{{sample.tool_calls}}"
+        tool_definitions = "{{sample.tool_definitions}}"
+      }
+
+      initialization_parameters = {
+        deployment_name = "gpt5.4-nano"
+      }
+    }]
+  }
+}

--- a/examples/resources/azapi_data_plane_resource/Microsoft.Foundry_evaluation_run/main.tf
+++ b/examples/resources/azapi_data_plane_resource/Microsoft.Foundry_evaluation_run/main.tf
@@ -1,0 +1,36 @@
+resource "azapi_data_plane_resource" "evaluation_run" {
+  type = "Microsoft.Foundry/evaluation/runs@2025-05-01"
+
+  parent_id = "foundry-account-id.services.ai.azure.com/api/projects/foundry-project-id"
+
+  evaluation_id = "eval_id"
+
+  body = {
+    name = "evaluation-run-name"
+
+    data_source = {
+      type = "azure_ai_target_completions"
+
+      source = {
+        type = "file_id"
+        id   = "azureai://accounts/foundry-account-id/projects/foundry-project-id/data/dataset/versions/1"
+      }
+
+      input_messages = {
+        type = "template"
+
+        template = [{
+          role    = "user"
+          content = "{{item.input}}"
+        }]
+      }
+
+      target = {
+        type = "azure_ai_agent"
+        name = "agent-name"
+      }
+    }
+
+    evaluation_level = "turn"
+  }
+}

--- a/internal/clients/data_plane_client.go
+++ b/internal/clients/data_plane_client.go
@@ -151,7 +151,9 @@ func buildRequest(ctx context.Context, options RequestOptions, urlPath, method, 
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", apiVersion)
+	if apiVersion != "" {
+		reqQP.Set("api-version", apiVersion)
+	}
 	for key, value := range options.QueryParameters {
 		reqQP.Set(key, value)
 	}

--- a/internal/clients/data_plane_client.go
+++ b/internal/clients/data_plane_client.go
@@ -87,8 +87,19 @@ func (client *DataPlaneClient) DeleteThenPoll(ctx context.Context, id parse.Data
 }
 
 func (client *DataPlaneClient) Action(ctx context.Context, resourceID string, action string, apiVersion string, method string, body interface{}, options RequestOptions) (interface{}, error) {
+	return client.action(ctx, resourceID, action, apiVersion, method, body, options, buildRequest)
+}
+
+// ActionWithoutAPIVersion invokes a data-plane action without adding the
+// default api-version query parameter. This is used by APIs whose endpoint
+// version is part of the path, such as Foundry evaluation APIs.
+func (client *DataPlaneClient) ActionWithoutAPIVersion(ctx context.Context, resourceID string, action string, method string, body interface{}, options RequestOptions) (interface{}, error) {
+	return client.action(ctx, resourceID, action, "", method, body, options, buildRequestWithoutAPIVersion)
+}
+
+func (client *DataPlaneClient) action(ctx context.Context, resourceID string, action string, apiVersion string, method string, body interface{}, options RequestOptions, requestBuilder func(context.Context, RequestOptions, string, string, string) (*policy.Request, error)) (interface{}, error) {
 	urlPath := buildURL(resourceID, action)
-	req, err := buildRequest(ctx, options, urlPath, method, apiVersion)
+	req, err := requestBuilder(ctx, options, urlPath, method, apiVersion)
 	if err != nil {
 		return nil, err
 	}
@@ -143,6 +154,14 @@ func buildURL(resourceId string, action string) (urlPath string) {
 }
 
 func buildRequest(ctx context.Context, options RequestOptions, urlPath, method, apiVersion string) (*policy.Request, error) {
+	return buildRequestWithAPIVersion(ctx, options, urlPath, method, apiVersion, true)
+}
+
+func buildRequestWithoutAPIVersion(ctx context.Context, options RequestOptions, urlPath, method, apiVersion string) (*policy.Request, error) {
+	return buildRequestWithAPIVersion(ctx, options, urlPath, method, apiVersion, false)
+}
+
+func buildRequestWithAPIVersion(ctx context.Context, options RequestOptions, urlPath, method, apiVersion string, includeAPIVersion bool) (*policy.Request, error) {
 	if options.RetryOptions != nil {
 		ctx = policy.WithRetryOptions(ctx, *options.RetryOptions)
 	}
@@ -151,7 +170,7 @@ func buildRequest(ctx context.Context, options RequestOptions, urlPath, method, 
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
-	if apiVersion != "" {
+	if includeAPIVersion {
 		reqQP.Set("api-version", apiVersion)
 	}
 	for key, value := range options.QueryParameters {

--- a/internal/clients/data_plane_client_test.go
+++ b/internal/clients/data_plane_client_test.go
@@ -1,0 +1,69 @@
+package clients
+
+import (
+	"context"
+	"net/http"
+	"testing"
+)
+
+func TestBuildRequestAPIParameters(t *testing.T) {
+	t.Run("original builder preserves empty API version", func(t *testing.T) {
+		request, err := buildRequest(
+			context.Background(),
+			RequestOptions{
+				QueryParameters: map[string]string{"foo": "bar"},
+			},
+			"https://example.com/resource?existing=value",
+			http.MethodGet,
+			"",
+		)
+		if err != nil {
+			t.Fatalf("building request: %v", err)
+		}
+
+		query := request.Raw().URL.Query()
+		if _, exists := query["api-version"]; !exists {
+			t.Fatal("expected original builder to include the API version parameter")
+		}
+		if got := query.Get("existing"); got != "value" {
+			t.Fatalf("expected existing query parameter, got %q", got)
+		}
+		if got := query.Get("foo"); got != "bar" {
+			t.Fatalf("expected custom query parameter, got %q", got)
+		}
+	})
+
+	t.Run("Foundry builder omits API version", func(t *testing.T) {
+		request, err := buildRequestWithoutAPIVersion(
+			context.Background(),
+			RequestOptions{},
+			"https://example.com/resource",
+			http.MethodGet,
+			"",
+		)
+		if err != nil {
+			t.Fatalf("building request: %v", err)
+		}
+
+		if _, exists := request.Raw().URL.Query()["api-version"]; exists {
+			t.Fatal("expected Foundry builder to omit the API version parameter")
+		}
+	})
+
+	t.Run("sets API version", func(t *testing.T) {
+		request, err := buildRequest(
+			context.Background(),
+			RequestOptions{},
+			"https://example.com/resource",
+			http.MethodGet,
+			"2025-05-01",
+		)
+		if err != nil {
+			t.Fatalf("building request: %v", err)
+		}
+
+		if got := request.Raw().URL.Query().Get("api-version"); got != "2025-05-01" {
+			t.Fatalf("expected API version, got %q", got)
+		}
+	})
+}

--- a/internal/services/azapi_data_plane_resource.go
+++ b/internal/services/azapi_data_plane_resource.go
@@ -634,33 +634,40 @@ func getCreateResultFunc(config *DataPlaneResourceModel) (customization.CreateRe
 	return nil, false
 }
 
-func validateDataPlaneResourceName(config *DataPlaneResourceModel) error {
-	if config == nil || config.Type.IsNull() || config.Type.IsUnknown() {
-		return nil
+func isFoundryEvaluationType(typeValue string) bool {
+	typeValue = strings.TrimSpace(typeValue)
+
+	if index := strings.IndexByte(typeValue, '@'); index >= 0 {
+		typeValue = typeValue[:index]
 	}
 
+	switch strings.ToLower(typeValue) {
+	case "microsoft.foundry/evaluation/versions",
+		"microsoft.foundry/evaluation/runs":
+		return true
+	default:
+		return false
+	}
+}
+
+func validateDataPlaneResourceName(config *DataPlaneResourceModel) error {
 	if config.Name.IsUnknown() {
 		return nil
 	}
 
-	nameIsEmpty := config.Name.IsNull() || strings.TrimSpace(config.Name.ValueString()) == ""
-	resourceType := strings.Split(config.Type.ValueString(), "@")[0]
-	if _, ok := getCreateResultFunc(config); ok {
-		// A resource exposing CreateResultFunc has a service-generated name, so "name" must not be set. See PR #1053.
-		if !nameIsEmpty {
-			return fmt.Errorf(`the argument "name" should not be set for resource type %q because the service generates the identifier`, resourceType)
+	if config.Name.IsNull() || strings.TrimSpace(config.Name.ValueString()) == "" {
+		// Foundry evaluations are created with POST /openai/v1/evals.
+		// The service generates the evaluation ID.
+		if isFoundryEvaluationType(config.Type.ValueString()) {
+			return nil
 		}
-		return nil
+
+		return fmt.Errorf(
+			`the argument "name" must be set for resource type "%s"`,
+			strings.SplitN(config.Type.ValueString(), "@", 2)[0],
+		)
 	}
-	if !parse.HasNameSegment(config.Type.ValueString()) {
-		if !nameIsEmpty {
-			return fmt.Errorf(`the argument "name" should not be set for resource type %q because this resource type does not have a name`, resourceType)
-		}
-		return nil
-	}
-	if nameIsEmpty {
-		return fmt.Errorf(`the argument "name" must be set for resource type %q`, resourceType)
-	}
+
 	return nil
 }
 
@@ -814,6 +821,12 @@ func validateDataPlaneResourceEvaluationID(config *DataPlaneResourceModel) error
 	if config.EvaluationID.IsUnknown() {
 		return nil
 	}
+
+	if config.EvaluationID.IsNull() || strings.TrimSpace(config.EvaluationID.ValueString()) == "" {
+		return fmt.Errorf(`the argument "evaluation_id" must be set for resource type %q`, strings.Split(config.Type.ValueString(), "@")[0])
+	}
+
+	return nil
 
 	if config.EvaluationID.IsNull() || strings.TrimSpace(config.EvaluationID.ValueString()) == "" {
 		return fmt.Errorf(`the argument "evaluation_id" must be set for resource type %q`, strings.Split(config.Type.ValueString(), "@")[0])

--- a/internal/services/azapi_data_plane_resource.go
+++ b/internal/services/azapi_data_plane_resource.go
@@ -44,6 +44,7 @@ import (
 type DataPlaneResourceModel struct {
 	ID                            types.String     `tfsdk:"id"`
 	Name                          types.String     `tfsdk:"name"`
+	EvaluationID                  types.String     `tfsdk:"evaluation_id"`
 	ParentID                      types.String     `tfsdk:"parent_id"`
 	Type                          types.String     `tfsdk:"type"`
 	Body                          types.Dynamic    `tfsdk:"body"`
@@ -118,6 +119,14 @@ func (r *DataPlaneResource) Schema(ctx context.Context, request resource.SchemaR
 					stringplanmodifier.RequiresReplace(),
 				},
 				MarkdownDescription: "Specifies the name (identifier segment) of the data plane resource. Changing this forces a new resource to be created.",
+			},
+
+			"evaluation_id": schema.StringAttribute{
+				Optional: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+				MarkdownDescription: "The ID of the evaluation for a Microsoft.Foundry evaluation run.",
 			},
 
 			"parent_id": schema.StringAttribute{
@@ -327,6 +336,10 @@ func (r *DataPlaneResource) ModifyPlan(ctx context.Context, request resource.Mod
 		response.Diagnostics.AddError("Invalid configuration", err.Error())
 		return
 	}
+	if err := validateDataPlaneResourceEvaluationID(config); err != nil {
+		response.Diagnostics.AddError("Invalid configuration", err.Error())
+		return
+	}
 
 	if state == nil || !plan.ResponseExportValues.Equal(state.ResponseExportValues) || !dynamic.SemanticallyEqual(plan.Body, state.Body) {
 		plan.Output = basetypes.NewDynamicUnknown()
@@ -424,6 +437,10 @@ func (r *DataPlaneResource) CreateUpdate(ctx context.Context, requestConfig tfsd
 		diagnostics.AddError("Invalid configuration", err.Error())
 		return
 	}
+	if err := validateDataPlaneResourceEvaluationID(config); err != nil {
+		diagnostics.AddError("Invalid configuration", err.Error())
+		return
+	}
 
 	isNewResource := responseState == nil || responseState.Raw.IsNull()
 	createResultFunc, hasCreateResult := getCreateResultFunc(plan)
@@ -433,7 +450,12 @@ func (r *DataPlaneResource) CreateUpdate(ctx context.Context, requestConfig tfsd
 		resourceName = "__generated__"
 	}
 
-	id, err := parse.NewDataPlaneResourceId(resourceName, plan.ParentID.ValueString(), plan.Type.ValueString())
+	id, err := parse.NewDataPlaneResourceIdWithEvaluationID(
+		resourceName,
+		plan.ParentID.ValueString(),
+		plan.EvaluationID.ValueString(),
+		plan.Type.ValueString(),
+	)
 	if err != nil {
 		diagnostics.AddError("Invalid configuration", err.Error())
 		return
@@ -569,6 +591,11 @@ func (r *DataPlaneResource) CreateUpdate(ctx context.Context, requestConfig tfsd
 
 	plan.ID = basetypes.NewStringValue(id.ID())
 	plan.Name = basetypes.NewStringValue(id.Name)
+	if id.EvaluationId != "" {
+		plan.EvaluationID = basetypes.NewStringValue(id.EvaluationId)
+	} else {
+		plan.EvaluationID = types.StringNull()
+	}
 	plan.ParentID = basetypes.NewStringValue(id.ParentId)
 	plan.Type = basetypes.NewStringValue(fmt.Sprintf("%s@%s", id.AzureResourceType, id.ApiVersion))
 
@@ -722,6 +749,11 @@ func (r *DataPlaneResource) Read(ctx context.Context, request resource.ReadReque
 	}
 
 	model.Name = basetypes.NewStringValue(id.Name)
+	if id.EvaluationId != "" {
+		model.EvaluationID = basetypes.NewStringValue(id.EvaluationId)
+	} else {
+		model.EvaluationID = types.StringNull()
+	}
 	model.ParentID = basetypes.NewStringValue(id.ParentId)
 	model.Type = basetypes.NewStringValue(fmt.Sprintf("%s@%s", id.AzureResourceType, id.ApiVersion))
 
@@ -743,6 +775,9 @@ func (r *DataPlaneResource) ImportState(ctx context.Context, request resource.Im
 
 	response.Diagnostics.Append(response.State.SetAttribute(ctx, path.Root("id"), id.ID())...)
 	response.Diagnostics.Append(response.State.SetAttribute(ctx, path.Root("name"), id.Name)...)
+	if id.EvaluationId != "" {
+		response.Diagnostics.Append(response.State.SetAttribute(ctx, path.Root("evaluation_id"), id.EvaluationId)...)
+	}
 	response.Diagnostics.Append(response.State.SetAttribute(ctx, path.Root("parent_id"), id.ParentId)...)
 	response.Diagnostics.Append(response.State.SetAttribute(ctx, path.Root("type"), fmt.Sprintf("%s@%s", id.AzureResourceType, id.ApiVersion))...)
 }
@@ -764,6 +799,27 @@ func parseDataPlaneImportID(input string) (string, string, error) {
 	}
 
 	return resourceID, resourceType, nil
+}
+
+func validateDataPlaneResourceEvaluationID(config *DataPlaneResourceModel) error {
+	if config == nil || config.Type.IsNull() || config.Type.IsUnknown() {
+		return nil
+	}
+
+	resourceType := strings.ToLower(strings.Split(config.Type.ValueString(), "@")[0])
+	if resourceType != "microsoft.foundry/evaluation/runs" {
+		return nil
+	}
+
+	if config.EvaluationID.IsUnknown() {
+		return nil
+	}
+
+	if config.EvaluationID.IsNull() || strings.TrimSpace(config.EvaluationID.ValueString()) == "" {
+		return fmt.Errorf(`the argument "evaluation_id" must be set for resource type %q`, strings.Split(config.Type.ValueString(), "@")[0])
+	}
+
+	return nil
 }
 
 func (r *DataPlaneResource) Delete(ctx context.Context, request resource.DeleteRequest, response *resource.DeleteResponse) {

--- a/internal/services/azapi_data_plane_resource.go
+++ b/internal/services/azapi_data_plane_resource.go
@@ -118,7 +118,7 @@ func (r *DataPlaneResource) Schema(ctx context.Context, request resource.SchemaR
 					stringplanmodifier.UseStateForUnknown(),
 					stringplanmodifier.RequiresReplace(),
 				},
-				MarkdownDescription: "Specifies the name (identifier segment) of the data plane resource. Changing this forces a new resource to be created.",
+				MarkdownDescription: "Specifies the name (identifier segment) of the data plane resource. For resource types where the service generates the identifier, this argument must not be set. Changing this forces a new resource to be created.",
 			},
 
 			"evaluation_id": schema.StringAttribute{
@@ -634,40 +634,33 @@ func getCreateResultFunc(config *DataPlaneResourceModel) (customization.CreateRe
 	return nil, false
 }
 
-func isFoundryEvaluationType(typeValue string) bool {
-	typeValue = strings.TrimSpace(typeValue)
-
-	if index := strings.IndexByte(typeValue, '@'); index >= 0 {
-		typeValue = typeValue[:index]
-	}
-
-	switch strings.ToLower(typeValue) {
-	case "microsoft.foundry/evaluation/versions",
-		"microsoft.foundry/evaluation/runs":
-		return true
-	default:
-		return false
-	}
-}
-
 func validateDataPlaneResourceName(config *DataPlaneResourceModel) error {
+	if config == nil || config.Type.IsNull() || config.Type.IsUnknown() {
+		return nil
+	}
+
 	if config.Name.IsUnknown() {
 		return nil
 	}
 
-	if config.Name.IsNull() || strings.TrimSpace(config.Name.ValueString()) == "" {
-		// Foundry evaluations are created with POST /openai/v1/evals.
-		// The service generates the evaluation ID.
-		if isFoundryEvaluationType(config.Type.ValueString()) {
-			return nil
+	nameIsEmpty := config.Name.IsNull() || strings.TrimSpace(config.Name.ValueString()) == ""
+	resourceType := strings.SplitN(config.Type.ValueString(), "@", 2)[0]
+	if _, ok := getCreateResultFunc(config); ok {
+		if !nameIsEmpty {
+			return fmt.Errorf(`the argument "name" should not be set for resource type %q because the service generates the identifier`, resourceType)
 		}
-
-		return fmt.Errorf(
-			`the argument "name" must be set for resource type "%s"`,
-			strings.SplitN(config.Type.ValueString(), "@", 2)[0],
-		)
+		return nil
 	}
 
+	if !parse.HasNameSegment(config.Type.ValueString()) {
+		if !nameIsEmpty {
+			return fmt.Errorf(`the argument "name" should not be set for resource type %q because this resource type does not have a name`, resourceType)
+		}
+		return nil
+	}
+	if nameIsEmpty {
+		return fmt.Errorf(`the argument "name" must be set for resource type %q`, resourceType)
+	}
 	return nil
 }
 
@@ -823,13 +816,7 @@ func validateDataPlaneResourceEvaluationID(config *DataPlaneResourceModel) error
 	}
 
 	if config.EvaluationID.IsNull() || strings.TrimSpace(config.EvaluationID.ValueString()) == "" {
-		return fmt.Errorf(`the argument "evaluation_id" must be set for resource type %q`, strings.Split(config.Type.ValueString(), "@")[0])
-	}
-
-	return nil
-
-	if config.EvaluationID.IsNull() || strings.TrimSpace(config.EvaluationID.ValueString()) == "" {
-		return fmt.Errorf(`the argument "evaluation_id" must be set for resource type %q`, strings.Split(config.Type.ValueString(), "@")[0])
+		return fmt.Errorf(`the argument "evaluation_id" must be set for resource type %q`, strings.SplitN(config.Type.ValueString(), "@", 2)[0])
 	}
 
 	return nil

--- a/internal/services/azapi_data_plane_resource.go
+++ b/internal/services/azapi_data_plane_resource.go
@@ -806,17 +806,21 @@ func validateDataPlaneResourceEvaluationID(config *DataPlaneResourceModel) error
 		return nil
 	}
 
-	resourceType := strings.ToLower(strings.Split(config.Type.ValueString(), "@")[0])
-	if resourceType != "microsoft.foundry/evaluation/runs" {
-		return nil
-	}
-
 	if config.EvaluationID.IsUnknown() {
 		return nil
 	}
 
-	if config.EvaluationID.IsNull() || strings.TrimSpace(config.EvaluationID.ValueString()) == "" {
-		return fmt.Errorf(`the argument "evaluation_id" must be set for resource type %q`, strings.SplitN(config.Type.ValueString(), "@", 2)[0])
+	evaluationIDIsEmpty := config.EvaluationID.IsNull() || strings.TrimSpace(config.EvaluationID.ValueString()) == ""
+	resourceType := strings.SplitN(config.Type.ValueString(), "@", 2)[0]
+	if !parse.HasEvaluationIdSegment(config.Type.ValueString()) {
+		if !evaluationIDIsEmpty {
+			return fmt.Errorf(`the argument "evaluation_id" should not be set for resource type %q because this resource type does not use an evaluation ID`, resourceType)
+		}
+		return nil
+	}
+
+	if evaluationIDIsEmpty {
+		return fmt.Errorf(`the argument "evaluation_id" must be set for resource type %q`, resourceType)
 	}
 
 	return nil

--- a/internal/services/azapi_data_plane_resource_import_test.go
+++ b/internal/services/azapi_data_plane_resource_import_test.go
@@ -2,6 +2,8 @@ package services
 
 import (
 	"testing"
+
+	"github.com/Azure/terraform-provider-azapi/internal/services/parse"
 )
 
 func TestParseDataPlaneImportID(t *testing.T) {
@@ -29,6 +31,29 @@ func TestParseDataPlaneImportID(t *testing.T) {
 		_, _, err := parseDataPlaneImportID("host/api/projects/project/agents/agent|Microsoft.Foundry/agents")
 		if err == nil {
 			t.Fatalf("expected error")
+		}
+	})
+
+	t.Run("foundry evaluation run", func(t *testing.T) {
+		resourceID, resourceType, err := parseDataPlaneImportID(
+			"host/api/projects/project/openai/v1/evals/eval_123/runs/run_456|Microsoft.Foundry/evaluation/runs@2025-05-01",
+		)
+		if err != nil {
+			t.Fatalf("expected nil error, got: %v", err)
+		}
+
+		id, err := parse.DataPlaneResourceIDWithResourceType(resourceID, resourceType)
+		if err != nil {
+			t.Fatalf("expected evaluation run ID to parse, got: %v", err)
+		}
+		if id.Name != "run_456" {
+			t.Fatalf("unexpected run ID: %q", id.Name)
+		}
+		if id.EvaluationId != "eval_123" {
+			t.Fatalf("unexpected evaluation ID: %q", id.EvaluationId)
+		}
+		if id.ParentId != "host/api/projects/project" {
+			t.Fatalf("unexpected parent: %q", id.ParentId)
 		}
 	})
 }

--- a/internal/services/azapi_data_plane_resource_name_validation_test.go
+++ b/internal/services/azapi_data_plane_resource_name_validation_test.go
@@ -150,4 +150,34 @@ func TestValidateDataPlaneResourceEvaluationID(t *testing.T) {
 			t.Fatalf("expected nil error, got: %v", err)
 		}
 	})
+
+	t.Run("evaluation version rejects evaluation ID", func(t *testing.T) {
+		config := &DataPlaneResourceModel{
+			Type:         types.StringValue("Microsoft.Foundry/evaluation/versions@2025-05-01"),
+			EvaluationID: types.StringValue("eval_123"),
+		}
+
+		err := validateDataPlaneResourceEvaluationID(config)
+		if err == nil {
+			t.Fatal("expected validation error")
+		}
+		if !strings.Contains(err.Error(), "should not be set") {
+			t.Fatalf("expected unsupported evaluation ID error, got: %v", err)
+		}
+	})
+
+	t.Run("non-Foundry resource rejects evaluation ID", func(t *testing.T) {
+		config := &DataPlaneResourceModel{
+			Type:         types.StringValue("Microsoft.KeyVault/vaults/secrets@7.4"),
+			EvaluationID: types.StringValue("eval_123"),
+		}
+
+		err := validateDataPlaneResourceEvaluationID(config)
+		if err == nil {
+			t.Fatal("expected validation error")
+		}
+		if !strings.Contains(err.Error(), "should not be set") {
+			t.Fatalf("expected unsupported evaluation ID error, got: %v", err)
+		}
+	})
 }

--- a/internal/services/azapi_data_plane_resource_name_validation_test.go
+++ b/internal/services/azapi_data_plane_resource_name_validation_test.go
@@ -59,4 +59,95 @@ func TestValidateDataPlaneResourceName(t *testing.T) {
 			t.Fatalf("expected nil error, got: %v", err)
 		}
 	})
+
+	t.Run("foundry evaluation generates name", func(t *testing.T) {
+		config := &DataPlaneResourceModel{
+			Type: types.StringValue("Microsoft.Foundry/evaluation/versions@2025-05-01"),
+			Name: types.StringNull(),
+		}
+
+		if err := validateDataPlaneResourceName(config); err != nil {
+			t.Fatalf("expected nil error, got: %v", err)
+		}
+	})
+
+	t.Run("foundry evaluation rejects configured name", func(t *testing.T) {
+		config := &DataPlaneResourceModel{
+			Type: types.StringValue("Microsoft.Foundry/evaluation/versions@2025-05-01"),
+			Name: types.StringValue("evaluation-name"),
+		}
+
+		err := validateDataPlaneResourceName(config)
+		if err == nil {
+			t.Fatal("expected validation error")
+		}
+		if !strings.Contains(err.Error(), "should not be set") {
+			t.Fatalf("expected generated-name error, got: %v", err)
+		}
+	})
+
+	t.Run("foundry evaluation run generates name", func(t *testing.T) {
+		config := &DataPlaneResourceModel{
+			Type: types.StringValue("Microsoft.Foundry/evaluation/runs@2025-05-01"),
+			Name: types.StringNull(),
+		}
+
+		if err := validateDataPlaneResourceName(config); err != nil {
+			t.Fatalf("expected nil error, got: %v", err)
+		}
+	})
+
+	t.Run("foundry evaluation run rejects configured name", func(t *testing.T) {
+		config := &DataPlaneResourceModel{
+			Type: types.StringValue("Microsoft.Foundry/evaluation/runs@2025-05-01"),
+			Name: types.StringValue("run-name"),
+		}
+
+		err := validateDataPlaneResourceName(config)
+		if err == nil {
+			t.Fatal("expected validation error")
+		}
+		if !strings.Contains(err.Error(), "should not be set") {
+			t.Fatalf("expected generated-name error, got: %v", err)
+		}
+	})
+}
+
+func TestValidateDataPlaneResourceEvaluationID(t *testing.T) {
+	t.Run("evaluation run requires evaluation ID", func(t *testing.T) {
+		config := &DataPlaneResourceModel{
+			Type:         types.StringValue("Microsoft.Foundry/evaluation/runs@2025-05-01"),
+			EvaluationID: types.StringNull(),
+		}
+
+		err := validateDataPlaneResourceEvaluationID(config)
+		if err == nil {
+			t.Fatal("expected validation error")
+		}
+		if !strings.Contains(err.Error(), "evaluation_id") {
+			t.Fatalf("expected evaluation_id error, got: %v", err)
+		}
+	})
+
+	t.Run("evaluation run accepts evaluation ID", func(t *testing.T) {
+		config := &DataPlaneResourceModel{
+			Type:         types.StringValue("Microsoft.Foundry/evaluation/runs@2025-05-01"),
+			EvaluationID: types.StringValue("eval_123"),
+		}
+
+		if err := validateDataPlaneResourceEvaluationID(config); err != nil {
+			t.Fatalf("expected nil error, got: %v", err)
+		}
+	})
+
+	t.Run("evaluation version ignores evaluation ID", func(t *testing.T) {
+		config := &DataPlaneResourceModel{
+			Type:         types.StringValue("Microsoft.Foundry/evaluation/versions@2025-05-01"),
+			EvaluationID: types.StringNull(),
+		}
+
+		if err := validateDataPlaneResourceEvaluationID(config); err != nil {
+			t.Fatalf("expected nil error, got: %v", err)
+		}
+	})
 }

--- a/internal/services/customization/foundry_evaluation_customization.go
+++ b/internal/services/customization/foundry_evaluation_customization.go
@@ -80,11 +80,10 @@ func (c FoundryEvaluationCustomization) CreateResultFunc() CreateResultFunc {
 		body interface{},
 		options clients.RequestOptions,
 	) (parse.DataPlaneResourceId, interface{}, error) {
-		responseBody, err := client.DataPlaneClient.Action(
+		responseBody, err := client.DataPlaneClient.ActionWithoutAPIVersion(
 			ctx,
 			foundryEvaluationCollectionID(id.ParentId),
 			"",
-			"", // /openai/v1 endpoints must not receive api-version
 			http.MethodPost,
 			body,
 			options,
@@ -118,11 +117,10 @@ func (c FoundryEvaluationCustomization) ReadFunc() ReadFunc {
 		id parse.DataPlaneResourceId,
 		options clients.RequestOptions,
 	) (interface{}, error) {
-		return client.DataPlaneClient.Action(
+		return client.DataPlaneClient.ActionWithoutAPIVersion(
 			ctx,
 			id.AzureResourceId,
 			"",
-			"", // /openai/v1 endpoints must not receive api-version
 			http.MethodGet,
 			nil,
 			options,
@@ -143,11 +141,10 @@ func (c FoundryEvaluationCustomization) UpdateFunc() UpdateFunc {
 			return err
 		}
 
-		_, err = client.DataPlaneClient.Action(
+		_, err = client.DataPlaneClient.ActionWithoutAPIVersion(
 			ctx,
 			id.AzureResourceId,
 			"",
-			"", // /openai/v1 endpoints must not receive api-version
 			http.MethodPost,
 			requestBody,
 			options,
@@ -163,11 +160,10 @@ func (c FoundryEvaluationCustomization) DeleteFunc() DeleteFunc {
 		id parse.DataPlaneResourceId,
 		options clients.RequestOptions,
 	) error {
-		_, err := client.DataPlaneClient.Action(
+		_, err := client.DataPlaneClient.ActionWithoutAPIVersion(
 			ctx,
 			id.AzureResourceId,
 			"",
-			"", // /openai/v1 endpoints must not receive api-version
 			http.MethodDelete,
 			nil,
 			options,

--- a/internal/services/customization/foundry_evaluation_customization.go
+++ b/internal/services/customization/foundry_evaluation_customization.go
@@ -1,0 +1,180 @@
+package customization
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/Azure/terraform-provider-azapi/internal/clients"
+	"github.com/Azure/terraform-provider-azapi/internal/services/parse"
+)
+
+// FoundryEvaluationCustomization supports Foundry evaluations, which use a
+// collection POST for creation and a generated evaluation ID for later calls.
+//
+// Create: POST {endpoint}/openai/v1/evals
+// Get:    GET  {endpoint}/openai/v1/evals/{evalID}
+// Update: POST {endpoint}/openai/v1/evals/{evalID}
+// Delete: DELETE {endpoint}/openai/v1/evals/{evalID}
+type FoundryEvaluationCustomization struct{}
+
+const foundryEvaluationCollectionPath = "/openai/v1/evals"
+
+func (c FoundryEvaluationCustomization) GetResourceType() string {
+	return "Microsoft.Foundry/evaluation/versions"
+}
+
+func (c FoundryEvaluationCustomization) CreateFunc() CreateFunc {
+	return nil
+}
+
+func foundryEvaluationCollectionID(parentID string) string {
+	return strings.TrimRight(strings.TrimSpace(parentID), "/") + foundryEvaluationCollectionPath
+}
+
+func foundryResourceID(response interface{}) (string, error) {
+	values, err := foundryEvaluationBodyMap(response)
+	if err != nil {
+		return "", fmt.Errorf("invalid evaluation response: %w", err)
+	}
+
+	value, ok := values["id"]
+	if !ok {
+		return "", fmt.Errorf(`evaluation response field "id" is missing`)
+	}
+	evaluationID, ok := value.(string)
+	if !ok {
+		return "", fmt.Errorf(`evaluation response field "id" must be a string`)
+	}
+	if strings.TrimSpace(evaluationID) == "" {
+		return "", fmt.Errorf(`evaluation response field "id" must be a non-empty string`)
+	}
+
+	return strings.TrimSpace(evaluationID), nil
+}
+
+func foundryEvaluationUpdateRequestBody(body interface{}) (map[string]interface{}, error) {
+	values, err := foundryEvaluationBodyMap(body)
+	if err != nil {
+		return nil, err
+	}
+
+	// The update API only accepts mutable evaluation metadata. The data source
+	// and testing criteria are create-time properties.
+	updateBody := make(map[string]interface{}, 2)
+	for _, fieldName := range []string{"name", "metadata"} {
+		if value, exists := values[fieldName]; exists {
+			updateBody[fieldName] = value
+		}
+	}
+
+	return updateBody, nil
+}
+
+func (c FoundryEvaluationCustomization) CreateResultFunc() CreateResultFunc {
+	return func(
+		ctx context.Context,
+		client clients.Client,
+		id parse.DataPlaneResourceId,
+		body interface{},
+		options clients.RequestOptions,
+	) (parse.DataPlaneResourceId, interface{}, error) {
+		responseBody, err := client.DataPlaneClient.Action(
+			ctx,
+			foundryEvaluationCollectionID(id.ParentId),
+			"",
+			"", // /openai/v1 endpoints must not receive api-version
+			http.MethodPost,
+			body,
+			options,
+		)
+		if err != nil {
+			return parse.DataPlaneResourceId{}, nil, err
+		}
+
+		evaluationID, err := foundryResourceID(responseBody)
+		if err != nil {
+			return parse.DataPlaneResourceId{}, nil, err
+		}
+
+		createdID, err := parse.NewDataPlaneResourceId(
+			evaluationID,
+			id.ParentId,
+			fmt.Sprintf("%s@%s", id.AzureResourceType, id.ApiVersion),
+		)
+		if err != nil {
+			return parse.DataPlaneResourceId{}, nil, err
+		}
+
+		return createdID, responseBody, nil
+	}
+}
+
+func (c FoundryEvaluationCustomization) ReadFunc() ReadFunc {
+	return func(
+		ctx context.Context,
+		client clients.Client,
+		id parse.DataPlaneResourceId,
+		options clients.RequestOptions,
+	) (interface{}, error) {
+		return client.DataPlaneClient.Action(
+			ctx,
+			id.AzureResourceId,
+			"",
+			"", // /openai/v1 endpoints must not receive api-version
+			http.MethodGet,
+			nil,
+			options,
+		)
+	}
+}
+
+func (c FoundryEvaluationCustomization) UpdateFunc() UpdateFunc {
+	return func(
+		ctx context.Context,
+		client clients.Client,
+		id parse.DataPlaneResourceId,
+		body interface{},
+		options clients.RequestOptions,
+	) error {
+		requestBody, err := foundryEvaluationUpdateRequestBody(body)
+		if err != nil {
+			return err
+		}
+
+		_, err = client.DataPlaneClient.Action(
+			ctx,
+			id.AzureResourceId,
+			"",
+			"", // /openai/v1 endpoints must not receive api-version
+			http.MethodPost,
+			requestBody,
+			options,
+		)
+		return err
+	}
+}
+
+func (c FoundryEvaluationCustomization) DeleteFunc() DeleteFunc {
+	return func(
+		ctx context.Context,
+		client clients.Client,
+		id parse.DataPlaneResourceId,
+		options clients.RequestOptions,
+	) error {
+		_, err := client.DataPlaneClient.Action(
+			ctx,
+			id.AzureResourceId,
+			"",
+			"", // /openai/v1 endpoints must not receive api-version
+			http.MethodDelete,
+			nil,
+			options,
+		)
+		return err
+	}
+}
+
+var _ DataPlaneResource = &FoundryEvaluationCustomization{}
+var _ DataPlaneResourceWithCreateResult = &FoundryEvaluationCustomization{}

--- a/internal/services/customization/foundry_evaluation_customization_test.go
+++ b/internal/services/customization/foundry_evaluation_customization_test.go
@@ -1,0 +1,223 @@
+package customization
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/terraform-provider-azapi/internal/clients"
+	"github.com/Azure/terraform-provider-azapi/internal/services/parse"
+)
+
+func TestFoundryEvaluationCustomizationCreateResult(t *testing.T) {
+	transport := &foundryTestTransport{
+		responses: []foundryTestResponse{
+			{
+				statusCode: http.StatusCreated,
+				body:       `{"id":"eval_123","name":"evaluation"}`,
+			},
+		},
+	}
+	client := newFoundryTestClient(t, transport)
+	inputID := parse.DataPlaneResourceId{
+		AzureResourceType: "Microsoft.Foundry/evaluation/versions",
+		ApiVersion:        "2025-05-01",
+		Name:              "__generated__",
+		ParentId:          "account.services.ai.azure.com/api/projects/project",
+	}
+
+	createdID, responseBody, err := (FoundryEvaluationCustomization{}).CreateResultFunc()(
+		t.Context(),
+		client,
+		inputID,
+		map[string]interface{}{
+			"name":               "evaluation",
+			"data_source_config": map[string]interface{}{"type": "custom"},
+		},
+		clients.RequestOptions{
+			Headers:         map[string]string{"X-Test": "header"},
+			QueryParameters: map[string]string{"custom": "value"},
+		},
+	)
+	if err != nil {
+		t.Fatalf("creating evaluation: %v", err)
+	}
+
+	if createdID.AzureResourceId != "account.services.ai.azure.com/api/projects/project/openai/v1/evals/eval_123" {
+		t.Fatalf("unexpected evaluation resource ID: %q", createdID.AzureResourceId)
+	}
+	if createdID.Name != "eval_123" {
+		t.Fatalf("unexpected evaluation name: %q", createdID.Name)
+	}
+	if responseBody == nil {
+		t.Fatal("expected response body")
+	}
+
+	request := transport.lastRequest(t)
+	if request.method != http.MethodPost {
+		t.Fatalf("unexpected method: %q", request.method)
+	}
+	if request.url != "https://account.services.ai.azure.com/api/projects/project/openai/v1/evals?custom=value" {
+		t.Fatalf("unexpected URL: %q", request.url)
+	}
+	if request.headers.Get("X-Test") != "header" {
+		t.Fatalf("expected custom header, got %q", request.headers.Get("X-Test"))
+	}
+	if strings.Contains(request.url, "api-version") {
+		t.Fatalf("unexpected API version in URL: %q", request.url)
+	}
+
+	var requestBody map[string]interface{}
+	if err := json.Unmarshal([]byte(request.body), &requestBody); err != nil {
+		t.Fatalf("decoding request body: %v", err)
+	}
+	if requestBody["name"] != "evaluation" {
+		t.Fatalf("unexpected request body: %#v", requestBody)
+	}
+}
+
+func TestFoundryEvaluationCustomizationUpdateBody(t *testing.T) {
+	body, err := foundryEvaluationUpdateRequestBody(map[string]interface{}{
+		"name":               "updated",
+		"metadata":           map[string]interface{}{"team": "platform"},
+		"data_source_config": map[string]interface{}{"type": "custom"},
+		"testing_criteria":   []interface{}{"immutable"},
+	})
+	if err != nil {
+		t.Fatalf("building update body: %v", err)
+	}
+
+	expected := map[string]interface{}{
+		"name":     "updated",
+		"metadata": map[string]interface{}{"team": "platform"},
+	}
+	if !reflect.DeepEqual(body, expected) {
+		t.Fatalf("unexpected update body: got %#v, want %#v", body, expected)
+	}
+}
+
+func TestFoundryEvaluationCustomizationResponseValidation(t *testing.T) {
+	tests := []struct {
+		name     string
+		response interface{}
+	}{
+		{name: "nil", response: nil},
+		{name: "missing ID", response: map[string]interface{}{}},
+		{name: "non-string ID", response: map[string]interface{}{"id": 123}},
+		{name: "empty ID", response: map[string]interface{}{"id": " "}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if _, err := foundryResourceID(test.response); err == nil {
+				t.Fatal("expected response validation error")
+			}
+		})
+	}
+}
+
+func TestFoundryEvaluationCustomizationLifecycle(t *testing.T) {
+	customization := FoundryEvaluationCustomization{}
+
+	if customization.GetResourceType() != "Microsoft.Foundry/evaluation/versions" {
+		t.Fatalf("unexpected resource type: %q", customization.GetResourceType())
+	}
+	if customization.CreateFunc() != nil {
+		t.Fatal("evaluation customization should use CreateResultFunc")
+	}
+	if customization.CreateResultFunc() == nil ||
+		customization.ReadFunc() == nil ||
+		customization.UpdateFunc() == nil ||
+		customization.DeleteFunc() == nil {
+		t.Fatal("evaluation customization must define complete lifecycle behavior")
+	}
+}
+
+type foundryTestResponse struct {
+	statusCode int
+	body       string
+}
+
+type foundryTestRequest struct {
+	method  string
+	url     string
+	headers http.Header
+	body    string
+}
+
+type foundryTestTransport struct {
+	responses []foundryTestResponse
+	requests  []foundryTestRequest
+}
+
+func (t *foundryTestTransport) Do(request *http.Request) (*http.Response, error) {
+	if len(t.responses) == 0 {
+		return nil, fmt.Errorf("unexpected %s request", request.Method)
+	}
+
+	var body []byte
+	if request.Body != nil {
+		var err error
+		body, err = io.ReadAll(request.Body)
+		if err != nil {
+			return nil, err
+		}
+	}
+	t.requests = append(t.requests, foundryTestRequest{
+		method:  request.Method,
+		url:     request.URL.String(),
+		headers: request.Header.Clone(),
+		body:    string(body),
+	})
+
+	response := t.responses[0]
+	t.responses = t.responses[1:]
+	return &http.Response{
+		StatusCode: response.statusCode,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(response.body)),
+		Request:    request,
+	}, nil
+}
+
+func (transport *foundryTestTransport) lastRequest(t testing.TB) foundryTestRequest {
+	t.Helper()
+	if len(transport.requests) == 0 {
+		t.Fatal("expected a request")
+	}
+	return transport.requests[len(transport.requests)-1]
+}
+
+type foundryTestCredential struct{}
+
+func (foundryTestCredential) GetToken(context.Context, policy.TokenRequestOptions) (azcore.AccessToken, error) {
+	return azcore.AccessToken{
+		Token:     "token",
+		ExpiresOn: time.Now().Add(time.Hour),
+	}, nil
+}
+
+func newFoundryTestClient(t *testing.T, transport policy.Transporter) clients.Client {
+	t.Helper()
+
+	dataPlaneClient, err := clients.NewDataPlaneClient(
+		foundryTestCredential{},
+		&arm.ClientOptions{
+			ClientOptions: policy.ClientOptions{Transport: transport},
+		},
+	)
+	if err != nil {
+		t.Fatalf("creating data-plane client: %v", err)
+	}
+
+	return clients.Client{DataPlaneClient: dataPlaneClient}
+}

--- a/internal/services/customization/foundry_evaluation_run_customization.go
+++ b/internal/services/customization/foundry_evaluation_run_customization.go
@@ -1,0 +1,262 @@
+package customization
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/Azure/terraform-provider-azapi/internal/clients"
+	"github.com/Azure/terraform-provider-azapi/internal/services/parse"
+)
+
+// FoundryEvaluationRunCustomization manages Foundry evaluation runs.
+//
+// The top-level evaluation_id identifies the evaluation collection and is
+// available through id.EvaluationId. It is used in the request URL and is not
+// sent in the request body.
+//
+// Foundry generates the run identifier, so the top-level name argument must
+// not be configured.
+type FoundryEvaluationRunCustomization struct{}
+
+const foundryEvaluationRunResourceType = "Microsoft.Foundry/evaluation/runs"
+
+func (c FoundryEvaluationRunCustomization) GetResourceType() string {
+	return foundryEvaluationRunResourceType
+}
+
+func foundryEvaluationRunCollectionID(
+	parentID string,
+	evaluationID string,
+) string {
+	return fmt.Sprintf(
+		"%s/openai/v1/evals/%s/runs",
+		strings.TrimRight(strings.TrimSpace(parentID), "/"),
+		url.PathEscape(strings.TrimSpace(evaluationID)),
+	)
+}
+
+func foundryEvaluationBodyMap(
+	body interface{},
+) (map[string]interface{}, error) {
+	data, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"marshalling evaluation body: %w",
+			err,
+		)
+	}
+
+	var values map[string]interface{}
+	if err := json.Unmarshal(data, &values); err != nil {
+		return nil, fmt.Errorf(
+			"unmarshalling evaluation body: %w",
+			err,
+		)
+	}
+
+	if values == nil {
+		return nil, fmt.Errorf(
+			"evaluation body must be an object",
+		)
+	}
+
+	return values, nil
+}
+
+func foundryEvaluationRunRequestBody(
+	body interface{},
+) (map[string]interface{}, error) {
+	values, err := foundryEvaluationBodyMap(body)
+	if err != nil {
+		return nil, err
+	}
+
+	// Remove defensively in case the generic resource layer injects this field
+	// into the body. The configured top-level evaluation_id is obtained from
+	// id.EvaluationId.
+	delete(values, "evaluation_id")
+	delete(values, "evaluationId")
+
+	return values, nil
+}
+
+func foundryEvaluationRunIDFromResponse(
+	response interface{},
+) (string, error) {
+	if value, ok := response.(string); ok {
+		runID := strings.TrimSpace(value)
+		if runID != "" {
+			return runID, nil
+		}
+	}
+
+	values, err := foundryEvaluationBodyMap(response)
+	if err != nil {
+		return "", err
+	}
+
+	for _, fieldName := range []string{
+		"id",
+		"run_id",
+		"runId",
+		"runID",
+	} {
+		value, exists := values[fieldName]
+		if !exists || value == nil {
+			continue
+		}
+
+		runID, ok := value.(string)
+		if !ok {
+			return "", fmt.Errorf(
+				"evaluation run response field %q must be a string",
+				fieldName,
+			)
+		}
+
+		runID = strings.TrimSpace(runID)
+		if runID == "" {
+			return "", fmt.Errorf(
+				"evaluation run response field %q must not be empty",
+				fieldName,
+			)
+		}
+
+		return runID, nil
+	}
+
+	return "", fmt.Errorf(
+		"evaluation run response did not contain a generated run ID",
+	)
+}
+
+func foundryEvaluationRunEvaluationID(
+	id parse.DataPlaneResourceId,
+) (string, error) {
+	evaluationID := strings.TrimSpace(id.EvaluationId)
+
+	if evaluationID == "" || evaluationID == "__generated__" {
+		return "", fmt.Errorf(
+			`top-level "evaluation_id" is required for %s`,
+			foundryEvaluationRunResourceType,
+		)
+	}
+
+	return evaluationID, nil
+}
+
+func (c FoundryEvaluationRunCustomization) CreateFunc() CreateFunc {
+	// Foundry generates the run ID. Creation uses CreateResultFunc.
+	return nil
+}
+
+func (c FoundryEvaluationRunCustomization) CreateResultFunc() CreateResultFunc {
+	return func(
+		ctx context.Context,
+		client clients.Client,
+		id parse.DataPlaneResourceId,
+		body interface{},
+		options clients.RequestOptions,
+	) (parse.DataPlaneResourceId, interface{}, error) {
+		evaluationID, err := foundryEvaluationRunEvaluationID(id)
+		if err != nil {
+			return parse.DataPlaneResourceId{}, nil, err
+		}
+
+		requestBody, err := foundryEvaluationRunRequestBody(body)
+		if err != nil {
+			return parse.DataPlaneResourceId{}, nil, err
+		}
+
+		responseBody, err := client.DataPlaneClient.Action(
+			ctx,
+			foundryEvaluationRunCollectionID(id.ParentId, evaluationID),
+			"",
+			"",
+			http.MethodPost,
+			requestBody,
+			options,
+		)
+		if err != nil {
+			return parse.DataPlaneResourceId{}, nil, err
+		}
+
+		runID, err := foundryEvaluationRunIDFromResponse(responseBody)
+		if err != nil {
+			return parse.DataPlaneResourceId{}, responseBody, err
+		}
+
+		createdID, err := parse.NewDataPlaneResourceIdWithEvaluationID(
+			runID,
+			id.ParentId,
+			evaluationID,
+			fmt.Sprintf("%s@%s", id.AzureResourceType, id.ApiVersion),
+		)
+		if err != nil {
+			return parse.DataPlaneResourceId{}, responseBody, err
+		}
+
+		return createdID, responseBody, nil
+	}
+}
+
+func (c FoundryEvaluationRunCustomization) ReadFunc() ReadFunc {
+	return func(
+		ctx context.Context,
+		client clients.Client,
+		id parse.DataPlaneResourceId,
+		options clients.RequestOptions,
+	) (interface{}, error) {
+		return client.DataPlaneClient.Action(
+			ctx,
+			id.AzureResourceId,
+			"",
+			"",
+			http.MethodGet,
+			nil,
+			options,
+		)
+	}
+}
+
+func (c FoundryEvaluationRunCustomization) UpdateFunc() UpdateFunc {
+	return func(
+		_ context.Context,
+		_ clients.Client,
+		_ parse.DataPlaneResourceId,
+		_ interface{},
+		_ clients.RequestOptions,
+	) error {
+		return fmt.Errorf(
+			"Foundry evaluation runs cannot be updated; create a new run instead",
+		)
+	}
+}
+
+func (c FoundryEvaluationRunCustomization) DeleteFunc() DeleteFunc {
+	return func(
+		ctx context.Context,
+		client clients.Client,
+		id parse.DataPlaneResourceId,
+		options clients.RequestOptions,
+	) error {
+		_, err := client.DataPlaneClient.Action(
+			ctx,
+			id.AzureResourceId,
+			"",
+			"",
+			http.MethodDelete,
+			nil,
+			options,
+		)
+
+		return err
+	}
+}
+
+var _ DataPlaneResource = &FoundryEvaluationRunCustomization{}
+var _ DataPlaneResourceWithCreateResult = &FoundryEvaluationRunCustomization{}

--- a/internal/services/customization/foundry_evaluation_run_customization.go
+++ b/internal/services/customization/foundry_evaluation_run_customization.go
@@ -172,10 +172,9 @@ func (c FoundryEvaluationRunCustomization) CreateResultFunc() CreateResultFunc {
 			return parse.DataPlaneResourceId{}, nil, err
 		}
 
-		responseBody, err := client.DataPlaneClient.Action(
+		responseBody, err := client.DataPlaneClient.ActionWithoutAPIVersion(
 			ctx,
 			foundryEvaluationRunCollectionID(id.ParentId, evaluationID),
-			"",
 			"",
 			http.MethodPost,
 			requestBody,
@@ -211,10 +210,9 @@ func (c FoundryEvaluationRunCustomization) ReadFunc() ReadFunc {
 		id parse.DataPlaneResourceId,
 		options clients.RequestOptions,
 	) (interface{}, error) {
-		return client.DataPlaneClient.Action(
+		return client.DataPlaneClient.ActionWithoutAPIVersion(
 			ctx,
 			id.AzureResourceId,
-			"",
 			"",
 			http.MethodGet,
 			nil,
@@ -244,10 +242,9 @@ func (c FoundryEvaluationRunCustomization) DeleteFunc() DeleteFunc {
 		id parse.DataPlaneResourceId,
 		options clients.RequestOptions,
 	) error {
-		_, err := client.DataPlaneClient.Action(
+		_, err := client.DataPlaneClient.ActionWithoutAPIVersion(
 			ctx,
 			id.AzureResourceId,
-			"",
 			"",
 			http.MethodDelete,
 			nil,

--- a/internal/services/customization/foundry_evaluation_run_customization_test.go
+++ b/internal/services/customization/foundry_evaluation_run_customization_test.go
@@ -1,0 +1,180 @@
+package customization
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/Azure/terraform-provider-azapi/internal/clients"
+	"github.com/Azure/terraform-provider-azapi/internal/services/parse"
+)
+
+func TestFoundryEvaluationRunCustomizationCreateResult(t *testing.T) {
+	transport := &foundryTestTransport{
+		responses: []foundryTestResponse{
+			{
+				statusCode: http.StatusCreated,
+				body:       `{"id":"run_456","status":"queued"}`,
+			},
+		},
+	}
+	client := newFoundryTestClient(t, transport)
+	inputID := parse.DataPlaneResourceId{
+		AzureResourceType: "Microsoft.Foundry/evaluation/runs",
+		ApiVersion:        "2025-05-01",
+		Name:              "__generated__",
+		ParentId:          "account.services.ai.azure.com/api/projects/project",
+		EvaluationId:      "eval_123",
+	}
+
+	createdID, _, err := (FoundryEvaluationRunCustomization{}).CreateResultFunc()(
+		t.Context(),
+		client,
+		inputID,
+		map[string]interface{}{
+			"name":          "run",
+			"evaluation_id": "must-not-be-sent",
+			"data_source":   map[string]interface{}{"type": "azure_ai_target_completions"},
+		},
+		clients.RequestOptions{},
+	)
+	if err != nil {
+		t.Fatalf("creating evaluation run: %v", err)
+	}
+
+	if createdID.AzureResourceId != "account.services.ai.azure.com/api/projects/project/openai/v1/evals/eval_123/runs/run_456" {
+		t.Fatalf("unexpected evaluation run resource ID: %q", createdID.AzureResourceId)
+	}
+	if createdID.Name != "run_456" || createdID.EvaluationId != "eval_123" {
+		t.Fatalf("unexpected generated ID fields: %#v", createdID)
+	}
+
+	request := transport.lastRequest(t)
+	if request.method != http.MethodPost {
+		t.Fatalf("unexpected method: %q", request.method)
+	}
+	if request.url != "https://account.services.ai.azure.com/api/projects/project/openai/v1/evals/eval_123/runs" {
+		t.Fatalf("unexpected URL: %q", request.url)
+	}
+	if strings.Contains(request.url, "api-version") {
+		t.Fatalf("unexpected API version in URL: %q", request.url)
+	}
+
+	var requestBody map[string]interface{}
+	if err := json.Unmarshal([]byte(request.body), &requestBody); err != nil {
+		t.Fatalf("decoding request body: %v", err)
+	}
+	if _, exists := requestBody["evaluation_id"]; exists {
+		t.Fatalf("evaluation_id must not be sent in request body: %#v", requestBody)
+	}
+	if requestBody["name"] != "run" {
+		t.Fatalf("unexpected request body: %#v", requestBody)
+	}
+}
+
+func TestFoundryEvaluationRunCustomizationValidation(t *testing.T) {
+	t.Run("requires evaluation ID", func(t *testing.T) {
+		_, err := foundryEvaluationRunEvaluationID(parse.DataPlaneResourceId{})
+		if err == nil || !strings.Contains(err.Error(), "evaluation_id") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("accepts trimmed evaluation ID", func(t *testing.T) {
+		id, err := foundryEvaluationRunEvaluationID(parse.DataPlaneResourceId{EvaluationId: " eval_123 "})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if id != "eval_123" {
+			t.Fatalf("unexpected evaluation ID: %q", id)
+		}
+	})
+
+	t.Run("removes both evaluation ID body spellings", func(t *testing.T) {
+		body, err := foundryEvaluationRunRequestBody(map[string]interface{}{
+			"evaluation_id": "one",
+			"evaluationId":  "two",
+			"name":          "run",
+		})
+		if err != nil {
+			t.Fatalf("building request body: %v", err)
+		}
+		if _, exists := body["evaluation_id"]; exists {
+			t.Fatal("snake-case evaluation_id was not removed")
+		}
+		if _, exists := body["evaluationId"]; exists {
+			t.Fatal("camel-case evaluationId was not removed")
+		}
+		if body["name"] != "run" {
+			t.Fatalf("unexpected request body: %#v", body)
+		}
+	})
+}
+
+func TestFoundryEvaluationRunIDFromResponse(t *testing.T) {
+	tests := []struct {
+		name     string
+		response interface{}
+		expected string
+	}{
+		{name: "id", response: map[string]interface{}{"id": "run_123"}, expected: "run_123"},
+		{name: "run_id", response: map[string]interface{}{"run_id": "run_123"}, expected: "run_123"},
+		{name: "runId", response: map[string]interface{}{"runId": "run_123"}, expected: "run_123"},
+		{name: "runID", response: map[string]interface{}{"runID": "run_123"}, expected: "run_123"},
+		{name: "text", response: "run_123", expected: "run_123"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual, err := foundryEvaluationRunIDFromResponse(test.response)
+			if err != nil {
+				t.Fatalf("extracting run ID: %v", err)
+			}
+			if actual != test.expected {
+				t.Fatalf("unexpected run ID: %q", actual)
+			}
+		})
+	}
+
+	for _, response := range []interface{}{
+		nil,
+		map[string]interface{}{},
+		map[string]interface{}{"id": 123},
+		map[string]interface{}{"id": " "},
+	} {
+		t.Run("invalid response", func(t *testing.T) {
+			if _, err := foundryEvaluationRunIDFromResponse(response); err == nil {
+				t.Fatal("expected response validation error")
+			}
+		})
+	}
+}
+
+func TestFoundryEvaluationRunCustomizationLifecycle(t *testing.T) {
+	customization := FoundryEvaluationRunCustomization{}
+
+	if customization.GetResourceType() != "Microsoft.Foundry/evaluation/runs" {
+		t.Fatalf("unexpected resource type: %q", customization.GetResourceType())
+	}
+	if customization.CreateFunc() != nil {
+		t.Fatal("evaluation run customization should use CreateResultFunc")
+	}
+	if customization.CreateResultFunc() == nil ||
+		customization.ReadFunc() == nil ||
+		customization.UpdateFunc() == nil ||
+		customization.DeleteFunc() == nil {
+		t.Fatal("evaluation run customization must define complete lifecycle behavior")
+	}
+
+	err := customization.UpdateFunc()(
+		t.Context(),
+		clients.Client{},
+		parse.DataPlaneResourceId{},
+		nil,
+		clients.RequestOptions{},
+	)
+	if err == nil || !strings.Contains(err.Error(), "cannot be updated") {
+		t.Fatalf("unexpected update error: %v", err)
+	}
+}

--- a/internal/services/customization/registration.go
+++ b/internal/services/customization/registration.go
@@ -13,6 +13,12 @@ func init() {
 
 	var foundryAgentCustomization DataPlaneResource = FoundryAgentCustomization{}
 	customizations[strings.ToLower(foundryAgentCustomization.GetResourceType())] = foundryAgentCustomization
+
+	var foundryEvaluationCustomization DataPlaneResource = FoundryEvaluationCustomization{}
+	customizations[strings.ToLower(foundryEvaluationCustomization.GetResourceType())] = foundryEvaluationCustomization
+
+	var foundryEvaluationRunCustomization DataPlaneResource = FoundryEvaluationRunCustomization{}
+	customizations[strings.ToLower(foundryEvaluationRunCustomization.GetResourceType())] = foundryEvaluationRunCustomization
 }
 
 func GetCustomization(resourceType string) *DataPlaneResource {

--- a/internal/services/parse/data_plane_resource_id.go
+++ b/internal/services/parse/data_plane_resource_id.go
@@ -13,9 +13,14 @@ type DataPlaneResourceId struct {
 	AzureResourceType string
 	Name              string
 	ParentId          string
+	EvaluationId      string
 }
 
 func NewDataPlaneResourceId(name, parentId, resourceType string) (DataPlaneResourceId, error) {
+	return NewDataPlaneResourceIdWithEvaluationID(name, parentId, "", resourceType)
+}
+
+func NewDataPlaneResourceIdWithEvaluationID(name, parentId, evaluationId, resourceType string) (DataPlaneResourceId, error) {
 	azureResourceType, apiVersion, err := utils.GetAzureResourceTypeApiVersion(resourceType)
 	if err != nil {
 		return DataPlaneResourceId{}, err
@@ -30,6 +35,8 @@ func NewDataPlaneResourceId(name, parentId, resourceType string) (DataPlaneResou
 				parts[i] = parentId
 			case part == "{name}":
 				parts[i] = name
+			case part == "{evaluationId}":
+				parts[i] = evaluationId
 			case part == "{apiVersion}":
 				parts[i] = apiVersion
 			case strings.HasPrefix(part, "{name="):
@@ -52,6 +59,7 @@ func NewDataPlaneResourceId(name, parentId, resourceType string) (DataPlaneResou
 		AzureResourceType: azureResourceType,
 		Name:              name,
 		ParentId:          parentId,
+		EvaluationId:      evaluationId,
 	}, nil
 }
 
@@ -64,6 +72,7 @@ func DataPlaneResourceIDWithResourceType(azureResourceId, resourceType string) (
 
 	name := ""
 	parentId := ""
+	evaluationId := ""
 	if apiPath := findApiPathByResourceType(azureResourceType); apiPath != nil {
 		urlFormatParts := strings.Split(apiPath.UrlFormat, "/")
 		azureResourceIdParts := strings.Split(azureResourceId, "/")
@@ -75,6 +84,9 @@ func DataPlaneResourceIDWithResourceType(azureResourceId, resourceType string) (
 			switch {
 			case strings.HasPrefix(urlFormatParts[i], "{name"):
 				name = azureResourceIdParts[j]
+				j--
+			case strings.HasPrefix(urlFormatParts[i], "{evaluationId"):
+				evaluationId = azureResourceIdParts[j]
 				j--
 			case strings.Contains(urlFormatParts[i], "{name}"):
 				// Handle embedded {name} placeholder, e.g., "indexes('{name}')"
@@ -110,7 +122,7 @@ func DataPlaneResourceIDWithResourceType(azureResourceId, resourceType string) (
 	}
 	parentId = strings.TrimSuffix(parentId, "/")
 
-	return NewDataPlaneResourceId(name, parentId, resourceType)
+	return NewDataPlaneResourceIdWithEvaluationID(name, parentId, evaluationId, resourceType)
 }
 
 func (id DataPlaneResourceId) String() string {

--- a/internal/services/parse/data_plane_resource_id_test.go
+++ b/internal/services/parse/data_plane_resource_id_test.go
@@ -291,3 +291,56 @@ func Test_DataPlaneResourceIDWithResourceType(t *testing.T) {
 		}
 	}
 }
+
+func Test_FoundryEvaluationResourceIDs(t *testing.T) {
+	const (
+		parentID          = "account.services.ai.azure.com/api/projects/project"
+		evaluationType    = "Microsoft.Foundry/evaluation/versions@2025-05-01"
+		evaluationRunType = "Microsoft.Foundry/evaluation/runs@2025-05-01"
+	)
+
+	evaluationID, err := parse.NewDataPlaneResourceId(
+		"eval_123",
+		parentID,
+		evaluationType,
+	)
+	if err != nil {
+		t.Fatalf("creating evaluation ID: %v", err)
+	}
+	if evaluationID.AzureResourceId != parentID+"/openai/v1/evals/eval_123" {
+		t.Fatalf("unexpected evaluation resource ID: %q", evaluationID.AzureResourceId)
+	}
+
+	runID, err := parse.NewDataPlaneResourceIdWithEvaluationID(
+		"run_456",
+		parentID,
+		"eval_123",
+		evaluationRunType,
+	)
+	if err != nil {
+		t.Fatalf("creating evaluation run ID: %v", err)
+	}
+	if runID.AzureResourceId != parentID+"/openai/v1/evals/eval_123/runs/run_456" {
+		t.Fatalf("unexpected evaluation run resource ID: %q", runID.AzureResourceId)
+	}
+	if runID.EvaluationId != "eval_123" {
+		t.Fatalf("unexpected evaluation ID: %q", runID.EvaluationId)
+	}
+
+	parsedID, err := parse.DataPlaneResourceIDWithResourceType(
+		runID.AzureResourceId,
+		evaluationRunType,
+	)
+	if err != nil {
+		t.Fatalf("parsing evaluation run ID: %v", err)
+	}
+	if parsedID.Name != "run_456" {
+		t.Fatalf("unexpected parsed run ID: %q", parsedID.Name)
+	}
+	if parsedID.EvaluationId != "eval_123" {
+		t.Fatalf("unexpected parsed evaluation ID: %q", parsedID.EvaluationId)
+	}
+	if parsedID.ParentId != parentID {
+		t.Fatalf("unexpected parsed parent ID: %q", parsedID.ParentId)
+	}
+}

--- a/internal/services/parse/data_plane_resources.json
+++ b/internal/services/parse/data_plane_resources.json
@@ -404,12 +404,14 @@
     "UrlFormat": "{parentId}/openai/v1/evals/{name}",
     "ResourceType": "Microsoft.Foundry/evaluation/versions",
     "ParentIDExample": "{aiServicesId}.services.ai.azure.com/api/projects/{projectName}",
-    "Url": "/openai/v1/evals/{evalId}"
+    "Url": "/openai/v1/evals/{evalId}",
+    "ExamplePath": "examples/resources/azapi_data_plane_resource/Microsoft.Foundry_evaluation/main.tf"
   },
   {
     "UrlFormat": "{parentId}/openai/v1/evals/{evaluationId}/runs/{name}",
     "ResourceType": "Microsoft.Foundry/evaluation/runs",
     "ParentIDExample": "{aiServicesId}.services.ai.azure.com/api/projects/{projectName}",
-    "Url": "/openai/v1/evals/{evalId}/runs/{runId}"
+    "Url": "/openai/v1/evals/{evalId}/runs/{runId}",
+    "ExamplePath": "examples/resources/azapi_data_plane_resource/Microsoft.Foundry_evaluation_run/main.tf"
   }
 ]

--- a/internal/services/parse/data_plane_resources.json
+++ b/internal/services/parse/data_plane_resources.json
@@ -399,5 +399,17 @@
     "ParentIDExample": "{aiServicesId}.services.ai.azure.com/api/projects/{projectName}",
     "Url": "/agents/{agentName}",
     "ExamplePath": "examples/resources/azapi_data_plane_resource/Microsoft.Foundry_agents/main.tf"
+  },
+  {
+    "UrlFormat": "{parentId}/openai/v1/evals/{name}",
+    "ResourceType": "Microsoft.Foundry/evaluation/versions",
+    "ParentIDExample": "{aiServicesId}.services.ai.azure.com/api/projects/{projectName}",
+    "Url": "/openai/v1/evals/{evalId}"
+  },
+  {
+    "UrlFormat": "{parentId}/openai/v1/evals/{evaluationId}/runs/{name}",
+    "ResourceType": "Microsoft.Foundry/evaluation/runs",
+    "ParentIDExample": "{aiServicesId}.services.ai.azure.com/api/projects/{projectName}",
+    "Url": "/openai/v1/evals/{evalId}/runs/{runId}"
   }
 ]

--- a/internal/services/parse/data_plane_type_map.go
+++ b/internal/services/parse/data_plane_type_map.go
@@ -52,3 +52,7 @@ func hasIdentifierSegment(resourceType string, identifier string) bool {
 func HasNameSegment(resourceType string) bool {
 	return hasIdentifierSegment(resourceType, "name")
 }
+
+func HasEvaluationIdSegment(resourceType string) bool {
+	return hasIdentifierSegment(resourceType, "evaluationId")
+}

--- a/internal/services/parse/data_plane_type_map_test.go
+++ b/internal/services/parse/data_plane_type_map_test.go
@@ -46,6 +46,18 @@ func Test_hasIdentifierSegment(t *testing.T) {
 			Expected:     true,
 		},
 		{
+			Name:         "evaluation ID identifier present",
+			ResourceType: "Microsoft.Foundry/evaluation/runs@2025-05-01",
+			Identifier:   "evaluationId",
+			Expected:     true,
+		},
+		{
+			Name:         "evaluation ID identifier absent",
+			ResourceType: "Microsoft.Foundry/evaluation/versions@2025-05-01",
+			Identifier:   "evaluationId",
+			Expected:     false,
+		},
+		{
 			Name:         "identifier prefix does not match longer placeholder",
 			ResourceType: "Microsoft.KeyVault/vaults/certificates@2016-10-01",
 			Identifier:   "nam",
@@ -66,5 +78,14 @@ func Test_hasIdentifierSegment(t *testing.T) {
 				t.Fatalf("expected %v but got %v for resource type %q and identifier %q", v.Expected, actual, v.ResourceType, v.Identifier)
 			}
 		})
+	}
+}
+
+func TestHasEvaluationIdSegment(t *testing.T) {
+	if !HasEvaluationIdSegment("Microsoft.Foundry/evaluation/runs@2025-05-01") {
+		t.Fatal("expected evaluation runs to have an evaluation ID segment")
+	}
+	if HasEvaluationIdSegment("Microsoft.Foundry/evaluation/versions@2025-05-01") {
+		t.Fatal("expected evaluation versions not to have an evaluation ID segment")
 	}
 }

--- a/internal/tools/gendoc/dataplane.go
+++ b/internal/tools/gendoc/dataplane.go
@@ -188,8 +188,12 @@ func generateExampleSections(apiPaths []ApiPath) (string, error) {
 		if err != nil {
 			return "", fmt.Errorf("failed to read %s: %v", path.ExamplePath, err)
 		}
-		fmt.Fprintf(&sb, "```terraform\n%s```\n", string(b))
+		fmt.Fprintf(&sb, "```terraform\n%s```\n", escapeTemplateDelimiters(string(b)))
 	}
 
 	return sb.String(), nil
+}
+
+func escapeTemplateDelimiters(content string) string {
+	return strings.ReplaceAll(content, "{{", `{{"{{"}}`)
 }

--- a/internal/tools/gendoc/dataplane_test.go
+++ b/internal/tools/gendoc/dataplane_test.go
@@ -1,0 +1,12 @@
+package main
+
+import "testing"
+
+func TestEscapeTemplateDelimiters(t *testing.T) {
+	const content = `content = "{{item.input}}"`
+	const expected = `content = "{{"{{"}}item.input}}"`
+
+	if actual := escapeTemplateDelimiters(content); actual != expected {
+		t.Fatalf("unexpected escaped content: got %q, want %q", actual, expected)
+	}
+}


### PR DESCRIPTION
## Description

This PR adds Azure AI Foundry evaluation and evaluation run support to `azapi_data_plane_resource` through customizations for POST-to-collection APIs that return service-generated resource identifiers.

The implementation preserves existing data-plane client behavior by adding a dedicated action path for Foundry endpoints whose API version is encoded in the `/openai/v1` URL path rather than sent as an `api-version` query parameter.

## Problem

### Creating an Evaluation Workflow

Foundry evaluations use a collection-based workflow:

1. Send a `POST` request to `/openai/v1/evals`.
2. Extract the generated evaluation ID from the response.
3. Use the generated ID for subsequent read, update, and delete operations.

Evaluation runs follow a similar workflow:

1. Send a `POST` request to `/openai/v1/evals/{evaluation_id}/runs`.
2. Extract the generated run ID from the response.
3. Use the generated evaluation and run IDs for subsequent read and delete operations.

These APIs do not accept a user-provided top-level resource name. Evaluation runs also require the parent evaluation ID to construct their request path.

## Solution

The new customizations use the existing create-result extension pattern to support server-generated identifiers while preserving the standard Terraform resource lifecycle.

- Evaluation and evaluation-run resources omit the top-level `name` argument.
- The service-generated identifier is extracted from the create response and stored in Terraform state.
- Evaluation runs expose a top-level `evaluation_id` argument that is used only to construct the request URL.
- `name` and `evaluation_id` validation is driven by the resource type's URL format (`data_plane_resources.json`) rather than hardcoded resource-type strings: `evaluation_id` is required when the type's path contains an `{evaluationId}` segment, and rejected when it doesn't — mirroring the existing `name`/`HasNameSegment` pattern from #1053.
- Provider-only fields are excluded from request bodies where necessary.
- Foundry `/openai/v1` requests do not receive an `api-version` query parameter.
- Existing data-plane resource request behavior remains unchanged for all other resources.

## Changes

### 1. Foundry Evaluation Customization

**File:** `internal/services/customization/foundry_evaluation_customization.go`

Implements the lifecycle for `Microsoft.Foundry/evaluation/versions`:

| Operation | Method | Endpoint | Notes |
|-----------|--------|----------|-------|
| **Create** | `POST` | `{parent}/openai/v1/evals` | Extracts the service-generated evaluation ID |
| **Read** | `GET` | `{parent}/openai/v1/evals/{evaluationId}` | Retrieves the evaluation |
| **Update** | `POST` | `{parent}/openai/v1/evals/{evaluationId}` | Sends mutable evaluation metadata |
| **Delete** | `DELETE` | `{parent}/openai/v1/evals/{evaluationId}` | Deletes the evaluation |

Key implementation details:

- Uses `CreateResultFunc` to capture the generated evaluation ID.
- Validates that the create response contains a non-empty string `id`.
- Limits update requests to supported mutable fields such as `name` and `metadata`.
- Uses the Foundry-specific action path without an `api-version` query parameter.

### 2. Foundry Evaluation Run Customization

**File:** `internal/services/customization/foundry_evaluation_run_customization.go`

Implements the lifecycle for `Microsoft.Foundry/evaluation/runs`:

| Operation | Method | Endpoint | Notes |
|-----------|--------|----------|-------|
| **Create** | `POST` | `{parent}/openai/v1/evals/{evaluationId}/runs` | Extracts the service-generated run ID |
| **Read** | `GET` | `{parent}/openai/v1/evals/{evaluationId}/runs/{runId}` | Retrieves the evaluation run |
| **Update** | N/A | N/A | Evaluation runs are immutable |
| **Delete** | `DELETE` | `{parent}/openai/v1/evals/{evaluationId}/runs/{runId}` | Deletes the evaluation run |

Key implementation details:

- Requires the top-level `evaluation_id` argument; also rejects the `__generated__` sentinel value used internally for service-generated names.
- Uses `evaluation_id` to construct the request path without including it in the request body.
- Supports generated run IDs returned as `id`, `run_id`, `runId`, or `runID`.
- Rejects update operations with an explicit immutability error.
- Uses the Foundry-specific action path without an `api-version` query parameter.

### 3. Additive Data Plane Client Support

**Files:**

- `internal/clients/data_plane_client.go`
- `internal/clients/data_plane_client_test.go`

Added `ActionWithoutAPIVersion` for data-plane APIs whose version is part of the endpoint path.

The existing `Action`, `buildRequest`, `CreateOrUpdateThenPoll`, `Get`, and `DeleteThenPoll` behavior remains unchanged. Existing data-plane resources continue to use the original API-version request path.

### 4. Resource Model and Resource ID Mapping

**Files:**

- `internal/services/azapi_data_plane_resource.go`
- `internal/services/parse/data_plane_resource_id.go`
- `internal/services/parse/data_plane_resources.json`
- `internal/services/parse/data_plane_type_map.go`
- `internal/services/customization/registration.go`

Added:

- The optional `evaluation_id` resource argument.
- A data-driven `parse.HasEvaluationIdSegment` helper (alongside the existing `HasNameSegment`) that inspects each resource type's URL format to determine whether it uses an evaluation ID segment.
- Plan-time and create-time validation requiring `evaluation_id` for resource types that use it, and rejecting it for resource types that don't.
- Generated-name validation for evaluation and evaluation-run resources.
- Evaluation ID parsing and reconstruction for imports and refresh operations.
- Resource mappings for:
  - `Microsoft.Foundry/evaluation/versions`
  - `Microsoft.Foundry/evaluation/runs`

### 5. Example Configuration

**Files:**

- `examples/resources/azapi_data_plane_resource/Microsoft.Foundry_evaluation/main.tf`
- `examples/resources/azapi_data_plane_resource/Microsoft.Foundry_evaluation_run/main.tf`

Examples demonstrate:

- Creating an evaluation without a top-level `name`.
- Creating an evaluation run with `evaluation_id`.
- Configuring evaluation data sources and testing criteria.
- Configuring evaluation run targets and input message templates.
- Using Foundry API version `2025-05-01`.

### 6. Documentation

**Files:**

- `docs/resources/data_plane_resource.md`
- `internal/tools/gendoc/dataplane.go`
- `internal/tools/gendoc/dataplane_test.go`

Regenerated the data-plane resource documentation to include both Foundry resource mappings and examples.

The documentation generator now safely preserves Terraform expressions such as `{{item.input}}` when embedding examples in Go templates.

### 7. Tests

**Files:**

- `internal/services/customization/foundry_evaluation_customization_test.go`
- `internal/services/customization/foundry_evaluation_run_customization_test.go`
- `internal/clients/data_plane_client_test.go`
- `internal/services/parse/data_plane_resource_id_test.go`
- `internal/services/parse/data_plane_type_map_test.go`
- `internal/services/azapi_data_plane_resource_name_validation_test.go`
- `internal/services/azapi_data_plane_resource_import_test.go`
- `internal/tools/gendoc/dataplane_test.go`

Added coverage for:

- Evaluation and evaluation-run create request construction.
- Generated evaluation and run ID extraction.
- Foundry endpoint paths and API-version omission.
- Evaluation-run `evaluation_id` validation and body filtering.
- Symmetric `evaluation_id` validation (required vs. rejected) driven by resource-type URL format.
- Immutable evaluation-run update behavior.
- Evaluation and evaluation-run resource ID parsing and round-tripping.
- Import state handling.
- Generated-name validation.
- Legacy and Foundry-specific data-plane request builders.
- Documentation generation with Terraform template expressions.

## Testing

```text
go test ./...
```

## AI-Assisted Development Disclaimer

AI was used to assist with developing the provider implementation under the direction of user-provided requirements and input. Testing was performed to verify request construction, generated identifier handling, evaluation-run parent ID handling, resource ID parsing, import behavior, validation, documentation generation, and preservation of existing data-plane client behavior.
