### PR TITLE
azapi_data_plane_resource: apply retry logic to existence check

### DIFF
--- a/internal/services/azapi_data_plane_resource.go
+++ b/internal/services/azapi_data_plane_resource.go
@@ -462,13 +462,12 @@ func (r *DataPlaneResource) CreateUpdate(ctx context.Context, requestConfig tfsd
 
 	customizedResource := customization.GetCustomization(plan.Type.ValueString())
 	if isNewResource && !hasCreateResult {
-		// check if the resource already exists using the non-retry client to avoid issue where user specifies
-		// a FooResourceNotFound error as a retryable error
-
+		// Do not retry an expected 404 even if it matches a user-configured retry expression.
 		requestOptions := clients.RequestOptions{
 			Headers:         common.AsMapOfString(plan.ReadHeaders),
 			QueryParameters: clients.NewQueryParameters(common.AsMapOfLists(plan.ReadQueryParameters)),
 		}
+		requestOptions.RetryOptions, requestOptions.LastRetryError = clients.NewRetryOptionsForResourceExistenceCheck(plan.Retry)
 		if customizedResource != nil && (*customizedResource).ReadFunc() != nil {
 			_, err = (*customizedResource).ReadFunc()(ctx, *r.ProviderData, id, requestOptions)
 		} else {

--- a/internal/services/azapi_data_plane_resource_retry_unit_test.go
+++ b/internal/services/azapi_data_plane_resource_retry_unit_test.go
@@ -1,0 +1,165 @@
+package services_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/terraform-provider-azapi/internal/clients"
+	"github.com/Azure/terraform-provider-azapi/internal/features"
+	"github.com/Azure/terraform-provider-azapi/internal/services"
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+func TestDataPlaneResourceCreateRetriesAuthorizationFailureDuringExistenceCheck(t *testing.T) {
+	transport := &sequenceTransport{responses: []sequenceResponse{
+		{
+			method:     http.MethodGet,
+			statusCode: http.StatusForbidden,
+			body:       `{"error":{"code":"Forbidden","message":"role assignment has not propagated"}}`,
+		},
+		{
+			method:     http.MethodGet,
+			statusCode: http.StatusNotFound,
+			body:       `{"error":{"code":"ResourceNotFound","message":"resource does not exist"}}`,
+		},
+		{
+			method:     http.MethodPut,
+			statusCode: http.StatusOK,
+			body:       dataPlaneResourceResponse,
+		},
+		{
+			method:     http.MethodGet,
+			statusCode: http.StatusOK,
+			body:       dataPlaneResourceResponse,
+		},
+	}}
+
+	diagnostics := createDataPlaneResourceWithRetry(t, transport, []string{"Forbidden"})
+	if diagnostics.HasError() {
+		t.Fatalf("creating data plane resource: %+v", diagnostics)
+	}
+
+	assertRequestMethods(t, transport, []string{http.MethodGet, http.MethodGet, http.MethodPut, http.MethodGet})
+}
+
+func TestDataPlaneResourceCreateDoesNotRetryNotFoundDuringExistenceCheck(t *testing.T) {
+	transport := &sequenceTransport{responses: []sequenceResponse{
+		{
+			method:     http.MethodGet,
+			statusCode: http.StatusNotFound,
+			body:       `{"error":{"code":"FooResourceNotFound","message":"resource does not exist"}}`,
+		},
+		{
+			method:     http.MethodPut,
+			statusCode: http.StatusOK,
+			body:       dataPlaneResourceResponse,
+		},
+		{
+			method:     http.MethodGet,
+			statusCode: http.StatusOK,
+			body:       dataPlaneResourceResponse,
+		},
+	}}
+
+	diagnostics := createDataPlaneResourceWithRetry(t, transport, []string{"FooResourceNotFound"})
+	if diagnostics.HasError() {
+		t.Fatalf("creating data plane resource: %+v", diagnostics)
+	}
+
+	assertRequestMethods(t, transport, []string{http.MethodGet, http.MethodPut, http.MethodGet})
+}
+
+const dataPlaneResourceResponse = `{
+	"key":"test",
+	"value":"value"
+}`
+
+func createDataPlaneResourceWithRetry(t *testing.T, transport policy.Transporter, regexes []string) diag.Diagnostics {
+	t.Helper()
+
+	ctx := context.Background()
+	dataPlaneClient, err := clients.NewDataPlaneClient(staticTokenCredential{}, &arm.ClientOptions{
+		ClientOptions: policy.ClientOptions{
+			Cloud:     cloud.AzurePublic,
+			Transport: transport,
+		},
+	})
+	if err != nil {
+		t.Fatalf("building data plane client: %+v", err)
+	}
+
+	dataPlaneResource := &services.DataPlaneResource{
+		ProviderData: &clients.Client{
+			Features:        features.Default(),
+			DataPlaneClient: dataPlaneClient,
+		},
+	}
+
+	var schemaResponse resource.SchemaResponse
+	dataPlaneResource.Schema(ctx, resource.SchemaRequest{}, &schemaResponse)
+	if schemaResponse.Diagnostics.HasError() {
+		t.Fatalf("building data plane resource schema: %+v", schemaResponse.Diagnostics)
+	}
+
+	model := services.DataPlaneResourceModel{
+		ID:                            types.StringNull(),
+		Name:                          types.StringValue("test"),
+		ParentID:                      types.StringValue("example.azconfig.io"),
+		Type:                          types.StringValue("Microsoft.AppConfiguration/configurationStores/keyValues@1.0"),
+		Body:                          types.DynamicValue(types.ObjectValueMust(map[string]attr.Type{}, map[string]attr.Value{})),
+		SensitiveBody:                 types.DynamicNull(),
+		SensitiveBodyVersion:          types.MapNull(types.StringType),
+		IgnoreCasing:                  types.BoolValue(false),
+		IgnoreMissingProperty:         types.BoolValue(true),
+		ReplaceTriggersExternalValues: types.DynamicNull(),
+		ReplaceTriggersRefs:           types.ListNull(types.StringType),
+		ResponseExportValues:          types.DynamicNull(),
+		Retry:                         testRetryValue(regexes),
+		Locks:                         types.ListNull(types.StringType),
+		Output:                        types.DynamicNull(),
+		Timeouts: timeouts.Value{
+			Object: types.ObjectNull(map[string]attr.Type{
+				"create": types.StringType,
+				"update": types.StringType,
+				"read":   types.StringType,
+				"delete": types.StringType,
+			}),
+		},
+		CreateHeaders:         types.MapNull(types.StringType),
+		CreateQueryParameters: types.MapNull(types.ListType{ElemType: types.StringType}),
+		UpdateHeaders:         types.MapNull(types.StringType),
+		UpdateQueryParameters: types.MapNull(types.ListType{ElemType: types.StringType}),
+		DeleteHeaders:         types.MapNull(types.StringType),
+		DeleteQueryParameters: types.MapNull(types.ListType{ElemType: types.StringType}),
+		ReadHeaders:           types.MapNull(types.StringType),
+		ReadQueryParameters:   types.MapNull(types.ListType{ElemType: types.StringType}),
+	}
+
+	plan := tfsdk.Plan{Schema: schemaResponse.Schema}
+	if diagnostics := plan.Set(ctx, &model); diagnostics.HasError() {
+		t.Fatalf("setting data plane resource plan: %+v", diagnostics)
+	}
+	config := tfsdk.Config{
+		Schema: schemaResponse.Schema,
+		Raw:    plan.Raw,
+	}
+
+	state := tfsdk.State{
+		Schema: schemaResponse.Schema,
+		Raw:    tftypes.NewValue(schemaResponse.Schema.Type().TerraformType(ctx), nil),
+	}
+
+	var diagnostics diag.Diagnostics
+	dataPlaneResource.CreateUpdate(ctx, config, plan, &state, &diagnostics, newTestPrivateData())
+	return diagnostics
+}

--- a/internal/services/azapi_data_plane_resource_test.go
+++ b/internal/services/azapi_data_plane_resource_test.go
@@ -98,6 +98,20 @@ func TestAccDataPlaneResource_keyVaultSecret(t *testing.T) {
 	})
 }
 
+func TestAccDataPlaneResource_keyVaultKeyRbac(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azapi_data_plane_resource", "test")
+	r := DataPlaneResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.keyVaultKeyRbac(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+	})
+}
+
 func TestAccDataPlaneResource_keyVaultCertificate(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azapi_data_plane_resource", "test")
 	r := DataPlaneResource{}
@@ -654,6 +668,79 @@ resource "azapi_resource_action" "add_accesspolicy_secret" {
 }
 
 
+`, data.LocationPrimary, data.RandomString)
+}
+
+func (r DataPlaneResource) keyVaultKeyRbac(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+data "azapi_client_config" "current" {}
+
+resource "azapi_resource" "resourceGroup" {
+  type     = "Microsoft.Resources/resourceGroups@2025-04-01"
+  name     = "acctest%[2]s"
+  location = "%[1]s"
+}
+
+resource "azapi_resource" "vault" {
+  type      = "Microsoft.KeyVault/vaults@2026-02-01"
+  parent_id = azapi_resource.resourceGroup.id
+  name      = "acctestkv%[2]s"
+  location  = azapi_resource.resourceGroup.location
+  body = {
+    properties = {
+      tenantId                = data.azapi_client_config.current.tenant_id
+      enableRbacAuthorization = true
+      accessPolicies          = []
+      publicNetworkAccess     = "Enabled"
+      sku = {
+        family = "A"
+        name   = "standard"
+      }
+    }
+  }
+  response_export_values = {
+    vaultUri = "properties.vaultUri"
+  }
+}
+
+resource "azapi_resource" "keyVaultCryptoOfficer" {
+  type      = "Microsoft.Authorization/roleAssignments@2022-04-01"
+  parent_id = azapi_resource.vault.id
+  name      = uuid()
+  body = {
+    properties = {
+      principalId      = data.azapi_client_config.current.object_id
+      roleDefinitionId = "/subscriptions/${data.azapi_client_config.current.subscription_id}/providers/Microsoft.Authorization/roleDefinitions/14b46e9e-c2b7-41b4-b07b-48a6ebf60603"
+    }
+  }
+  lifecycle {
+    ignore_changes = [name]
+  }
+}
+
+resource "azapi_data_plane_resource" "test" {
+  type      = "Microsoft.KeyVault/vaults/keys@2025-07-01"
+  parent_id = trimsuffix(trimprefix(azapi_resource.vault.output.vaultUri, "https://"), "/")
+  name      = "acctest%[2]s"
+  body = {
+    kty      = "RSA"
+    key_size = 2048
+    key_ops  = ["encrypt", "decrypt", "sign", "verify", "wrapKey", "unwrapKey"]
+    attributes = {
+      enabled = true
+    }
+  }
+
+  retry = {
+    error_message_regex  = ["Forbidden", "Unauthorized", "authorization"]
+    interval_seconds     = 10
+    max_interval_seconds = 60
+  }
+
+  depends_on = [
+    azapi_resource.keyVaultCryptoOfficer,
+  ]
+}
 `, data.LocationPrimary, data.RandomString)
 }
 


### PR DESCRIPTION
Apply retry logic to data plane resource existence check to fix following bug:

1. Create an RBAC based key vault
2. Assign "key vault crypto officer" role into current principal
3. Add a key to the keyvault using the data_plane_resource with retry config set for "Forbidden" error regex

Step 2 require 20-30 seconds to be effective despite the successful assignment confirmation returned by the API. The expectation was the retry config on step 3 will activate to poll until the role assignment become effective. However it failed with 403 right away because the resource existence check did not have retry logic applied to it.

Related to: #988

## Testing

1. Check no regression on acctest: https://github.com/Azure/terraform-provider-azapi/pull/1229/checks?check_run_id=100243295549
2. Added unit test to simulate the role assignment lag