### PR TITLE
feat: support Content Understanding analyzers

### DIFF
--- a/docs/resources/data_plane_resource.md
+++ b/docs/resources/data_plane_resource.md
@@ -552,12 +552,6 @@ resource "azapi_data_plane_resource" "example" {
   parent_id = trimprefix(azapi_resource.foundry.output.properties.endpoint, "https://")
   name      = "exampleanalyzer"
 
-  retry = {
-    error_message_regex  = ["lacks the required data action", "PermissionDenied", "Unauthorized", "authorization", "context deadline exceeded"]
-    interval_seconds     = 30
-    max_interval_seconds = 180
-  }
-
   body = {
     description    = "My test analyzer"
     baseAnalyzerId = "prebuilt-document"

--- a/docs/resources/data_plane_resource.md
+++ b/docs/resources/data_plane_resource.md
@@ -241,6 +241,7 @@ Optional:
 | Resource Type | URL | Parent ID Example                                                                           |
 | --- | --- |---------------------------------------------------------------------------------------------|
 | Microsoft.AppConfiguration/configurationStores/keyValues | /kv/{key} | {storeName}.azconfig.io                                                                     |
+| Microsoft.CognitiveServices/accounts/ContentUnderstanding/analyzers | /contentunderstanding/analyzers/{analyzerId} | {accountName}.cognitiveservices.azure.com                                                   |
 | Microsoft.DeviceUpdate/accounts/groups | /deviceupdate/{instanceId}/management/groups/{groupId} | {accountName}.api.adu.microsoft.com/deviceupdate/{instanceName}                             |
 | Microsoft.DeviceUpdate/accounts/groups/deployments | /deviceUpdate/{instanceId}/management/groups/{groupId}/deployments/{deploymentId} | {accountName}.api.adu.microsoft.com/deviceupdate/{instanceName}/management/groups/{groupId} |
 | Microsoft.DeviceUpdate/accounts/v2/deployments | /deviceupdate/{instanceId}/v2/management/deployments/{deploymentId} | {accountName}.api.adu.microsoft.com/deviceupdate/{instanceName}                             |
@@ -382,6 +383,192 @@ resource "azapi_data_plane_resource" "example" {
   ]
 }
 ```
+
+### Microsoft.CognitiveServices/accounts/ContentUnderstanding/analyzers
+
+```terraform
+terraform {
+  required_providers {
+    azapi = {
+      source = "Azure/azapi"
+    }
+    random = {
+      source = "hashicorp/random"
+    }
+  }
+}
+
+provider "azapi" {
+}
+
+provider "random" {
+}
+
+data "azapi_client_config" "current" {}
+
+locals {
+  content_understanding_owner_role_definition_id = "/subscriptions/${data.azapi_client_config.current.subscription_id}/providers/Microsoft.Authorization/roleDefinitions/4b42bd01-da42-4c92-9b07-15ea5bd6a602"
+}
+
+resource "random_string" "unique" {
+  length      = 5
+  min_numeric = 5
+  numeric     = true
+  special     = false
+  lower       = true
+  upper       = false
+}
+
+variable "location" {
+  type        = string
+  description = "Azure region for the resources"
+}
+
+variable "resource_group_tags" {
+  type        = map(string)
+  description = "Optional tags to apply to the resource group (useful for policy-constrained subscriptions)."
+  default     = {}
+}
+
+resource "azapi_resource" "resource_group" {
+  type     = "Microsoft.Resources/resourceGroups@2021-04-01"
+  name     = "acctest${random_string.unique.result}"
+  location = var.location
+  tags     = var.resource_group_tags
+}
+
+resource "azapi_resource" "foundry" {
+  type                      = "Microsoft.CognitiveServices/accounts@2025-06-01"
+  name                      = "acctest${random_string.unique.result}"
+  parent_id                 = azapi_resource.resource_group.id
+  location                  = var.location
+  schema_validation_enabled = false
+
+  body = {
+    kind = "AIServices"
+    sku = {
+      name = "S0"
+    }
+    identity = {
+      type = "SystemAssigned"
+    }
+    properties = {
+      disableLocalAuth       = false
+      allowProjectManagement = true
+      customSubDomainName    = "acctest${random_string.unique.result}"
+    }
+  }
+  response_export_values = ["properties.endpoint"]
+}
+
+resource "azapi_resource" "contentUnderstandingOwnerRoleAssignment" {
+  type      = "Microsoft.Authorization/roleAssignments@2022-04-01"
+  parent_id = azapi_resource.foundry.id
+  name      = uuid()
+  body = {
+    properties = {
+      principalId      = data.azapi_client_config.current.object_id
+      roleDefinitionId = local.content_understanding_owner_role_definition_id
+    }
+  }
+}
+
+resource "azapi_resource" "foundry_gpt5_deployment" {
+  type      = "Microsoft.CognitiveServices/accounts/deployments@2023-05-01"
+  name      = "gpt-5"
+  parent_id = azapi_resource.foundry.id
+
+  body = {
+    sku = {
+      name     = "DataZoneStandard"
+      capacity = 1
+    }
+    properties = {
+      model = {
+        format  = "OpenAI"
+        name    = "gpt-5"
+        version = "2025-08-07"
+      }
+    }
+  }
+}
+
+resource "azapi_resource" "foundry_embedding_deployment" {
+  type      = "Microsoft.CognitiveServices/accounts/deployments@2023-05-01"
+  name      = "text-embedding-3-large"
+  parent_id = azapi_resource.foundry.id
+
+  body = {
+    sku = {
+      name     = "Standard"
+      capacity = 1
+    }
+    properties = {
+      model = {
+        format  = "OpenAI"
+        name    = "text-embedding-3-large"
+        version = "1"
+      }
+    }
+  }
+}
+
+resource "terraform_data" "contentUnderstandingDefaults" {
+  triggers_replace = [
+    azapi_resource.foundry.id,
+    azapi_resource.foundry_gpt5_deployment.id,
+    azapi_resource.foundry_embedding_deployment.id,
+  ]
+
+  provisioner "local-exec" {
+    interpreter = ["pwsh", "-Command"]
+    command     = <<-EOT
+      $token = (az account get-access-token --resource https://cognitiveservices.azure.com --query accessToken -o tsv)
+      $headers = @{
+        "Authorization" = "Bearer $token"
+        "Content-Type"  = "application/merge-patch+json"
+      }
+      $body = @{
+        modelDeployments = @{
+          "gpt-5"                  = "gpt-5"
+          "text-embedding-3-large" = "text-embedding-3-large"
+        }
+      } | ConvertTo-Json
+
+      $endpoint = "${azapi_resource.foundry.output.properties.endpoint}contentunderstanding/defaults?api-version=2025-11-01"
+      Invoke-RestMethod -Uri $endpoint -Method Patch -Headers $headers -Body $body
+    EOT
+  }
+
+  depends_on = [
+    azapi_resource.contentUnderstandingOwnerRoleAssignment,
+    azapi_resource.foundry_gpt5_deployment,
+    azapi_resource.foundry_embedding_deployment,
+  ]
+}
+
+resource "azapi_data_plane_resource" "example" {
+  type      = "Microsoft.CognitiveServices/accounts/ContentUnderstanding/analyzers@2025-11-01"
+  parent_id = trimprefix(azapi_resource.foundry.output.properties.endpoint, "https://")
+  name      = "exampleanalyzer"
+
+  retry = {
+    error_message_regex  = ["lacks the required data action", "PermissionDenied", "Unauthorized", "authorization", "context deadline exceeded"]
+    interval_seconds     = 30
+    max_interval_seconds = 180
+  }
+
+  body = {
+    description    = "My test analyzer"
+    baseAnalyzerId = "prebuilt-document"
+    models = {
+      completion = "gpt-5"
+      embedding  = "text-embedding-3-large"
+    }
+  }
+
+  depends_on = [terraform_data.contentUnderstandingDefaults]
+}```
 
 ### Microsoft.Foundry/agents
 

--- a/examples/resources/azapi_data_plane_resource/Microsoft.CognitiveServices_accounts_ContentUnderstanding_analyzers/main.tf
+++ b/examples/resources/azapi_data_plane_resource/Microsoft.CognitiveServices_accounts_ContentUnderstanding_analyzers/main.tf
@@ -163,12 +163,6 @@ resource "azapi_data_plane_resource" "example" {
   parent_id = trimprefix(azapi_resource.foundry.output.properties.endpoint, "https://")
   name      = "exampleanalyzer"
 
-  retry = {
-    error_message_regex  = ["lacks the required data action", "PermissionDenied", "Unauthorized", "authorization", "context deadline exceeded"]
-    interval_seconds     = 30
-    max_interval_seconds = 180
-  }
-
   body = {
     description    = "My test analyzer"
     baseAnalyzerId = "prebuilt-document"

--- a/examples/resources/azapi_data_plane_resource/Microsoft.CognitiveServices_accounts_ContentUnderstanding_analyzers/main.tf
+++ b/examples/resources/azapi_data_plane_resource/Microsoft.CognitiveServices_accounts_ContentUnderstanding_analyzers/main.tf
@@ -1,0 +1,182 @@
+terraform {
+  required_providers {
+    azapi = {
+      source = "Azure/azapi"
+    }
+    random = {
+      source = "hashicorp/random"
+    }
+  }
+}
+
+provider "azapi" {
+}
+
+provider "random" {
+}
+
+data "azapi_client_config" "current" {}
+
+locals {
+  content_understanding_owner_role_definition_id = "/subscriptions/${data.azapi_client_config.current.subscription_id}/providers/Microsoft.Authorization/roleDefinitions/4b42bd01-da42-4c92-9b07-15ea5bd6a602"
+}
+
+resource "random_string" "unique" {
+  length      = 5
+  min_numeric = 5
+  numeric     = true
+  special     = false
+  lower       = true
+  upper       = false
+}
+
+variable "location" {
+  type        = string
+  description = "Azure region for the resources"
+}
+
+variable "resource_group_tags" {
+  type        = map(string)
+  description = "Optional tags to apply to the resource group (useful for policy-constrained subscriptions)."
+  default     = {}
+}
+
+resource "azapi_resource" "resource_group" {
+  type     = "Microsoft.Resources/resourceGroups@2021-04-01"
+  name     = "acctest${random_string.unique.result}"
+  location = var.location
+  tags     = var.resource_group_tags
+}
+
+resource "azapi_resource" "foundry" {
+  type                      = "Microsoft.CognitiveServices/accounts@2025-06-01"
+  name                      = "acctest${random_string.unique.result}"
+  parent_id                 = azapi_resource.resource_group.id
+  location                  = var.location
+  schema_validation_enabled = false
+
+  body = {
+    kind = "AIServices"
+    sku = {
+      name = "S0"
+    }
+    identity = {
+      type = "SystemAssigned"
+    }
+    properties = {
+      disableLocalAuth       = false
+      allowProjectManagement = true
+      customSubDomainName    = "acctest${random_string.unique.result}"
+    }
+  }
+  response_export_values = ["properties.endpoint"]
+}
+
+resource "azapi_resource" "contentUnderstandingOwnerRoleAssignment" {
+  type      = "Microsoft.Authorization/roleAssignments@2022-04-01"
+  parent_id = azapi_resource.foundry.id
+  name      = uuid()
+  body = {
+    properties = {
+      principalId      = data.azapi_client_config.current.object_id
+      roleDefinitionId = local.content_understanding_owner_role_definition_id
+    }
+  }
+}
+
+resource "azapi_resource" "foundry_gpt5_deployment" {
+  type      = "Microsoft.CognitiveServices/accounts/deployments@2023-05-01"
+  name      = "gpt-5"
+  parent_id = azapi_resource.foundry.id
+
+  body = {
+    sku = {
+      name     = "DataZoneStandard"
+      capacity = 1
+    }
+    properties = {
+      model = {
+        format  = "OpenAI"
+        name    = "gpt-5"
+        version = "2025-08-07"
+      }
+    }
+  }
+}
+
+resource "azapi_resource" "foundry_embedding_deployment" {
+  type      = "Microsoft.CognitiveServices/accounts/deployments@2023-05-01"
+  name      = "text-embedding-3-large"
+  parent_id = azapi_resource.foundry.id
+
+  body = {
+    sku = {
+      name     = "Standard"
+      capacity = 1
+    }
+    properties = {
+      model = {
+        format  = "OpenAI"
+        name    = "text-embedding-3-large"
+        version = "1"
+      }
+    }
+  }
+}
+
+resource "terraform_data" "contentUnderstandingDefaults" {
+  triggers_replace = [
+    azapi_resource.foundry.id,
+    azapi_resource.foundry_gpt5_deployment.id,
+    azapi_resource.foundry_embedding_deployment.id,
+  ]
+
+  provisioner "local-exec" {
+    interpreter = ["pwsh", "-Command"]
+    command     = <<-EOT
+      $token = (az account get-access-token --resource https://cognitiveservices.azure.com --query accessToken -o tsv)
+      $headers = @{
+        "Authorization" = "Bearer $token"
+        "Content-Type"  = "application/merge-patch+json"
+      }
+      $body = @{
+        modelDeployments = @{
+          "gpt-5"                  = "gpt-5"
+          "text-embedding-3-large" = "text-embedding-3-large"
+        }
+      } | ConvertTo-Json
+
+      $endpoint = "${azapi_resource.foundry.output.properties.endpoint}contentunderstanding/defaults?api-version=2025-11-01"
+      Invoke-RestMethod -Uri $endpoint -Method Patch -Headers $headers -Body $body
+    EOT
+  }
+
+  depends_on = [
+    azapi_resource.contentUnderstandingOwnerRoleAssignment,
+    azapi_resource.foundry_gpt5_deployment,
+    azapi_resource.foundry_embedding_deployment,
+  ]
+}
+
+resource "azapi_data_plane_resource" "example" {
+  type      = "Microsoft.CognitiveServices/accounts/ContentUnderstanding/analyzers@2025-11-01"
+  parent_id = trimprefix(azapi_resource.foundry.output.properties.endpoint, "https://")
+  name      = "exampleanalyzer"
+
+  retry = {
+    error_message_regex  = ["lacks the required data action", "PermissionDenied", "Unauthorized", "authorization", "context deadline exceeded"]
+    interval_seconds     = 30
+    max_interval_seconds = 180
+  }
+
+  body = {
+    description    = "My test analyzer"
+    baseAnalyzerId = "prebuilt-document"
+    models = {
+      completion = "gpt-5"
+      embedding  = "text-embedding-3-large"
+    }
+  }
+
+  depends_on = [terraform_data.contentUnderstandingDefaults]
+}

--- a/internal/clients/data_plane_client.go
+++ b/internal/clients/data_plane_client.go
@@ -186,6 +186,9 @@ func (client *DataPlaneClient) sendRequestThenPoll(ctx context.Context, req *pol
 	}
 
 	if pt, err := runtime.NewPoller[interface{}](resp, pipeline, nil); err == nil {
+		if options.RetryOptions != nil {
+			ctx = policy.WithRetryOptions(ctx, *options.RetryOptions)
+		}
 		return pt.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{
 			Frequency: 10 * time.Second,
 		})

--- a/internal/provider/environments.go
+++ b/internal/provider/environments.go
@@ -12,6 +12,7 @@ const (
 	Purview          cloud.ServiceName = "Purview"
 	Synapse          cloud.ServiceName = "Synapse"
 	Search           cloud.ServiceName = "Search"
+	Cognitive        cloud.ServiceName = "Cognitive"
 )
 
 func init() {
@@ -54,6 +55,10 @@ func init() {
 	cloud.AzurePublic.Services[Search] = cloud.ServiceConfiguration{
 		Audience: "https://search.azure.com",
 		Endpoint: "https://search.windows.net",
+	}
+	cloud.AzurePublic.Services[Cognitive] = cloud.ServiceConfiguration{
+		Audience: "https://cognitiveservices.azure.com",
+		Endpoint: "https://cognitiveservices.azure.com",
 	}
 
 }

--- a/internal/services/azapi_data_plane_resource_test.go
+++ b/internal/services/azapi_data_plane_resource_test.go
@@ -1648,13 +1648,6 @@ data "azapi_client_config" "current" {}
 
 locals {
   content_understanding_owner_role_definition_id = "/subscriptions/${data.azapi_client_config.current.subscription_id}/providers/Microsoft.Authorization/roleDefinitions/4b42bd01-da42-4c92-9b07-15ea5bd6a602"
-  content_understanding_owner_assignment_id = format("%%s-%%s-%%s-%%s-%%s",
-    substr(md5("content-understanding-owner-%[1]s"), 0, 8),
-    substr(md5("content-understanding-owner-%[1]s"), 8, 4),
-    substr(md5("content-understanding-owner-%[1]s"), 12, 4),
-    substr(md5("content-understanding-owner-%[1]s"), 16, 4),
-    substr(md5("content-understanding-owner-%[1]s"), 20, 12)
-  )
 }
 
 resource "azapi_resource" "resource_group" {
@@ -1690,7 +1683,7 @@ resource "azapi_resource" "foundry" {
 resource "azapi_resource" "contentUnderstandingOwnerRoleAssignment" {
   type      = "Microsoft.Authorization/roleAssignments@2022-04-01"
   parent_id = azapi_resource.foundry.id
-  name      = local.content_understanding_owner_assignment_id
+  name      = uuid()
   body = {
     properties = {
       principalId      = data.azapi_client_config.current.object_id

--- a/internal/services/azapi_data_plane_resource_test.go
+++ b/internal/services/azapi_data_plane_resource_test.go
@@ -1710,7 +1710,6 @@ resource "azapi_resource" "gpt5Deployment" {
         name    = "gpt-5"
         version = "2025-08-07"
       }
-      versionUpgradeOption = "OnceNewDefaultVersionAvailable"
     }
     sku = {
       name     = "DataZoneStandard"
@@ -1730,10 +1729,9 @@ resource "azapi_resource" "textEmbedding3LargeDeployment" {
         name    = "text-embedding-3-large"
         version = "1"
       }
-      versionUpgradeOption = "OnceNewDefaultVersionAvailable"
     }
     sku = {
-      name     = "GlobalStandard"
+      name     = "Standard"
       capacity = 1
     }
   }

--- a/internal/services/azapi_data_plane_resource_test.go
+++ b/internal/services/azapi_data_plane_resource_test.go
@@ -33,6 +33,23 @@ func TestAccDataPlaneResource_appConfigKeyValues(t *testing.T) {
 	})
 }
 
+func TestAccDataPlaneResource_contentUnderstandingAnalyzer(t *testing.T) {
+	acceptance.SkipIfCoreAcctestsOnly(t, "Acctest subscription has no quota to run this test")
+	data := acceptance.BuildTestData(t, "azapi_data_plane_resource", "test")
+	r := DataPlaneResource{}
+	importIgnores := []string{"retry"}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.contentUnderstandingAnalyzer(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStepWithImportStateIdFunc(r.ImportIdFunc, append(importIgnores, defaultIgnores()...)...),
+	})
+}
+
 func TestAccDataPlaneResource_purviewClassification(t *testing.T) {
 	acceptance.SkipIfCoreAcctestsOnly(t, "only 1 purview account is allowed per tenant")
 	data := acceptance.BuildTestData(t, "azapi_data_plane_resource", "test")
@@ -354,6 +371,11 @@ func (DataPlaneResource) Exists(ctx context.Context, client *clients.Client, sta
 		return &b, nil
 	}
 	return nil, fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+}
+
+func (DataPlaneResource) ImportIdFunc(tfState *terraform.State) (string, error) {
+	state := tfState.RootModule().Resources["azapi_data_plane_resource.test"].Primary
+	return fmt.Sprintf("%s|%s", state.ID, state.Attributes["type"]), nil
 }
 
 func (r DataPlaneResource) appConfigKeyValues(data acceptance.TestData) string {
@@ -1613,6 +1635,172 @@ resource "azapi_data_plane_resource" "test" {
   ]
 }
 `, data.LocationPrimary, data.RandomString)
+}
+
+func (r DataPlaneResource) contentUnderstandingAnalyzer(data acceptance.TestData) string {
+	location := data.LocationPrimary
+	if location == "" {
+		location = "westus3"
+	}
+
+	return fmt.Sprintf(`
+data "azapi_client_config" "current" {}
+
+locals {
+  content_understanding_owner_role_definition_id = "/subscriptions/${data.azapi_client_config.current.subscription_id}/providers/Microsoft.Authorization/roleDefinitions/4b42bd01-da42-4c92-9b07-15ea5bd6a602"
+  content_understanding_owner_assignment_id = format("%%s-%%s-%%s-%%s-%%s",
+    substr(md5("content-understanding-owner-%[1]s"), 0, 8),
+    substr(md5("content-understanding-owner-%[1]s"), 8, 4),
+    substr(md5("content-understanding-owner-%[1]s"), 12, 4),
+    substr(md5("content-understanding-owner-%[1]s"), 16, 4),
+    substr(md5("content-understanding-owner-%[1]s"), 20, 12)
+  )
+}
+
+resource "azapi_resource" "resource_group" {
+  type     = "Microsoft.Resources/resourceGroups@2021-04-01"
+  name     = "acctest%[1]s"
+  location = "%[2]s"
+}
+
+resource "azapi_resource" "foundry" {
+  type                      = "Microsoft.CognitiveServices/accounts@2025-06-01"
+  parent_id                 = azapi_resource.resource_group.id
+  name                      = "acctest%[1]s"
+  location                  = azapi_resource.resource_group.location
+  schema_validation_enabled = false
+
+  body = {
+    kind = "AIServices"
+    sku = {
+      name = "S0"
+    }
+    identity = {
+      type = "SystemAssigned"
+    }
+    properties = {
+      disableLocalAuth       = false
+      allowProjectManagement = true
+      customSubDomainName    = "acctest%[1]s"
+    }
+  }
+  response_export_values = ["properties.endpoint"]
+}
+
+resource "azapi_resource" "contentUnderstandingOwnerRoleAssignment" {
+  type      = "Microsoft.Authorization/roleAssignments@2022-04-01"
+  parent_id = azapi_resource.foundry.id
+  name      = local.content_understanding_owner_assignment_id
+  body = {
+    properties = {
+      principalId      = data.azapi_client_config.current.object_id
+      roleDefinitionId = local.content_understanding_owner_role_definition_id
+    }
+  }
+}
+
+resource "azapi_resource" "gpt5Deployment" {
+  type      = "Microsoft.CognitiveServices/accounts/deployments@2023-05-01"
+  parent_id = azapi_resource.foundry.id
+  name      = "gpt-5"
+  body = {
+    properties = {
+      model = {
+        format  = "OpenAI"
+        name    = "gpt-5"
+        version = "2025-08-07"
+      }
+      versionUpgradeOption = "OnceNewDefaultVersionAvailable"
+    }
+    sku = {
+      name     = "DataZoneStandard"
+      capacity = 1
+    }
+  }
+}
+
+resource "azapi_resource" "textEmbedding3LargeDeployment" {
+  type      = "Microsoft.CognitiveServices/accounts/deployments@2023-05-01"
+  parent_id = azapi_resource.foundry.id
+  name      = "text-embedding-3-large"
+  body = {
+    properties = {
+      model = {
+        format  = "OpenAI"
+        name    = "text-embedding-3-large"
+        version = "1"
+      }
+      versionUpgradeOption = "OnceNewDefaultVersionAvailable"
+    }
+    sku = {
+      name     = "GlobalStandard"
+      capacity = 1
+    }
+  }
+  depends_on = [azapi_resource.gpt5Deployment]
+}
+
+resource "terraform_data" "contentUnderstandingDefaults" {
+  triggers_replace = [
+    azapi_resource.foundry.id,
+    azapi_resource.contentUnderstandingOwnerRoleAssignment,
+    azapi_resource.gpt5Deployment,
+    azapi_resource.textEmbedding3LargeDeployment,
+  ]
+
+  provisioner "local-exec" {
+    interpreter = ["pwsh", "-Command"]
+    command     = <<-EOT
+      $token = (az account get-access-token --resource https://cognitiveservices.azure.com --query accessToken -o tsv)
+      $headers = @{
+        "Authorization" = "Bearer $token"
+        "Content-Type"  = "application/merge-patch+json"
+      }
+      $body = @{
+        modelDeployments = @{
+          "gpt-5"                  = "gpt-5"
+          "text-embedding-3-large" = "text-embedding-3-large"
+        }
+      } | ConvertTo-Json
+
+      $endpoint = "${azapi_resource.foundry.output.properties.endpoint}contentunderstanding/defaults?api-version=2025-11-01"
+      Invoke-RestMethod -Uri $endpoint -Method Patch -Headers $headers -Body $body
+    EOT
+  }
+
+  depends_on = [
+    azapi_resource.contentUnderstandingOwnerRoleAssignment,
+    azapi_resource.gpt5Deployment,
+    azapi_resource.textEmbedding3LargeDeployment,
+  ]
+}
+
+resource "azapi_data_plane_resource" "test" {
+  type      = "Microsoft.CognitiveServices/accounts/ContentUnderstanding/analyzers@2025-11-01"
+  parent_id = "acctest%[1]s.cognitiveservices.azure.com"
+  name      = "acctest%[1]s"
+
+  retry = {
+    error_message_regex  = ["lacks the required data action", "PermissionDenied", "Unauthorized", "authorization", "context deadline exceeded"]
+    interval_seconds     = 30
+    max_interval_seconds = 180
+  }
+
+  body = {
+    description    = "My test analyzer"
+    baseAnalyzerId = "prebuilt-document"
+    models = {
+      completion = "gpt-5"
+      embedding  = "text-embedding-3-large"
+    }
+  }
+
+  depends_on = [
+    azapi_resource.contentUnderstandingOwnerRoleAssignment,
+    terraform_data.contentUnderstandingDefaults,
+  ]
+}
+`, data.RandomString, location)
 }
 
 func (r DataPlaneResource) appConfigKeyValuesSensitiveBody(data acceptance.TestData, value string) string {

--- a/internal/services/parse/data_plane_resource_id_test.go
+++ b/internal/services/parse/data_plane_resource_id_test.go
@@ -113,6 +113,17 @@ func Test_NewDataPlaneResourceId(t *testing.T) {
 				AzureResourceType: "Microsoft.Search/searchServices/synonymmaps",
 			},
 		},
+		{
+			Name:         "analyzer",
+			ParentId:     "contoso.cognitiveservices.azure.com",
+			ResourceType: "Microsoft.CognitiveServices/accounts/ContentUnderstanding/analyzers@2025-11-01",
+			Error:        false,
+			Expected: &parse.DataPlaneResourceId{
+				AzureResourceId:   "contoso.cognitiveservices.azure.com/contentunderstanding/analyzers/analyzer",
+				ApiVersion:        "2025-11-01",
+				AzureResourceType: "Microsoft.CognitiveServices/accounts/ContentUnderstanding/analyzers",
+			},
+		},
 	}
 
 	for _, v := range testData {

--- a/internal/services/parse/data_plane_resources.json
+++ b/internal/services/parse/data_plane_resources.json
@@ -399,5 +399,12 @@
     "ParentIDExample": "{aiServicesId}.services.ai.azure.com/api/projects/{projectName}",
     "Url": "/agents/{agentName}",
     "ExamplePath": "examples/resources/azapi_data_plane_resource/Microsoft.Foundry_agents/main.tf"
+  },
+  {
+    "UrlFormat": "{parentId}/contentunderstanding/analyzers/{name}",
+    "ResourceType": "Microsoft.CognitiveServices/accounts/ContentUnderstanding/analyzers",
+    "ParentIDExample": "{accountName}.cognitiveservices.azure.com",
+    "Url": "/contentunderstanding/analyzers/{analyzerId}",
+    "ExamplePath": "examples/resources/azapi_data_plane_resource/Microsoft.CognitiveServices_accounts_ContentUnderstanding_analyzers/main.tf"
   }
 ]


### PR DESCRIPTION
## Summary

Adds support for managing Azure AI Content Understanding analyzers with `azapi_data_plane_resource`.

Content Understanding exposes analyzers through an Azure AI Services account's custom `*.cognitiveservices.azure.com` data-plane endpoint. AzAPI did not previously recognize the analyzer resource type or request a token for the Cognitive Services audience, so these resources could not be managed through the generic data-plane resource.

This supersedes #1032 and updates the implementation to follow the current data-plane contribution guidance and repository conventions.

## Changes

- Register `Microsoft.CognitiveServices/accounts/ContentUnderstanding/analyzers` and its `/contentunderstanding/analyzers/{analyzerId}` URL format.
- Add Cognitive Services data-plane authentication for `*.cognitiveservices.azure.com` endpoints.
- Apply configured retry options while polling data-plane long-running operations.
- Add an AzAPI-only example that provisions the required Azure AI Services account, role assignment, model deployments, defaults, and analyzer.
- Generate the corresponding `azapi_data_plane_resource` documentation.

The analyzer endpoint follows the generic data-plane CRUD contract, so no resource-specific customization is required.

## Validation

- Added parser coverage for constructing Content Understanding analyzer resource IDs.
- Added acceptance coverage that creates an analyzer, verifies it exists, and imports it into state.