### PR TITLE
feat(clients/resource): Support $skipToken paginagtion for `Action()`

### DIFF
--- a/internal/clients/resource_client.go
+++ b/internal/clients/resource_client.go
@@ -228,10 +228,76 @@ func (client *ResourceClient) Action(ctx context.Context, resourceID string, act
 			options.RetryOptions.ShouldRetry != nil,
 		)
 	}
+
 	urlPath := resourceID
 	if action != "" {
 		urlPath = fmt.Sprintf("%s/%s", resourceID, action)
 	}
+
+	// Some actions (e.g. Azure Resource Graph's `resources` action) paginate their results via a `$skipToken`
+	// property: the request body carries the token in `options.$skipToken` and the response echoes back a
+	// top-level `$skipToken` when there are more pages, together with a `data` array of results for the current
+	// page. Since this convention isn't part of the generic ARM action contract, only the responses that expose a
+	// `data` array are paged this way; all other actions return their response body as-is.
+	data := make([]interface{}, 0)
+	var skipToken string
+	for {
+		requestBody := body
+		if skipToken != "" {
+			requestBody = withSkipToken(body, skipToken)
+		}
+
+		responseBody, err := client.doAction(ctx, urlPath, apiVersion, method, requestBody, options)
+		if err != nil {
+			return nil, err
+		}
+
+		responseMap, ok := responseBody.(map[string]interface{})
+		if !ok {
+			return responseBody, nil
+		}
+
+		pageData, hasData := responseMap["data"].([]interface{})
+		if !hasData {
+			return responseBody, nil
+		}
+		data = append(data, pageData...)
+
+		nextSkipToken, _ := responseMap["$skipToken"].(string)
+		if nextSkipToken == "" {
+			responseMap["data"] = data
+			delete(responseMap, "$skipToken")
+			return responseMap, nil
+		}
+		skipToken = nextSkipToken
+	}
+}
+
+// withSkipToken returns a shallow copy of body with `options.$skipToken` set to skipToken. body is expected to be
+// a map[string]interface{} (or nil); any other shape is returned unmodified since it can't carry a skip token.
+func withSkipToken(body interface{}, skipToken string) interface{} {
+	bodyMap, ok := body.(map[string]interface{})
+	if !ok {
+		return body
+	}
+
+	newBody := make(map[string]interface{}, len(bodyMap))
+	for k, v := range bodyMap {
+		newBody[k] = v
+	}
+
+	requestOptions, _ := newBody["options"].(map[string]interface{})
+	newOptions := make(map[string]interface{}, len(requestOptions)+1)
+	for k, v := range requestOptions {
+		newOptions[k] = v
+	}
+	newOptions["$skipToken"] = skipToken
+	newBody["options"] = newOptions
+
+	return newBody
+}
+
+func (client *ResourceClient) doAction(ctx context.Context, urlPath string, apiVersion string, method string, body interface{}, options RequestOptions) (interface{}, error) {
 	req, err := runtime.NewRequest(ctx, method, runtime.JoinPaths(client.host, urlPath))
 	if err != nil {
 		return nil, err

--- a/internal/services/azapi_resource_action_data_source_test.go
+++ b/internal/services/azapi_resource_action_data_source_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/Azure/terraform-provider-azapi/internal/acceptance"
+	"github.com/Azure/terraform-provider-azapi/internal/acceptance/check"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
@@ -43,6 +44,26 @@ func TestAccActionDataSource_providerAction(t *testing.T) {
 		{
 			Config: r.providerAction(),
 			Check:  resource.ComposeTestCheckFunc(),
+		},
+	})
+}
+
+func TestAccActionDataSource_resourceGraphPaging(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azapi_resource_action", "test")
+	r := ActionDataSource{}
+
+	data.DataSourceTest(t, []resource.TestStep{
+		{
+			Config: r.resourceGraphPaging(data),
+			ExternalProviders: map[string]resource.ExternalProvider{
+				"time": {
+					Source:            "hashicorp/time",
+					VersionConstraint: "0.14.1",
+				},
+			},
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("output.data.#").HasValue("3"),
+			),
 		},
 	})
 }
@@ -124,6 +145,64 @@ data "azapi_resource_action" "test" {
   response_export_values = ["*"]
 }
 `
+}
+
+func (r ActionDataSource) resourceGraphPaging(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+resource "azapi_resource" "test1" {
+  type     = "Microsoft.Resources/resourceGroups@2023-07-01"
+  name     = "acctestRG-%[1]d-1"
+  location = "%[2]s"
+  tags = {
+    acctestGraphPaging = "%[3]s"
+  }
+}
+
+resource "azapi_resource" "test2" {
+  type     = "Microsoft.Resources/resourceGroups@2023-07-01"
+  name     = "acctestRG-%[1]d-2"
+  location = "%[2]s"
+  tags = {
+    acctestGraphPaging = "%[3]s"
+  }
+}
+
+resource "azapi_resource" "test3" {
+  type     = "Microsoft.Resources/resourceGroups@2023-07-01"
+  name     = "acctestRG-%[1]d-3"
+  location = "%[2]s"
+  tags = {
+    acctestGraphPaging = "%[3]s"
+  }
+}
+
+resource "time_sleep" "wait_for_resource_graph_index" {
+  create_duration = "1m"
+
+  depends_on = [
+    azapi_resource.test1,
+    azapi_resource.test2,
+    azapi_resource.test3,
+  ]
+}
+
+data "azapi_resource_action" "test" {
+  type                   = "Microsoft.ResourceGraph@2024-04-01"
+  resource_id            = "/providers/Microsoft.ResourceGraph"
+  action                 = "resources"
+  response_export_values = ["data"]
+
+  body = {
+    query = "resourcecontainers | where tags['acctestGraphPaging'] == '%[3]s' | project id"
+    options = {
+      "$top"       = 1
+      resultFormat = "objectArray"
+    }
+  }
+
+  depends_on = [time_sleep.wait_for_resource_graph_index]
+}
+`, data.RandomInteger, data.LocationPrimary, data.RandomString)
 }
 
 func (r ActionDataSource) headers(data acceptance.TestData) string {


### PR DESCRIPTION
This PR adds support for `$skipToken` based pagination for the resources client action `Action()`.

This allows us to use the Terraform provider to query the Azure Resource Graph. Example:

```terraform
data "azapi_resource_action" "production_subscriptions" {
  type                   = "Microsoft.ResourceGraph@2024-04-01"
  resource_id            = "/providers/Microsoft.ResourceGraph"
  action                 = "resources"
  response_export_values = ["data"]

  body = {
    query = <<QUERY
ResourceContainers
| where type =~ "microsoft.resources/subscriptions"
| where tags["environment"] =~ "production"
| project id, name
QUERY
  }
}
```

Closes #1132 

Tests pass:
<img width="909" height="200" alt="image" src="https://github.com/user-attachments/assets/109b9373-3a60-4d71-b641-7658efd0aa75" />

I've used Copilot for the implementation.